### PR TITLE
Make LiteLLM optional, restore reasoning parser autodetect, and revive Logs UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,22 @@ VLLM_STUDIO_DATA_DIR=./data
 # VLLM_STUDIO_TABBY_API_DIR=/path/to/tabbyAPI
 
 # =============================================================================
+# Chat Routing Configuration
+# =============================================================================
+
+# Chat routing mode: set to "true" to bypass LiteLLM and connect directly to vLLM/SGLang
+# When unset or "false", the controller will try LiteLLM first, then fall back to direct
+# VLLM_STUDIO_DIRECT_MODE=false
+
+# LiteLLM Gateway URL (for optional API routing/format translation)
+# Only used when VLLM_STUDIO_DIRECT_MODE is not set
+VLLM_STUDIO_LITELLM_URL=http://localhost:4100
+
+# Direct inference URL (vLLM/SGLang backend)
+# Used when VLLM_STUDIO_DIRECT_MODE is set, or as fallback when LiteLLM is unavailable
+VLLM_STUDIO_INFERENCE_URL=http://localhost:8000
+
+# =============================================================================
 # LiteLLM Gateway (Optional - for API routing/format translation)
 # =============================================================================
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ docs
 # Logs
 *.log
 logs/
+!frontend/src/app/logs/
+!frontend/src/app/logs/**
 
 # Recipes (user-specific)
 recipes/

--- a/README.md
+++ b/README.md
@@ -157,13 +157,30 @@ vllm-studio/
 
 ## With LiteLLM (Optional)
 
-For OpenAI/Anthropic API compatibility:
+For OpenAI/Anthropic API compatibility and advanced routing features:
 
 ```bash
 docker compose up litellm
 ```
 
 Then use `http://localhost:4100` as your API endpoint with any OpenAI-compatible client.
+
+**Note:** LiteLLM is optional for chat. The controller will automatically fall back to direct vLLM/SGLang connection if LiteLLM is not running. To force direct mode (bypassing LiteLLM entirely), set `VLLM_STUDIO_DIRECT_MODE=true`.
+
+## Chat Without LiteLLM
+
+Chat works directly with vLLM/SGLang without LiteLLM:
+
+```bash
+# Just start the controller and vLLM
+vllm-studio
+
+# Or start vLLM manually, then the controller
+vllm serve <model_name>
+vllm-studio
+```
+
+The web UI chat will connect directly to vLLM on port 8000 by default, with automatic fallback if LiteLLM is unavailable.
 
 ## License
 

--- a/controller/src/config/env.ts
+++ b/controller/src/config/env.ts
@@ -17,6 +17,9 @@ export interface Config {
   models_dir: string;
   sglang_python?: string;
   tabby_api_dir?: string;
+  direct_mode: boolean;
+  litellm_url: string;
+  inference_url: string;
 }
 
 /**
@@ -63,6 +66,12 @@ export const createConfig = (): Config => {
     VLLM_STUDIO_MODELS_DIR: z.string().default("/models"),
     VLLM_STUDIO_SGLANG_PYTHON: z.string().optional(),
     VLLM_STUDIO_TABBY_API_DIR: z.string().optional(),
+    VLLM_STUDIO_DIRECT_MODE: z.preprocess(
+      (value) => value === "true" || value === true,
+      z.boolean().default(false)
+    ),
+    VLLM_STUDIO_LITELLM_URL: z.string().default("http://localhost:4100"),
+    VLLM_STUDIO_INFERENCE_URL: z.string().default("http://localhost:8000"),
   });
 
   const parsed = schema.parse(process.env);
@@ -74,6 +83,9 @@ export const createConfig = (): Config => {
     data_dir: resolve(parsed.VLLM_STUDIO_DATA_DIR),
     db_path: resolve(parsed.VLLM_STUDIO_DB_PATH),
     models_dir: resolve(parsed.VLLM_STUDIO_MODELS_DIR),
+    direct_mode: parsed.VLLM_STUDIO_DIRECT_MODE,
+    litellm_url: parsed.VLLM_STUDIO_LITELLM_URL,
+    inference_url: parsed.VLLM_STUDIO_INFERENCE_URL,
   };
 
   if (parsed.VLLM_STUDIO_API_KEY) {

--- a/controller/src/main.ts
+++ b/controller/src/main.ts
@@ -1,39 +1,86 @@
-import { execSync } from "node:child_process";
+// CRITICAL
+import { execSync, spawnSync } from "node:child_process";
 import { createAppContext } from "./app-context";
 import { createApp } from "./http/app";
 import { startMetricsCollector } from "./metrics-collector";
+import { detectGpuType } from "./services/gpu";
+import { createThrobber } from "./services/shell-ui";
 
 /**
- * Check if nvidia-smi is accessible (important for GPU monitoring).
- * Snap-installed bun has sandbox restrictions that block nvidia-smi.
+ * Check GPU monitoring tools are accessible.
+ * Supports nvidia-smi for NVIDIA GPUs and rocm-smi for AMD GPUs.
+ * Snap-installed bun has sandbox restrictions that block these tools.
  */
