### PR TITLE
fix: context indicator now uses recipe's max_model_len

### DIFF
--- a/controller/models.py
+++ b/controller/models.py
@@ -157,6 +157,7 @@ class OpenAIModelInfo(BaseModel):
     object: str = "model"
     created: int
     owned_by: str = "vllm-studio"
+    root: Optional[str] = None  # model_path for frontend matching
     active: bool = False
     max_model_len: Optional[int] = None
 

--- a/controller/routes/models.py
+++ b/controller/routes/models.py
@@ -67,6 +67,7 @@ async def list_models_openai():
             OpenAIModelInfo(
                 id=model_id,
                 created=current_time,
+                root=recipe.model_path,
                 active=is_active,
                 max_model_len=max_model_len,
             )
@@ -111,6 +112,7 @@ async def get_model_openai(model_id: str, store: RecipeStore = Depends(get_store
     return OpenAIModelInfo(
         id=display_id,
         created=int(time.time()),
+        root=recipe.model_path,
         active=is_active,
         max_model_len=max_model_len,
     )

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -141,7 +141,11 @@ export default function ChatPage() {
 
   // Context management
   const maxContext = useMemo(() => {
-    const model = availableModels.find(m => m.id === selectedModel || m.id === runningModel);
+    // Match by id first, then by root (model_path) for cases where selectedModel is the path
+    const model = availableModels.find(m =>
+      m.id === selectedModel || m.id === runningModel ||
+      m.root === selectedModel || m.root === runningModel
+    );
     return model?.max_model_len || 200000;
   }, [availableModels, selectedModel, runningModel]);
 


### PR DESCRIPTION
## Summary
- Fixed context indicator in `/chat` always showing 200K tokens instead of the actual `max_model_len` from the recipe
- Root cause: Model ID mismatch between `/status` (returns `model_path`) and `/v1/models` (returns recipe `id`)
- Added `root` field to `OpenAIModelInfo` containing the `model_path` for proper matching

## Changes
- `controller/models.py`: Added `root` field to `OpenAIModelInfo`
- `controller/routes/models.py`: Return `recipe.model_path` as `root` in `/v1/models` responses
- `frontend/src/app/chat/page.tsx`: Updated model lookup to match on both `id` and `root`

## Test plan
- [x] Start a model with a recipe that has custom `max_model_len` (e.g., 16384)
- [x] Open `/chat` and verify context indicator shows correct max (16.4K instead of 200K)
- [x] Verify `/v1/models` API returns `root` field with model path