### PR TITLE
fix: graceful degradation for /usage analytics endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ VLLM_STUDIO_DATA_DIR=./data
 # VLLM_STUDIO_TABBY_API_DIR=/path/to/tabbyAPI
 
 # =============================================================================
+# Analytics (Optional - requires: pip install vllm-studio[analytics])
+# =============================================================================
+
+# PostgreSQL URL for LiteLLM spend logs analytics
+# VLLM_STUDIO_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/litellm
+
+# =============================================================================
 # LiteLLM Gateway (Optional - for API routing/format translation)
 # =============================================================================
 

--- a/controller/config.py
+++ b/controller/config.py
@@ -39,6 +39,12 @@ class Settings(BaseSettings):
         description="TabbyAPI installation directory",
     )
 
+    # Analytics (optional - only needed if using LiteLLM with PostgreSQL)
+    postgres_url: Optional[str] = Field(
+        default=None,
+        description="PostgreSQL URL for LiteLLM spend logs (e.g., postgresql://user:pass@localhost:5432/litellm)",
+    )
+
     model_config = {
         "env_prefix": "VLLM_STUDIO_",
         "env_file": ".env",

--- a/controller/routes/usage.py
+++ b/controller/routes/usage.py
@@ -6,6 +6,16 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from controller.config import settings
+
+# Optional dependency - only needed when using LiteLLM with PostgreSQL
+try:
+    import asyncpg
+    ASYNCPG_AVAILABLE = True
+except ImportError:
+    asyncpg = None
+    ASYNCPG_AVAILABLE = False
+
 router = APIRouter(tags=["Analytics"])
 logger = logging.getLogger(__name__)
 
@@ -23,11 +33,26 @@ async def get_usage_stats():
     - Cache efficiency stats
     - Session and user counts
     - Peak usage periods
+
+    Requires:
+    - asyncpg package: pip install vllm-studio[analytics]
+    - PostgreSQL with LiteLLM spend logs
+    - VLLM_STUDIO_POSTGRES_URL environment variable
     """
-    import asyncpg
     from decimal import Decimal
 
-    db_url = "postgresql://postgres:postgres@127.0.0.1:5432/litellm"
+    # Check if analytics are available
+    if not ASYNCPG_AVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics unavailable: asyncpg not installed. Install with: pip install vllm-studio[analytics]"
+        )
+
+    if not settings.postgres_url:
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics unavailable: VLLM_STUDIO_POSTGRES_URL not configured"
+        )
 
     def to_float(val):
         """Convert Decimal/None to float for JSON serialization."""
@@ -36,7 +61,7 @@ async def get_usage_stats():
         return float(val) if isinstance(val, Decimal) else val
 
     try:
-        conn = await asyncpg.connect(db_url)
+        conn = await asyncpg.connect(settings.postgres_url)
 
         # === SUMMARY TOTALS ===
         totals = await conn.fetchrow('''
@@ -335,6 +360,17 @@ async def get_usage_stats():
                 for row in hourly
             ]
         }
+    except OSError as e:
+        logger.error(f"Failed to connect to PostgreSQL: {e}")
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics unavailable: Cannot connect to PostgreSQL. Is the database running?"
+        )
+    except asyncpg.exceptions.UndefinedTableError:
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics unavailable: No usage data yet. LiteLLM spend logs table will be created after first API request through LiteLLM."
+        )
     except Exception as e:
         logger.error(f"Failed to fetch usage stats: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "ruff>=0.1.0"]
+analytics = ["asyncpg>=0.29.0"]
 
 [project.urls]
 Homepage = "https://github.com/0xSero/vllm-studio"


### PR DESCRIPTION
## Summary

The `/usage` endpoint crashed with `ModuleNotFoundError: No module named 'asyncpg'` when asyncpg wasn't installed, and returned unhelpful 500 errors in other failure scenarios.

This PR makes analytics an optional feature with clear error messages:

- **asyncpg not installed** → 503 with install instructions
- **POSTGRES_URL not configured** → 503 with config guidance  
- **PostgreSQL not running** → 503 with "Is the database running?"
- **LiteLLM_SpendLogs table missing** → 503 explaining table is created on first LiteLLM request

## Changes

- Add `asyncpg` as optional dependency: `pip install vllm-studio[analytics]`
- Add configurable `VLLM_STUDIO_POSTGRES_URL` env var (removes hardcoded URL)
- Return clear 503 (Service Unavailable) instead of 500 (Internal Server Error)
- Document new config in `.env.example`

## Test plan

- [x] Verified 503 when asyncpg not installed
- [x] Verified 503 when POSTGRES_URL not set
- [x] Verified 503 when PostgreSQL not running
- [x] Verified 503 when LiteLLM_SpendLogs table doesn't exist
- [x] Verified /usage works when all dependencies are met