-const checkNvidiaSmi = (): void => {
-  try {
-    execSync("nvidia-smi --query-gpu=name --format=csv,noheader,nounits", {
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: "pipe",
-    });
-  } catch {
-    const isSnapBun = process.execPath.includes("/snap/");
-    console.warn("╔════════════════════════════════════════════════════════════════╗");
-    console.warn("║  WARNING: nvidia-smi is not accessible                         ║");
-    console.warn("║  GPU monitoring will not work.                                 ║");
-    if (isSnapBun) {
-      console.warn("║                                                                ║");
-      console.warn("║  You are using snap-installed bun which has sandbox            ║");
-      console.warn("║  restrictions. Use native bun instead:                         ║");
-      console.warn("║                                                                ║");
-      console.warn("║    curl -fsSL https://bun.sh/install | bash                    ║");
-      console.warn("║    ~/.bun/bin/bun run controller/src/main.ts                   ║");
-      console.warn("║                                                                ║");
-      console.warn("║  Or use the start script: ./start.sh                           ║");
+const checkGpuMonitoring = (): string => {
+  const gpuType = detectGpuType();
+  const isSnapBun = process.execPath.includes("/snap/");
+
+  if (gpuType === "nvidia") {
+    let gpuList = "";
+    try {
+      const output = execSync("nvidia-smi --query-gpu=name --format=csv,noheader,nounits", {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: "pipe",
+      }).trim();
+      if (output) {
+        gpuList = ` (${output.split("\n").join(", ")})`;
+      }
+    } catch {
+      gpuList = "";
     }
-    console.warn("╚════════════════════════════════════════════════════════════════╝");
+    return `[GPU] NVIDIA GPU detected - nvidia-smi monitoring available${gpuList}`;
   }
+
+  if (gpuType === "amd") {
+    let gpuList = "";
+    let isIdle = false;
+    try {
+      const result = spawnSync("rocm-smi", ["--showproductname", "--csv"], {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.stderr?.includes("low-power state")) {
+        isIdle = true;
+      }
+      const output = result.stdout?.toString().trim() ?? "";
+      const names = output.split("\n").slice(1).map((line) => line.split(",")[1]?.trim() ?? "").filter(Boolean);
+      if (names.length > 0) {
+        gpuList = ` (${names.join(", ")})`;
+      }
+    } catch {
+      gpuList = "";
+    }
+    const idleNote = isIdle ? " (idling)" : "";
+    return `[GPU] AMD GPU detected - rocm-smi monitoring available${gpuList}${idleNote}`;
+  }
+
+  // No GPU detected
+  console.warn("╔════════════════════════════════════════════════════════════════╗");
+  console.warn("║  WARNING: No GPU monitoring tools accessible                    ║");
+  console.warn("║  GPU monitoring will not work.                                  ║");
+  console.warn("║                                                                ║");
+  console.warn("║  vLLM Studio supports:                                          ║");
+  console.warn("║  - nvidia-smi for NVIDIA GPUs                                   ║");
+  console.warn("║  - rocm-smi for AMD GPUs                                        ║");
+  if (isSnapBun) {
+    console.warn("║                                                                ║");
+    console.warn("║  You are using snap-installed bun which has sandbox            ║");
+    console.warn("║  restrictions. Use native bun instead:                         ║");
+    console.warn("║                                                                ║");
+    console.warn("║    curl -fsSL https://bun.sh/install | bash                    ║");
+    console.warn("║    ~/.bun/bin/bun run controller/src/main.ts                   ║");
+    console.warn("║                                                                ║");
+    console.warn("║  Or use the start script: ./start.sh                           ║");
+  }
+  console.warn("╚════════════════════════════════════════════════════════════════╝");
+  return "[GPU] No GPU monitoring tools accessible";
 };
 
-checkNvidiaSmi();
+const throbber = createThrobber();
+throbber.update("Checking GPU status");
+const gpuMessage = checkGpuMonitoring();
 
 const context = createAppContext();
 const app = createApp(context);
@@ -44,6 +91,7 @@ const stopMetrics = startMetricsCollector(context);
  * @returns Promise that resolves when started.
  */
 const run = async (): Promise<void> => {
+  throbber.update("Starting controller");
   const server = Bun.serve({
     port: context.config.port,
     hostname: context.config.host,
@@ -51,6 +99,7 @@ const run = async (): Promise<void> => {
     idleTimeout: 120,
   });
 
+  throbber.stop(`${gpuMessage} | Controller listening on ${context.config.host}:${server.port}`);
   context.logger.info(`Controller listening on ${context.config.host}:${server.port}`);
 
   const shutdown = (): void => {

--- a/controller/src/routes/models.ts
+++ b/controller/src/routes/models.ts
@@ -181,6 +181,8 @@ export const registerModelsRoutes = (app: Hono, context: AppContext): void => {
     const scanRoots = roots.filter((root) => root.exists).map((root) => root.path);
 
     const modelDirectories = discoverModelDirectories(scanRoots, 2, 1000);
+    const discoveredPaths = new Set<string>(modelDirectories);
+
     const models = [];
     for (const directory of modelDirectories) {
       const canonical = resolve(directory);
@@ -194,6 +196,66 @@ export const registerModelsRoutes = (app: Hono, context: AppContext): void => {
       const info = await buildModelInfo(directory, recipeIds);
       models.push(info);
     }
+
+    // HOTSWAP: Add currently running model that might not be in discovered paths
+    const current = await context.processManager.findInferenceProcess(context.config.inference_port);
+    if (current && current.model_path) {
+      const runningPath = current.model_path;
+      // Check if the running model is already in the discovered list
+      const canonicalRunningPath = resolve(runningPath);
+      const runningBasename = basename(runningPath);
+
+      // Check if already discovered (either by path or basename)
+      const alreadyDiscovered = discoveredPaths.has(canonicalRunningPath) ||
+        models.some((m: typeof models[0]) => basename(m.path) === runningBasename);
+
+      if (!alreadyDiscovered && existsSync(runningPath)) {
+        // Get associated recipe IDs
+        let recipeIds = recipesByPath.get(canonicalRunningPath) ?? [];
+        if (recipeIds.length === 0) {
+          const byName = recipesByBasename.get(runningBasename) ?? [];
+          recipeIds = byName.length === 1 ? [...byName] : [];
+        }
+
+        // Get file stats for size and modified time
+        const { statSync } = await import("node:fs");
+        let sizeBytes: number | null = null;
+        let modifiedAt: number | null = null;
+        try {
+          const stats = statSync(runningPath);
+          sizeBytes = stats.size;
+          modifiedAt = stats.mtimeMs;
+        } catch {
+          // Ignore stat errors
+        }
+
+        // Create a model info entry for the running file-based model
+        const runningInfo = {
+          name: runningBasename,
+          path: runningPath,
+          size_bytes: sizeBytes,
+          modified_at: modifiedAt,
+          architecture: null,
+          quantization: runningBasename.toLowerCase().includes("gguf") ? "gguf" : null,
+          context_length: null,
+          recipe_ids: recipeIds,
+          has_recipe: recipeIds.length > 0,
+          running: true,
+          served_model_name: current.served_model_name,
+        };
+        models.push(runningInfo);
+      } else {
+        // Model is in discovered list, update its running status
+        for (const model of models) {
+          if (resolve(model.path) === canonicalRunningPath || basename(model.path) === runningBasename) {
+            (model as unknown as { running: boolean }).running = true;
+            (model as unknown as { served_model_name: string | null }).served_model_name = current.served_model_name;
+            break;
+          }
+        }
+      }
+    }
+
     models.sort((left, right) => String(left.name).toLowerCase().localeCompare(String(right.name).toLowerCase()));
 
     const rootsPayload = roots.map((root) => ({

--- a/controller/src/routes/proxy.ts
+++ b/controller/src/routes/proxy.ts
@@ -5,10 +5,11 @@ import { AsyncLock, delay } from "../core/async";
 import { HttpStatus, serviceUnavailable } from "../core/errors";
 import { buildSseHeaders } from "../http/sse";
 import type { AppContext } from "../types/context";
-import type { Recipe } from "../types/models";
+import type { BackendTarget, Recipe } from "../types/models";
 import type { ToolCallBuffer, ThinkState, Utf8State } from "../services/proxy-parsers";
 import { parseToolCallsFromContent } from "../services/proxy-parsers";
 import { createProxyStream } from "../services/proxy-streamer";
+import { detectAvailableBackends, selectBackend } from "../services/backend-health.js";
 
 const switchLock = new AsyncLock();
 
@@ -241,15 +242,98 @@ IMPORTANT: Do not use emoji, Unicode symbols, or decorative box-drawing characte
       }
     }
 
+    // Detect available backends and select target
+    let availability;
+    try {
+      availability = await detectAvailableBackends(context.config);
+    } catch (error) {
+      throw serviceUnavailable(`Failed to check backend health: ${String(error)}`);
+    }
+
+    let backend: BackendTarget;
+    try {
+      backend = selectBackend(context.config, availability);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "No inference backend available";
+      throw serviceUnavailable(detail);
+    }
+
+    // Log the selected backend mode
+    context.logger.info(`Chat completions routing: ${backend.name} (${backend.mode})`, {
+      mode: backend.mode,
+      url: backend.url,
+      direct_mode: context.config.direct_mode,
+      litellm_available: availability.litellm_available,
+      inference_available: availability.inference_available,
+    });
+
     const masterKey = process.env["LITELLM_MASTER_KEY"] ?? "sk-master";
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${masterKey}`,
     };
-    const litellmUrl = "http://localhost:4100/v1/chat/completions";
+    const fallbackTarget: BackendTarget = {
+      mode: "direct",
+      url: context.config.inference_url,
+      name: "Direct Inference (fallback)",
+    };
+
+    const shouldFallback = (target: BackendTarget, response: Response | null, error: string | null): boolean => {
+      if (target.mode !== "litellm" || !availability.inference_available) {
+        return false;
+      }
+      if (error) {
+        return true;
+      }
+      return Boolean(response && response.status >= 500);
+    };
+
+    const requestBackend = async (target: BackendTarget): Promise<{ response: Response | null; error: string | null }> => {
+      try {
+        const response = await fetch(`${target.url}/v1/chat/completions`, { method: "POST", headers, body: finalBody });
+        return { response, error: null };
+      } catch (error) {
+        return { response: null, error: `Failed to reach ${target.name}: ${String(error)}` };
+      }
+    };
+
+    const requestWithFallback = async (): Promise<{ response: Response; backend: BackendTarget }> => {
+      const primary = await requestBackend(backend);
+      if (shouldFallback(backend, primary.response, primary.error)) {
+        context.logger.warn("LiteLLM request failed, falling back to direct inference", {
+          error: primary.error,
+          status: primary.response?.status,
+        });
+        const fallback = await requestBackend(fallbackTarget);
+        if (fallback.error) {
+          const primaryMessage = primary.error ?? `LiteLLM responded with ${primary.response?.status}`;
+          throw serviceUnavailable(`${primaryMessage}. Fallback to direct inference failed: ${fallback.error}`);
+        }
+        if (!fallback.response) {
+          throw serviceUnavailable("Direct inference unavailable");
+        }
+        return { response: fallback.response, backend: fallbackTarget };
+      }
+      if (primary.error) {
+        throw serviceUnavailable(primary.error);
+      }
+      if (!primary.response) {
+        throw serviceUnavailable(`${backend.name} unavailable`);
+      }
+      return { response: primary.response, backend };
+    };
 
     if (!isStreaming) {
-      const response = await fetch(litellmUrl, { method: "POST", headers, body: finalBody });
+      const { response } = await requestWithFallback();
+      if (!response.ok) {
+        const errorText = await response.text();
+        return new Response(errorText, {
+          status: response.status,
+          headers: {
+            "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+          },
+        });
+      }
       const result = (await response.json()) as Record<string, unknown>;
 
       // Track token usage to lifetime metrics
@@ -298,19 +382,19 @@ IMPORTANT: Do not use emoji, Unicode symbols, or decorative box-drawing characte
       return ctx.json(result, { status: response.status });
     }
 
-    const litellmResponse = await fetch(litellmUrl, { method: "POST", headers, body: finalBody });
-    if (!litellmResponse.ok) {
-      const errorText = await litellmResponse.text();
+    const { response: backendResponse, backend: activeBackend } = await requestWithFallback();
+    if (!backendResponse.ok) {
+      const errorText = await backendResponse.text();
       return new Response(errorText, {
-        status: litellmResponse.status,
+        status: backendResponse.status,
         headers: {
-          "Content-Type": litellmResponse.headers.get("Content-Type") ?? "application/json",
+          "Content-Type": backendResponse.headers.get("Content-Type") ?? "application/json",
         },
       });
     }
-    const reader = litellmResponse.body?.getReader();
+    const reader = backendResponse.body?.getReader();
     if (!reader) {
-      throw serviceUnavailable("LiteLLM backend unavailable");
+      throw serviceUnavailable(`${activeBackend.name} unavailable`);
     }
 
     const thinkState: ThinkState = { inThinking: false };

--- a/controller/src/routes/system.test.ts
+++ b/controller/src/routes/system.test.ts
@@ -23,6 +23,9 @@ describe("System Routes", () => {
       data_dir: "./data",
       db_path: ":memory:",
       models_dir: "/models",
+      direct_mode: false,
+      litellm_url: "http://localhost:4100",
+      inference_url: "http://localhost:8000",
     };
 
     const mockContext = {

--- a/controller/src/routes/system.ts
+++ b/controller/src/routes/system.ts
@@ -38,6 +38,24 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
     });
   };
 
+  const parsePort = (urlValue: string, fallbackPort: number): number => {
+    try {
+      const parsed = new URL(urlValue);
+      return parsed.port ? Number(parsed.port) : fallbackPort;
+    } catch {
+      return fallbackPort;
+    }
+  };
+
+  const parseProtocol = (urlValue: string, fallbackProtocol: string): string => {
+    try {
+      const parsed = new URL(urlValue);
+      return parsed.protocol.replace(":", "") || fallbackProtocol;
+    } catch {
+      return fallbackProtocol;
+    }
+  };
+
   app.get("/health", async (ctx) => {
     const current = await context.processManager.findInferenceProcess(context.config.inference_port);
     let inferenceReady = false;
@@ -85,6 +103,11 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
 
   app.get("/config", async (ctx) => {
     const services: Array<{ name: string; port: number; internal_port: number; protocol: string; status: string; description?: string | null }> = [];
+    const inferencePort = parsePort(context.config.inference_url, context.config.inference_port);
+    const inferenceProtocol = parseProtocol(context.config.inference_url, "http");
+    const litellmPort = parsePort(context.config.litellm_url, 4100);
+    const litellmProtocol = parseProtocol(context.config.litellm_url, "http");
+
     services.push({
       name: "Controller",
       port: context.config.port,
@@ -100,7 +123,7 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
       if (current) {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 2000);
-        const response = await fetch(`http://localhost:${context.config.inference_port}/health`, {
+        const response = await fetch(`${context.config.inference_url}/health`, {
           signal: controller.signal,
         });
         clearTimeout(timeout);
@@ -114,9 +137,9 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
 
     services.push({
       name: "vLLM/SGLang",
-      port: context.config.inference_port,
-      internal_port: context.config.inference_port,
-      protocol: "http",
+      port: inferencePort,
+      internal_port: inferencePort,
+      protocol: inferenceProtocol,
       status: inferenceStatus,
       description: "Inference backend (vLLM or SGLang)",
     });
@@ -126,7 +149,7 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10_000);
       const masterKey = process.env["LITELLM_MASTER_KEY"] ?? "sk-master";
-      const response = await fetch("http://localhost:4100/health", {
+      const response = await fetch(`${context.config.litellm_url}/health`, {
         headers: { Authorization: `Bearer ${masterKey}` },
         signal: controller.signal,
       });
@@ -143,9 +166,9 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
 
     services.push({
       name: "LiteLLM",
-      port: 4100,
-      internal_port: 4000,
-      protocol: "http",
+      port: litellmPort,
+      internal_port: litellmPort,
+      protocol: litellmProtocol,
       status: litellmStatus,
       description: "API gateway and load balancer",
     });
@@ -214,8 +237,8 @@ export const registerSystemRoutes = (app: Hono, context: AppContext): void => {
       services,
       environment: {
         controller_url: `http://${hostname()}:${context.config.port}`,
-        inference_url: `http://${hostname()}:${context.config.inference_port}`,
-        litellm_url: `http://${hostname()}:4100`,
+        inference_url: context.config.inference_url,
+        litellm_url: context.config.litellm_url,
         frontend_url: `http://${hostname()}:3000`,
       },
     };

--- a/controller/src/services/backend-health.ts
+++ b/controller/src/services/backend-health.ts
@@ -1,0 +1,102 @@
+// CRITICAL
+import type { Config } from "../config/env.js";
+import type { BackendAvailability, BackendTarget } from "../types/models.js";
+
+/**
+ * Health check timeout in milliseconds.
+ */
+const HEALTH_CHECK_TIMEOUT = 2000;
+
+/**
+ * Check if a backend is healthy by hitting its /health endpoint.
+ * @param url - Backend URL.
+ * @param timeoutMs - Timeout in milliseconds.
+ * @returns True if backend is healthy.
+ */
+export async function checkBackendHealth(
+  url: string,
+  timeoutMs: number = HEALTH_CHECK_TIMEOUT,
+  headers: Record<string, string> = {},
+): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(`${url}/health`, {
+      signal: controller.signal,
+      headers: { "User-Agent": "vllm-studio/1.0", ...headers },
+    });
+
+    clearTimeout(timeoutId);
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect which backends are available.
+ * @param config - Runtime configuration.
+ * @returns Backend availability status.
+ */
+export async function detectAvailableBackends(
+  config: Config,
+): Promise<BackendAvailability> {
+  const masterKey = process.env["LITELLM_MASTER_KEY"] ?? "sk-master";
+  const litellmHeaders = { Authorization: `Bearer ${masterKey}` };
+  const [litellmAvailable, inferenceAvailable] = await Promise.all([
+    checkBackendHealth(config.litellm_url, HEALTH_CHECK_TIMEOUT, litellmHeaders),
+    checkBackendHealth(config.inference_url),
+  ]);
+
+  return {
+    litellm_available: litellmAvailable,
+    inference_available: inferenceAvailable,
+    selected_mode: "auto",
+  };
+}
+
+/**
+ * Select the best backend target based on configuration and availability.
+ * @param config - Runtime configuration.
+ * @param availability - Backend availability status.
+ * @returns Selected backend target.
+ * @throws Error if no backend is available.
+ */
+export function selectBackend(
+  config: Config,
+  availability: BackendAvailability,
+): BackendTarget {
+  // Direct mode forced by configuration
+  if (config.direct_mode) {
+    return {
+      mode: "direct",
+      url: config.inference_url,
+      name: "Direct Inference",
+    };
+  }
+
+  // Prefer LiteLLM if available
+  if (availability.litellm_available) {
+    return {
+      mode: "litellm",
+      url: config.litellm_url,
+      name: "LiteLLM Gateway",
+    };
+  }
+
+  // Fallback to direct inference
+  if (availability.inference_available) {
+    return {
+      mode: "direct",
+      url: config.inference_url,
+      name: "Direct Inference (fallback)",
+    };
+  }
+
+  // No backend available
+  throw new Error(
+    "No inference backend available. LiteLLM is not running and vLLM/SGLang is not reachable. " +
+      `Ensure either ${config.litellm_url} or ${config.inference_url} is accessible.`,
+  );
+}

--- a/controller/src/services/backends.ts
+++ b/controller/src/services/backends.ts
@@ -108,21 +108,24 @@ export const getPythonPath = (recipe: Recipe): string | undefined => {
  */
 export const getDefaultReasoningParser = (recipe: Recipe): string | undefined => {
   const modelId = (recipe.served_model_name || recipe.model_path || "").toLowerCase();
+  const isGguf = modelId.endsWith(".gguf");
 
   if (modelId.includes("minimax") && (modelId.includes("m2") || modelId.includes("m-2"))) {
     return "minimax_m2_append_think";
   }
-  if (modelId.includes("intellect") && modelId.includes("3")) {
+
+  const deepseekCandidates = [
+    modelId.includes("deepseek") && modelId.includes("r1"),
+    modelId.includes("intellect") && modelId.includes("3"),
+    modelId.includes("mirothinker"),
+    modelId.includes("qwen3") && modelId.includes("thinking"),
+  ];
+  if (!isGguf && deepseekCandidates.some(Boolean)) {
     return "deepseek_r1";
   }
+
   if (modelId.includes("glm") && ["4.5", "4.6", "4.7", "4-5", "4-6", "4-7"].some((tag) => modelId.includes(tag))) {
     return "glm45";
-  }
-  if (modelId.includes("mirothinker")) {
-    return "deepseek_r1";
-  }
-  if (modelId.includes("qwen3") && modelId.includes("thinking")) {
-    return "deepseek_r1";
   }
   if (modelId.includes("qwen3")) {
     return "qwen3";
@@ -259,9 +262,15 @@ export const buildVllmCommand = (recipe: Recipe): string[] => {
   if (toolCallParser) {
     command.push("--tool-call-parser", toolCallParser, "--enable-auto-tool-choice");
   }
-  const reasoningParser = recipe.reasoning_parser || getDefaultReasoningParser(recipe);
+  // Only use auto-detection if reasoning_parser is not explicitly set to null
+  const reasoningParser = recipe.reasoning_parser ?? undefined;
   if (reasoningParser) {
     command.push("--reasoning-parser", reasoningParser);
+  } else if (recipe.reasoning_parser === undefined) {
+    const autoParser = getDefaultReasoningParser(recipe);
+    if (autoParser) {
+      command.push("--reasoning-parser", autoParser);
+    }
   }
   if (recipe.quantization) {
     command.push("--quantization", recipe.quantization);

--- a/controller/src/services/gpu.ts
+++ b/controller/src/services/gpu.ts
@@ -1,12 +1,165 @@
 // CRITICAL
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import type { GpuInfo } from "../types/models";
 
 /**
- * Query GPU info from nvidia-smi.
+ * Detect the GPU type available on the system.
+ * @returns "nvidia", "amd", or null if no GPU detected.
+ */
+export const detectGpuType = (): "nvidia" | "amd" | null => {
+  // Check for NVIDIA GPUs
+  try {
+    const nvidiaSmi = process.env["NVIDIA_SMI_PATH"] || "nvidia-smi";
+    execSync(`${nvidiaSmi} --query-gpu=name --format=csv,noheader,nounits`, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+    });
+    return "nvidia";
+  } catch {
+    // NVIDIA not available
+  }
+
+  // Check for AMD GPUs
+  try {
+    execSync("rocm-smi --showproductname", {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+    });
+    return "amd";
+  } catch {
+    // AMD not available
+  }
+
+  return null;
+};
+
+/**
+ * Parse CSV output from rocm-smi.
+ * @param output - CSV output string.
+ * @returns Array of objects keyed by column name.
+ */
+const parseRocmCsv = (output: string): Record<string, string>[] => {
+  if (!output || output.trim().length === 0) {
+    return [];
+  }
+  const lines = output.trim().split("\n");
+  if (lines.length < 2) {
+    return [];
+  }
+
+  // Parse header (skipping device column which is first)
+  const headers = lines[0].split(",").slice(1);
+  const result: Record<string, string>[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = lines[i].split(",").slice(1);
+    const record: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) {
+      record[headers[j] ?? `col${j}`] = values[j]?.trim() ?? "";
+    }
+    result.push(record);
+  }
+
+  return result;
+};
+
+/**
+ * Query GPU info from rocm-smi (AMD GPUs).
  * @returns List of GPU info objects.
  */
-export const getGpuInfo = (): GpuInfo[] => {
+export const getAmdGpuInfo = (): GpuInfo[] => {
+  try {
+    const runRocm = (args: string[]): string => {
+      const result = spawnSync("rocm-smi", args, {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.status !== 0 || !result.stdout) {
+        return "";
+      }
+      return result.stdout.toString();
+    };
+
+    const [productOutput, memOutput, useOutput, tempOutput, powerOutput] = [
+      runRocm(["--showproductname", "--csv"]),
+      runRocm(["--showmeminfo", "vram", "--csv"]),
+      runRocm(["--showuse", "--csv"]),
+      runRocm(["-t", "--csv"]),
+      runRocm(["--showpower", "--csv"]),
+    ];
+
+    // Parse each CSV output
+    const products = parseRocmCsv(productOutput);
+    const mems = parseRocmCsv(memOutput);
+    const uses = parseRocmCsv(useOutput);
+    const temps = parseRocmCsv(tempOutput);
+    const powers = parseRocmCsv(powerOutput);
+
+    // Determine GPU count (all should have same length)
+    const gpuCount = Math.max(products.length, mems.length, uses.length, temps.length, powers.length);
+
+    if (gpuCount === 0) {
+      return [];
+    }
+
+    const gpus: GpuInfo[] = [];
+
+    for (let i = 0; i < gpuCount; i++) {
+      const product = products[i] ?? {};
+      const mem = mems[i] ?? {};
+      const use = uses[i] ?? {};
+      const temp = temps[i] ?? {};
+      const power = powers[i] ?? {};
+
+      // Extract GPU name from product info
+      const name = product["Card Series"] || product["Device Name"] || "AMD GPU";
+
+      // Extract memory info (in bytes for rocm-smi)
+      const memTotal = Number(mem["VRAM Total Memory (B)"] ?? 0);
+      const memUsed = Number(mem["VRAM Total Used Memory (B)"] ?? 0);
+      const memFree = Math.max(0, memTotal - memUsed);
+
+      // Extract utilization (percentage)
+      const utilization = Number(use["GPU use (%)"] ?? 0);
+
+      // Extract temperature (edge sensor)
+      const temperature = Number(temp["Temperature (Sensor edge) (C)"] ?? 0);
+
+      // Extract power draw (watts)
+      const powerDraw = Number(power["Average Graphics Package Power (W)"] ?? 0);
+
+      // Power limit - AMD doesn't easily expose this via rocm-smi
+      // We can use the Max Graphics Package Power from full info if needed
+      // For now, set to 0 to indicate unavailable
+      const powerLimit = 0;
+
+      gpus.push({
+        index: i,
+        name,
+        memory_total: memTotal,
+        memory_used: memUsed,
+        memory_free: memFree,
+        utilization,
+        temperature,
+        power_draw: powerDraw,
+        power_limit: powerLimit,
+      });
+    }
+
+    return gpus;
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Query GPU info from nvidia-smi (NVIDIA GPUs).
+ * @returns List of GPU info objects.
+ */
+export const getNvidiaGpuInfo = (): GpuInfo[] => {
   const query = [
     "name",
     "memory.total",
@@ -64,6 +217,24 @@ export const getGpuInfo = (): GpuInfo[] => {
   } catch {
     return [];
   }
+};
+
+/**
+ * Query GPU info from available GPU vendor (NVIDIA or AMD).
+ * @returns List of GPU info objects.
+ */
+export const getGpuInfo = (): GpuInfo[] => {
+  const gpuType = detectGpuType();
+
+  if (gpuType === "amd") {
+    return getAmdGpuInfo();
+  }
+
+  if (gpuType === "nvidia") {
+    return getNvidiaGpuInfo();
+  }
+
+  return [];
 };
 
 /**

--- a/controller/src/services/model-browser.ts
+++ b/controller/src/services/model-browser.ts
@@ -15,6 +15,9 @@ export interface ModelInfo {
   context_length: number | null;
   recipe_ids: string[];
   has_recipe: boolean;
+  // Hotswap support: indicates this model is currently running
+  running?: boolean;
+  served_model_name?: string | null;
 }
 
 const WEIGHT_EXTS = [".safetensors", ".bin", ".gguf"] as const;

--- a/controller/src/services/process-manager.ts
+++ b/controller/src/services/process-manager.ts
@@ -22,6 +22,7 @@ import {
     listProcesses,
     pidExists,
     buildProcessTree,
+    isProcessListeningOnPort,
 } from "./process-utilities";
 
 /**
@@ -65,8 +66,17 @@ export const createProcessManager = (
                 if (port !== 8000) {
                     continue;
                 }
-            } else if (!flagPort || Number(flagPort) !== port) {
-                continue;
+            } else if (flagPort) {
+                // If --port flag is present, verify it matches
+                if (Number(flagPort) !== port) {
+                    continue;
+                }
+            } else {
+                // If --port flag is absent, verify the process is actually listening on the expected port
+                // This handles cases where vLLM/SGLang are started with default ports
+                if (!isProcessListeningOnPort(proc.pid, port)) {
+                    continue;
+                }
             }
             let modelPath =
                 extractFlag(proc.args, "--model") ||

--- a/controller/src/services/process-utilities.ts
+++ b/controller/src/services/process-utilities.ts
@@ -40,10 +40,15 @@ export const detectBackend = (args: string[]): string | null => {
     return null;
   }
   const joined = args.join(" ");
+  // Check for vLLM - multiple invocation patterns
   if (joined.includes("vllm.entrypoints.openai.api_server")) {
     return "vllm";
   }
   if (joined.includes("vllm") && joined.includes("serve")) {
+    return "vllm";
+  }
+  // Also catch just "-m vllm" pattern
+  if (joined.includes("-m") && joined.includes("vllm")) {
     return "vllm";
   }
   if (joined.includes("sglang.launch_server")) {
@@ -194,6 +199,78 @@ export const pidExists = (pid: number): boolean => {
   try {
     process.kill(pid, 0);
     return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Check if a process is listening on a specific port.
+ * Parses /proc/net/tcp for the given PID to find listening ports.
+ * @param pid - Process id.
+ * @param port - Port to check.
+ * @returns True if process is listening on the port.
+ */
+export const isProcessListeningOnPort = (pid: number, port: number): boolean => {
+  try {
+    // Read /proc/net/tcp to find which processes are listening on which ports
+    const result = spawnSync("cat", ["/proc/net/tcp"], { encoding: "utf-8" });
+    if (result.status !== 0) {
+      return false;
+    }
+
+    // Convert port to hex format used in /proc/net/tcp (little-endian)
+    // Port 8000 = 0x1F40 -> stored as 401F0000 in the file
+    const portHex = port.toString(16).toUpperCase().padStart(4, "0");
+    const portHexLE = portHex.substring(2, 4) + portHex.substring(0, 2) + "0000";
+
+    const lines = result.stdout.split("\n");
+    for (const line of lines) {
+      // Skip header and empty lines
+      if (line.startsWith("  sl") || !line.trim()) {
+        continue;
+      }
+
+      // Format: sl  local_address rem_address   st tx_queue rx_queue ...
+      // local_address format: hex:port (little endian hex)
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 10) {
+        continue;
+      }
+
+      const localAddress = parts[1];
+      const inode = parts[9];
+
+      // Check if this is a listening entry (state 0A = LISTEN)
+      // And if the port matches
+      if (localAddress.endsWith(`:${portHexLE}`)) {
+        // Now check if this inode belongs to our PID
+        try {
+          const fdPath = `/proc/${pid}/fd`;
+          if (existsSync(fdPath)) {
+            // Check if any file descriptor points to a socket with this inode
+            const fds = spawnSync("ls", ["-la", fdPath], { encoding: "utf-8" });
+            if (fds.stdout.includes(`socket:[${inode}]`)) {
+              return true;
+            }
+          }
+        } catch {
+          // Fall through to try lsof as backup
+        }
+      }
+    }
+
+    // Fallback: try using ss or lsof if available
+    try {
+      const ssResult = spawnSync("ss", ["-tlnp", `sport = :${port}`], { encoding: "utf-8" });
+      if (ssResult.stdout.includes(`pid=${pid}`)) {
+        return true;
+      }
+    } catch {
+      // ss command not available or failed
+    }
+
+    return false;
   } catch {
     return false;
   }

--- a/controller/src/services/shell-ui.ts
+++ b/controller/src/services/shell-ui.ts
@@ -1,0 +1,44 @@
+// CRITICAL
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+export interface Throbber {
+  update: (message: string) => void;
+  stop: (finalMessage: string) => void;
+}
+
+export const createThrobber = (): Throbber => {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let frame = 0;
+  let message = "";
+
+  const render = (): void => {
+    if (!process.stdout.isTTY) {
+      return;
+    }
+    const output = `\r${FRAMES[frame % FRAMES.length]} ${message}`;
+    process.stdout.write(`${output}\x1b[0K`);
+    frame += 1;
+  };
+
+  const update = (nextMessage: string): void => {
+    message = nextMessage;
+    if (!timer && process.stdout.isTTY) {
+      timer = setInterval(render, 120);
+    }
+    render();
+  };
+
+  const stop = (finalMessage: string): void => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    if (process.stdout.isTTY) {
+      process.stdout.write(`\r${finalMessage}\x1b[0K\n`);
+    } else {
+      console.log(finalMessage);
+    }
+  };
+
+  return { update, stop };
+};

--- a/controller/src/stores/recipe-serializer.ts
+++ b/controller/src/stores/recipe-serializer.ts
@@ -132,7 +132,7 @@ export const parseRecipe = (raw: unknown): Recipe => {
     id: asRecipeId(parsed.id),
     env_vars: environmentVariables,
     tool_call_parser: parsed.tool_call_parser ?? null,
-    reasoning_parser: parsed.reasoning_parser ?? null,
+    reasoning_parser: parsed.reasoning_parser === undefined ? undefined : parsed.reasoning_parser,
     quantization: parsed.quantization ?? null,
     dtype: parsed.dtype ?? null,
     served_model_name: parsed.served_model_name ?? null,

--- a/controller/src/types/models.ts
+++ b/controller/src/types/models.ts
@@ -7,6 +7,29 @@ import type { RecipeId } from "./brand";
 export type Backend = "vllm" | "sglang" | "transformers" | "tabbyapi";
 
 /**
+ * Chat proxy routing mode.
+ */
+export type RoutingMode = "auto" | "direct" | "litellm";
+
+/**
+ * Target backend for chat completions.
+ */
+export interface BackendTarget {
+  mode: RoutingMode;
+  url: string;
+  name: string;
+}
+
+/**
+ * Backend availability status.
+ */
+export interface BackendAvailability {
+  litellm_available: boolean;
+  inference_available: boolean;
+  selected_mode: RoutingMode;
+}
+
+/**
  * Model launch configuration.
  */
 export interface Recipe {
@@ -23,7 +46,7 @@ export interface Recipe {
   max_num_seqs: number;
   trust_remote_code: boolean;
   tool_call_parser: string | null;
-  reasoning_parser: string | null;
+  reasoning_parser?: string | null;
   enable_auto_tool_choice: boolean;
   quantization: string | null;
   dtype: string | null;

--- a/frontend/src/app/logs/logs-view.tsx
+++ b/frontend/src/app/logs/logs-view.tsx
@@ -1,0 +1,80 @@
+// CRITICAL
+import type { LogSession } from "@/lib/types";
+
+interface LogsViewProps {
+  sessions: LogSession[];
+  selectedSession: LogSession | null;
+  logs: string[];
+  loading: boolean;
+  loadingLogs: boolean;
+  onSelect: (sessionId: string) => void;
+  onRefresh: () => void;
+}
+
+export function LogsView({
+  sessions,
+  selectedSession,
+  logs,
+  loading,
+  loadingLogs,
+  onSelect,
+  onRefresh,
+}: LogsViewProps) {
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Logs</h1>
+        <button className="text-xs text-(--accent)" onClick={onRefresh} type="button">
+          Refresh
+        </button>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[240px_1fr]">
+        <div className="border border-(--border) rounded-lg p-3 space-y-2">
+          <div className="text-[10px] uppercase tracking-widest text-(--muted-foreground)/60">Sessions</div>
+          {loading ? (
+            <div className="text-xs text-(--muted-foreground)/60">Loading...</div>
+          ) : sessions.length === 0 ? (
+            <div className="text-xs text-(--muted-foreground)/60">No log sessions</div>
+          ) : (
+            <div className="space-y-1">
+              {sessions.map((session) => (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => onSelect(session.id)}
+                  className={`w-full text-left text-xs px-2 py-1 rounded ${
+                    selectedSession?.id === session.id ? "bg-(--accent)/10" : "hover:bg-(--muted)/20"
+                  }`}
+                >
+                  <div className="font-medium truncate">{session.recipe_name || session.id}</div>
+                  <div className="text-[10px] text-(--muted-foreground)/60">{session.status}</div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="border border-(--border) rounded-lg p-3">
+          <div className="text-[10px] uppercase tracking-widest text-(--muted-foreground)/60 mb-2">
+            {selectedSession ? `Session ${selectedSession.id}` : "Logs"}
+          </div>
+          {loadingLogs ? (
+            <div className="text-xs text-(--muted-foreground)/60">Loading logs...</div>
+          ) : logs.length === 0 ? (
+            <div className="text-xs text-(--muted-foreground)/60">No logs available</div>
+          ) : (
+            <div className="max-h-[60vh] overflow-auto font-mono text-[11px] leading-relaxed space-y-0.5">
+              {logs.map((line, index) => (
+                <div
+                  key={`${selectedSession?.id ?? "logs"}-${index}`}
+                  className={line.includes("ERROR") ? "text-(--error)/70" : "text-(--muted-foreground)/70"}
+                >
+                  {line}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -1,60 +1,20 @@
 "use client";
 
-import { LogsView } from "./_components/logs-view";
-import { useLogs } from "./hooks/use-logs";
+import { LogsView } from "./logs-view";
+import { useLogs } from "./use-logs";
 
 export default function LogsPage() {
-  const {
-    sessions,
-    filteredSessions,
-    selectedSession,
-    logContent,
-    filter,
-    contentFilter,
-    loading,
-    loadingContent,
-    autoScroll,
-    autoRefresh,
-    sidebarOpen,
-    logRef,
-    setFilter,
-    setContentFilter,
-    setAutoScroll,
-    setAutoRefresh,
-    setSidebarOpen,
-    loadLogContent,
-    deleteSession,
-    downloadLog,
-    renderLogs,
-    handleSelectSession,
-    formatDateTime,
-  } = useLogs();
+  const { sessions, selectedSession, logs, loading, loadingLogs, selectSession, refresh } = useLogs();
 
   return (
     <LogsView
       sessions={sessions}
-      filteredSessions={filteredSessions}
       selectedSession={selectedSession}
-      logContent={logContent}
-      filter={filter}
-      contentFilter={contentFilter}
+      logs={logs}
       loading={loading}
-      loadingContent={loadingContent}
-      autoScroll={autoScroll}
-      autoRefresh={autoRefresh}
-      sidebarOpen={sidebarOpen}
-      logRef={logRef}
-      onFilterChange={setFilter}
-      onContentFilterChange={setContentFilter}
-      onAutoScrollChange={setAutoScroll}
-      onAutoRefreshChange={setAutoRefresh}
-      onSidebarToggle={setSidebarOpen}
-      onLoadLogContent={loadLogContent}
-      onDeleteSession={deleteSession}
-      onDownloadLog={downloadLog}
-      onRenderLogs={renderLogs}
-      onSelectSession={handleSelectSession}
-      formatDateTime={formatDateTime}
+      loadingLogs={loadingLogs}
+      onSelect={selectSession}
+      onRefresh={refresh}
     />
   );
 }

--- a/frontend/src/app/logs/use-logs.ts
+++ b/frontend/src/app/logs/use-logs.ts
@@ -1,0 +1,70 @@
+// CRITICAL
+import { useCallback, useEffect, useMemo, useState } from "react";
+import api from "@/lib/api";
+import type { LogSession } from "@/lib/types";
+
+export function useLogs() {
+  const [sessions, setSessions] = useState<LogSession[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingLogs, setLoadingLogs] = useState(false);
+
+  const loadSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.getLogSessions();
+      const list = data.sessions ?? [];
+      setSessions(list);
+      setSelectedId((current) => {
+        if (current && list.some((item) => item.id === current)) {
+          return current;
+        }
+        const preferred = list.find((item) => item.status === "running") ?? list[0];
+        return preferred?.id ?? null;
+      });
+      if (list.length === 0) {
+        setLogs([]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadLogs = useCallback(async (sessionId: string) => {
+    setLoadingLogs(true);
+    try {
+      const data = await api.getLogs(sessionId, 200);
+      setLogs(data.logs ?? []);
+    } catch {
+      setLogs([]);
+    } finally {
+      setLoadingLogs(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  useEffect(() => {
+    if (selectedId) {
+      loadLogs(selectedId);
+    }
+  }, [selectedId, sessions, loadLogs]);
+
+  const selectedSession = useMemo(
+    () => sessions.find((item) => item.id === selectedId) ?? null,
+    [sessions, selectedId],
+  );
+
+  return {
+    sessions,
+    selectedSession,
+    logs,
+    loading,
+    loadingLogs,
+    selectSession: setSelectedId,
+    refresh: loadSessions,
+  };
+}

--- a/frontend/src/lib/api-settings.ts
+++ b/frontend/src/lib/api-settings.ts
@@ -40,6 +40,18 @@ function resolveSettingsFile() {
   };
 }
 
+/**
+ * Normalize a backend URL for client-side use.
+ * Converts 0.0.0.0 to localhost since browsers cannot connect to 0.0.0.0.
+ * @param url - The backend URL to normalize.
+ * @returns Normalized URL.
+ */
+function normalizeBackendUrl(url: string): string {
+  if (!url) return DEFAULT_SETTINGS.backendUrl;
+  // Replace 0.0.0.0 with localhost for browser compatibility
+  return url.replace(/:\/\/0\.0\.0\.0:/, "://localhost:");
+}
+
 export async function getApiSettings(): Promise<ApiSettings> {
   try {
     const { settingsFile } = resolveSettingsFile();
@@ -48,7 +60,7 @@ export async function getApiSettings(): Promise<ApiSettings> {
       const saved = JSON.parse(content) as Partial<ApiSettings>;
       // Merge with defaults (env vars still take precedence if settings file has empty values)
       return {
-        backendUrl: saved.backendUrl || DEFAULT_SETTINGS.backendUrl,
+        backendUrl: normalizeBackendUrl(saved.backendUrl || DEFAULT_SETTINGS.backendUrl),
         apiKey: saved.apiKey || DEFAULT_SETTINGS.apiKey,
         voiceUrl: saved.voiceUrl || DEFAULT_SETTINGS.voiceUrl,
         voiceModel: saved.voiceModel || DEFAULT_SETTINGS.voiceModel,
@@ -57,7 +69,7 @@ export async function getApiSettings(): Promise<ApiSettings> {
   } catch (error) {
     console.error("[API Settings] Failed to read settings file:", error);
   }
-  return DEFAULT_SETTINGS;
+  return { ...DEFAULT_SETTINGS, backendUrl: normalizeBackendUrl(DEFAULT_SETTINGS.backendUrl) };
 }
 
 export async function saveApiSettings(settings: ApiSettings): Promise<void> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -254,6 +254,9 @@ export interface ModelInfo {
   context_length?: number | null;
   recipe_ids?: string[];
   has_recipe?: boolean;
+  // Hotswap support: indicates this model is currently running
+  running?: boolean;
+  served_model_name?: string | null;
   // KV cache calculation fields
   num_hidden_layers?: number | null;
   num_kv_heads?: number | null;


### PR DESCRIPTION
This PR implements resilient backend routing and the reasoning parser fix, then
 layers in UX and consistency improvements: dynamic /config URLs, restored Logs page using existing
 APIs, and a shell UI throbber plus AMD rocm-smi controller integration and idle messaging instead of repeated rocm-smi warnings.

Maestro Track Alignment

 1. litellm-optional_20250201

 - Direct inference mode (VLLM_STUDIO_DIRECT_MODE) and configurable backend URLs.
 - Health-checked routing with LiteLLM → direct fallback and clear 503 errors when unavailable.
 - Streaming/tool-calling/token tracking preserved in direct mode.

 2. reasoning-parser-fix_20250202

 - Autodetect now applies DeepSeek-style parsers only to compatible non-GGUF models.
 - Explicit reasoning_parser: null still disables parser injection.
 - Auto-detection works when the field is unset.

 Key Changes

 1. Backend selection + resilient fallback

 - Files: controller/src/services/backend-health.ts, controller/src/routes/proxy.ts
 - Adds LiteLLM auth to health checks and request-level fallback when LiteLLM fails.

 Snippet:

 ```ts
   const { response: backendResponse, backend: activeBackend } = await requestWithFallback();
   if (!backendResponse.body) throw serviceUnavailable(`${activeBackend.name} unavailable`);
 ```

 2. Reasoning parser autodetect guard

 - Files: controller/src/services/backends.ts, controller/src/stores/recipe-serializer.ts,
 controller/src/types/models.ts
 - Ensures DeepSeek-style parsers never apply to GGUF.

 Snippet:

 ```ts
   const isGguf = modelId.endsWith(".gguf");
   if (!isGguf && deepseekCandidates.some(Boolean)) return "deepseek_r1";
 ```

 3. /config URL consistency

 - File: controller/src/routes/system.ts
 - Service/URL metadata now reflects configured inference/LiteLLM URLs.

 4. Logs UI restored

 - Files: frontend/src/app/logs/page.tsx, frontend/src/app/logs/logs-view.tsx,
 frontend/src/app/logs/use-logs.ts, .gitignore
 - Uses /logs + /logs/{id} to display sessions and log content.

 5. GPU startup UX

 - Files: controller/src/services/gpu.ts, controller/src/services/shell-ui.ts, controller/src/main.ts
 - Suppresses noisy rocm-smi low-power stderr, reports “idling” once, and shows a startup throbber.

 PR Checklist Summary
 - LiteLLM optional routing and direct-mode fallback
 - Reasoning parser fix with GGUF guard
 - Config endpoints reflect dynamic URLs
 - Logs page functional
 - Cleaner GPU startup output