### PR TITLE
Add optional LiteLLM routing and AMD GPU startup UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,19 @@ VLLM_STUDIO_API_KEY=
 # Inference backend port (where vLLM/SGLang runs)
 VLLM_STUDIO_INFERENCE_PORT=8000
 
+# =============================================================================
+# Chat Routing (Optional LiteLLM bypass)
+# =============================================================================
+
+# Set true to bypass LiteLLM and connect directly to vLLM/SGLang
+# VLLM_STUDIO_DIRECT_MODE=false
+
+# LiteLLM Gateway URL (optional)
+VLLM_STUDIO_LITELLM_URL=http://localhost:4100
+
+# Direct inference URL (vLLM/SGLang)
+VLLM_STUDIO_INFERENCE_URL=http://localhost:8000
+
 # Temporal dev server address (local Temporal OSS)
 VLLM_STUDIO_TEMPORAL_ADDRESS=localhost:7233
 

--- a/controller/src/config/env.ts
+++ b/controller/src/config/env.ts
@@ -20,6 +20,9 @@ export interface Config {
   models_dir: string;
   sglang_python?: string;
   tabby_api_dir?: string;
+  direct_mode: boolean;
+  litellm_url: string;
+  inference_url: string;
 }
 
 /**
@@ -70,6 +73,12 @@ export const createConfig = (): Config => {
     DATABASE_URL: z.string().optional(),
     VLLM_STUDIO_SGLANG_PYTHON: z.string().optional(),
     VLLM_STUDIO_TABBY_API_DIR: z.string().optional(),
+    VLLM_STUDIO_DIRECT_MODE: z.preprocess(
+      (value) => value === "true" || value === true,
+      z.boolean().default(false)
+    ),
+    VLLM_STUDIO_LITELLM_URL: z.string().default("http://localhost:4100"),
+    VLLM_STUDIO_INFERENCE_URL: z.string().default("http://localhost:8000"),
   });
 
   const parsed = schema.parse(process.env);
@@ -82,6 +91,9 @@ export const createConfig = (): Config => {
     data_dir: resolve(parsed.VLLM_STUDIO_DATA_DIR),
     db_path: resolve(parsed.VLLM_STUDIO_DB_PATH),
     models_dir: resolve(parsed.VLLM_STUDIO_MODELS_DIR),
+    direct_mode: parsed.VLLM_STUDIO_DIRECT_MODE,
+    litellm_url: parsed.VLLM_STUDIO_LITELLM_URL,
+    inference_url: parsed.VLLM_STUDIO_INFERENCE_URL,
   };
 
   const litellmDatabaseUrl =

--- a/controller/src/main.ts
+++ b/controller/src/main.ts
@@ -1,39 +1,89 @@
-import { execSync } from "node:child_process";
+// CRITICAL
+import { execSync, spawnSync } from "node:child_process";
 import { createAppContext } from "./app-context";
 import { createApp } from "./http/app";
 import { startMetricsCollector } from "./metrics-collector";
+import { detectGpuType } from "./services/gpu";
+import { createThrobber } from "./services/shell-ui";
 
 /**
- * Check if nvidia-smi is accessible (important for GPU monitoring).
- * Snap-installed bun has sandbox restrictions that block nvidia-smi.
+ * Check GPU monitoring tools for NVIDIA/AMD.
+ * Snap-installed bun has sandbox restrictions that block GPU tools.
  */
-const checkNvidiaSmi = (): void => {
-  try {
-    execSync("nvidia-smi --query-gpu=name --format=csv,noheader,nounits", {
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: "pipe",
-    });
-  } catch {
-    const isSnapBun = process.execPath.includes("/snap/");
-    console.warn("╔════════════════════════════════════════════════════════════════╗");
-    console.warn("║  WARNING: nvidia-smi is not accessible                         ║");
-    console.warn("║  GPU monitoring will not work.                                 ║");
-    if (isSnapBun) {
-      console.warn("║                                                                ║");
-      console.warn("║  You are using snap-installed bun which has sandbox            ║");
-      console.warn("║  restrictions. Use native bun instead:                         ║");
-      console.warn("║                                                                ║");
-      console.warn("║    curl -fsSL https://bun.sh/install | bash                    ║");
-      console.warn("║    ~/.bun/bin/bun run controller/src/main.ts                   ║");
-      console.warn("║                                                                ║");
-      console.warn("║  Or use the start script: ./start.sh                           ║");
+const checkGpuMonitoring = (): string => {
+  const gpuType = detectGpuType();
+  const isSnapBun = process.execPath.includes("/snap/");
+
+  if (gpuType === "nvidia") {
+    let gpuList = "";
+    try {
+      const output = execSync("nvidia-smi --query-gpu=name --format=csv,noheader,nounits", {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: "pipe",
+      }).trim();
+      if (output) {
+        gpuList = ` (${output.split("\n").join(", ")})`;
+      }
+    } catch {
+      gpuList = "";
     }
-    console.warn("╚════════════════════════════════════════════════════════════════╝");
+    return `[GPU] NVIDIA GPU detected - nvidia-smi monitoring available${gpuList}`;
   }
+
+  if (gpuType === "amd") {
+    let gpuList = "";
+    let isIdle = false;
+    try {
+      const result = spawnSync("rocm-smi", ["--showproductname", "--csv"], {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.stderr?.includes("low-power state")) {
+        isIdle = true;
+      }
+      const output = result.stdout?.toString().trim() ?? "";
+      const names = output
+        .split("\n")
+        .slice(1)
+        .map((line) => line.split(",")[1]?.trim() ?? "")
+        .filter(Boolean);
+      if (names.length > 0) {
+        gpuList = ` (${names.join(", ")})`;
+      }
+    } catch {
+      gpuList = "";
+    }
+    const idleNote = isIdle ? " (idling)" : "";
+    return `[GPU] AMD GPU detected - rocm-smi monitoring available${gpuList}${idleNote}`;
+  }
+
+  console.warn("╔════════════════════════════════════════════════════════════════╗");
+  console.warn("║  WARNING: No GPU monitoring tools accessible                    ║");
+  console.warn("║  GPU monitoring will not work.                                  ║");
+  console.warn("║                                                                ║");
+  console.warn("║  vLLM Studio supports:                                          ║");
+  console.warn("║  - nvidia-smi for NVIDIA GPUs                                   ║");
+  console.warn("║  - rocm-smi for AMD GPUs                                        ║");
+  if (isSnapBun) {
+    console.warn("║                                                                ║");
+    console.warn("║  You are using snap-installed bun which has sandbox            ║");
+    console.warn("║  restrictions. Use native bun instead:                         ║");
+    console.warn("║                                                                ║");
+    console.warn("║    curl -fsSL https://bun.sh/install | bash                    ║");
+    console.warn("║    ~/.bun/bin/bun run controller/src/main.ts                   ║");
+    console.warn("║                                                                ║");
+    console.warn("║                                                                ║");
+    console.warn("║  Or use the start script: ./start.sh                           ║");
+  }
+  console.warn("╚════════════════════════════════════════════════════════════════╝");
+  return "[GPU] No GPU monitoring tools accessible";
 };
 
-checkNvidiaSmi();
+const throbber = createThrobber();
+throbber.update("Checking GPU status");
+const gpuMessage = checkGpuMonitoring();
 
 const context = createAppContext();
 const app = createApp(context);
@@ -44,6 +94,7 @@ const stopMetrics = startMetricsCollector(context);
  * @returns Promise that resolves when started.
  */
 const run = async (): Promise<void> => {
+  throbber.update("Starting controller");
   const server = Bun.serve({
     port: context.config.port,
     hostname: context.config.host,
@@ -51,6 +102,7 @@ const run = async (): Promise<void> => {
     idleTimeout: 120,
   });
 
+  throbber.stop(`${gpuMessage} | Controller listening on ${context.config.host}:${server.port}`);
   context.logger.info(`Controller listening on ${context.config.host}:${server.port}`);
 
   const shutdown = (): void => {

--- a/controller/src/routes/proxy.ts
+++ b/controller/src/routes/proxy.ts
@@ -5,10 +5,11 @@ import { AsyncLock, delay } from "../core/async";
 import { HttpStatus, serviceUnavailable } from "../core/errors";
 import { buildSseHeaders } from "../http/sse";
 import type { AppContext } from "../types/context";
-import type { ProcessInfo, Recipe } from "../types/models";
+import type { BackendTarget, ProcessInfo, Recipe } from "../types/models";
 import type { ToolCallBuffer, ThinkState, Utf8State } from "../services/proxy-parsers";
 import { parseToolCallsFromContent } from "../services/proxy-parsers";
 import { createProxyStream } from "../services/proxy-streamer";
+import { detectAvailableBackends, selectBackend } from "../services/backend-health";
 
 const switchLock = new AsyncLock();
 
@@ -241,15 +242,96 @@ IMPORTANT: Do not use emoji, Unicode symbols, or decorative box-drawing characte
       }
     }
 
+    let availability;
+    try {
+      availability = await detectAvailableBackends(context.config);
+    } catch (error) {
+      throw serviceUnavailable(`Failed to check backend health: ${String(error)}`);
+    }
+
+    let backend: BackendTarget;
+    try {
+      backend = selectBackend(context.config, availability);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "No inference backend available";
+      throw serviceUnavailable(detail);
+    }
+
+    context.logger.info(`Chat completions routing: ${backend.name} (${backend.mode})`, {
+      mode: backend.mode,
+      url: backend.url,
+      direct_mode: context.config.direct_mode,
+      litellm_available: availability.litellm_available,
+      inference_available: availability.inference_available,
+    });
+
     const masterKey = process.env["LITELLM_MASTER_KEY"] ?? "sk-master";
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${masterKey}`,
     };
-    const litellmUrl = "http://localhost:4100/v1/chat/completions";
+    const fallbackTarget: BackendTarget = {
+      mode: "direct",
+      url: context.config.inference_url,
+      name: "Direct Inference (fallback)",
+    };
+
+    const shouldFallback = (target: BackendTarget, response: Response | null, error: string | null): boolean => {
+      if (target.mode !== "litellm" || !availability.inference_available) {
+        return false;
+      }
+      if (error) {
+        return true;
+      }
+      return Boolean(response && response.status >= 500);
+    };
+
+    const requestBackend = async (target: BackendTarget): Promise<{ response: Response | null; error: string | null }> => {
+      try {
+        const response = await fetch(`${target.url}/v1/chat/completions`, { method: "POST", headers, body: finalBody });
+        return { response, error: null };
+      } catch (error) {
+        return { response: null, error: `Failed to reach ${target.name}: ${String(error)}` };
+      }
+    };
+
+    const requestWithFallback = async (): Promise<{ response: Response; backend: BackendTarget }> => {
+      const primary = await requestBackend(backend);
+      if (shouldFallback(backend, primary.response, primary.error)) {
+        context.logger.warn("LiteLLM request failed, falling back to direct inference", {
+          error: primary.error,
+          status: primary.response?.status,
+        });
+        const fallback = await requestBackend(fallbackTarget);
+        if (fallback.error) {
+          const primaryMessage = primary.error ?? `LiteLLM responded with ${primary.response?.status}`;
+          throw serviceUnavailable(`${primaryMessage}. Fallback to direct inference failed: ${fallback.error}`);
+        }
+        if (!fallback.response) {
+          throw serviceUnavailable("Direct inference unavailable");
+        }
+        return { response: fallback.response, backend: fallbackTarget };
+      }
+      if (primary.error) {
+        throw serviceUnavailable(primary.error);
+      }
+      if (!primary.response) {
+        throw serviceUnavailable(`${backend.name} unavailable`);
+      }
+      return { response: primary.response, backend };
+    };
 
     if (!isStreaming) {
-      const response = await fetch(litellmUrl, { method: "POST", headers, body: finalBody });
+      const { response } = await requestWithFallback();
+      if (!response.ok) {
+        const errorText = await response.text();
+        return new Response(errorText, {
+          status: response.status,
+          headers: {
+            "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+          },
+        });
+      }
       const result = (await response.json()) as Record<string, unknown>;
 
       // Track token usage to lifetime metrics
@@ -298,19 +380,19 @@ IMPORTANT: Do not use emoji, Unicode symbols, or decorative box-drawing characte
       return ctx.json(result, { status: response.status });
     }
 
-    const litellmResponse = await fetch(litellmUrl, { method: "POST", headers, body: finalBody });
-    if (!litellmResponse.ok) {
-      const errorText = await litellmResponse.text();
+    const { response: backendResponse, backend: activeBackend } = await requestWithFallback();
+    if (!backendResponse.ok) {
+      const errorText = await backendResponse.text();
       return new Response(errorText, {
-        status: litellmResponse.status,
+        status: backendResponse.status,
         headers: {
-          "Content-Type": litellmResponse.headers.get("Content-Type") ?? "application/json",
+          "Content-Type": backendResponse.headers.get("Content-Type") ?? "application/json",
         },
       });
     }
-    const reader = litellmResponse.body?.getReader();
+    const reader = backendResponse.body?.getReader();
     if (!reader) {
-      throw serviceUnavailable("LiteLLM backend unavailable");
+      throw serviceUnavailable(`${activeBackend.name} unavailable`);
     }
 
     const thinkState: ThinkState = { inThinking: false };

--- a/controller/src/routes/system.test.ts
+++ b/controller/src/routes/system.test.ts
@@ -24,6 +24,9 @@ describe("System Routes", () => {
       data_dir: "./data",
       db_path: ":memory:",
       models_dir: "/models",
+      direct_mode: false,
+      litellm_url: "http://localhost:4100",
+      inference_url: "http://localhost:8000",
     };
 
     const mockContext = {

--- a/controller/src/services/backend-health.ts
+++ b/controller/src/services/backend-health.ts
@@ -1,0 +1,53 @@
+// CRITICAL
+import type { Config } from "../config/env";
+import type { BackendAvailability, BackendTarget } from "../types/models";
+
+const HEALTH_CHECK_TIMEOUT = 2000;
+
+export const checkBackendHealth = async (
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<boolean> => {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT);
+    const response = await fetch(`${url}/health`, {
+      signal: controller.signal,
+      headers: { "User-Agent": "vllm-studio/1.0", ...headers },
+    });
+    clearTimeout(timeoutId);
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+};
+
+export const detectAvailableBackends = async (config: Config): Promise<BackendAvailability> => {
+  const masterKey = process.env["LITELLM_MASTER_KEY"] ?? "sk-master";
+  const litellmHeaders = { Authorization: `Bearer ${masterKey}` };
+  const [litellmAvailable, inferenceAvailable] = await Promise.all([
+    checkBackendHealth(config.litellm_url, litellmHeaders),
+    checkBackendHealth(config.inference_url),
+  ]);
+
+  return {
+    litellm_available: litellmAvailable,
+    inference_available: inferenceAvailable,
+    selected_mode: "auto",
+  };
+};
+
+export const selectBackend = (config: Config, availability: BackendAvailability): BackendTarget => {
+  if (config.direct_mode) {
+    return { mode: "direct", url: config.inference_url, name: "Direct Inference" };
+  }
+  if (availability.litellm_available) {
+    return { mode: "litellm", url: config.litellm_url, name: "LiteLLM Gateway" };
+  }
+  if (availability.inference_available) {
+    return { mode: "direct", url: config.inference_url, name: "Direct Inference (fallback)" };
+  }
+  throw new Error(
+    "No inference backend available. LiteLLM is not running and vLLM/SGLang is not reachable.",
+  );
+};

--- a/controller/src/services/gpu.ts
+++ b/controller/src/services/gpu.ts
@@ -1,12 +1,125 @@
 // CRITICAL
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import type { GpuInfo } from "../types/models";
 
-/**
- * Query GPU info from nvidia-smi.
- * @returns List of GPU info objects.
- */
-export const getGpuInfo = (): GpuInfo[] => {
+export const detectGpuType = (): "nvidia" | "amd" | null => {
+  try {
+    const nvidiaSmi = process.env["NVIDIA_SMI_PATH"] || "nvidia-smi";
+    execSync(`${nvidiaSmi} --query-gpu=name --format=csv,noheader,nounits`, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+    });
+    return "nvidia";
+  } catch {
+    // Ignore
+  }
+
+  try {
+    spawnSync("rocm-smi", ["--showproductname"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return "amd";
+  } catch {
+    return null;
+  }
+};
+
+const parseRocmCsv = (output: string): Record<string, string>[] => {
+  if (!output || output.trim().length === 0) {
+    return [];
+  }
+  const lines = output.trim().split("\n");
+  if (lines.length < 2) {
+    return [];
+  }
+  const headers = lines[0].split(",").slice(1);
+  return lines.slice(1).map((line) => {
+    const values = line.split(",").slice(1);
+    return headers.reduce((acc, header, index) => {
+      acc[header] = values[index]?.trim() ?? "";
+      return acc;
+    }, {} as Record<string, string>);
+  });
+};
+
+export const getAmdGpuInfo = (): GpuInfo[] => {
+  try {
+    const runRocm = (args: string[]): string => {
+      const result = spawnSync("rocm-smi", args, {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.status !== 0 || !result.stdout) {
+        return "";
+      }
+      return result.stdout.toString();
+    };
+
+    const [productOutput, memOutput, useOutput, tempOutput, powerOutput] = [
+      runRocm(["--showproductname", "--csv"]),
+      runRocm(["--showmeminfo", "vram", "--csv"]),
+      runRocm(["--showuse", "--csv"]),
+      runRocm(["-t", "--csv"]),
+      runRocm(["--showpower", "--csv"]),
+    ];
+
+    const products = parseRocmCsv(productOutput);
+    const mems = parseRocmCsv(memOutput);
+    const uses = parseRocmCsv(useOutput);
+    const temps = parseRocmCsv(tempOutput);
+    const powers = parseRocmCsv(powerOutput);
+
+    const gpuCount = Math.max(products.length, mems.length, uses.length, temps.length, powers.length);
+    if (gpuCount === 0) {
+      return [];
+    }
+
+    const gpus: GpuInfo[] = [];
+    for (let i = 0; i < gpuCount; i += 1) {
+      const product = products[i] ?? {};
+      const mem = mems[i] ?? {};
+      const use = uses[i] ?? {};
+      const temp = temps[i] ?? {};
+      const power = powers[i] ?? {};
+
+      const name = product["Card Series"] || product["Device Name"] || "AMD GPU";
+      const memTotal = Number(mem["VRAM Total Memory (B)"] ?? 0);
+      const memUsed = Number(mem["VRAM Total Used Memory (B)"] ?? 0);
+      const memFree = Math.max(0, memTotal - memUsed);
+      const utilization = Number(use["GPU use (%)"] ?? 0);
+      const temperature = Number(temp["Temperature (Sensor edge) (C)"] ?? 0);
+      const powerDraw = Number(power["Average Graphics Package Power (W)"] ?? 0);
+      const toMB = (bytes: number): number => Math.max(0, Math.round(bytes / 1024 / 1024));
+
+      gpus.push({
+        index: i,
+        name,
+        memory_total: memTotal,
+        memory_total_mb: toMB(memTotal),
+        memory_used: memUsed,
+        memory_used_mb: toMB(memUsed),
+        memory_free: memFree,
+        memory_free_mb: toMB(memFree),
+        utilization,
+        utilization_pct: utilization,
+        temperature,
+        temp_c: temperature,
+        power_draw: powerDraw,
+        power_limit: 0,
+      });
+    }
+
+    return gpus;
+  } catch {
+    return [];
+  }
+};
+
+export const getNvidiaGpuInfo = (): GpuInfo[] => {
   const query = [
     "name",
     "memory.total",
@@ -19,7 +132,6 @@ export const getGpuInfo = (): GpuInfo[] => {
   ].join(",");
 
   try {
-    // Use full path to nvidia-smi with explicit env to ensure it can find CUDA libs
     const nvidiaSmi = process.env["NVIDIA_SMI_PATH"] || "/usr/bin/nvidia-smi";
     const output = execSync(
       `${nvidiaSmi} --query-gpu=${query} --format=csv,noheader,nounits`,
@@ -71,6 +183,17 @@ export const getGpuInfo = (): GpuInfo[] => {
   } catch {
     return [];
   }
+};
+
+export const getGpuInfo = (): GpuInfo[] => {
+  const gpuType = detectGpuType();
+  if (gpuType === "amd") {
+    return getAmdGpuInfo();
+  }
+  if (gpuType === "nvidia") {
+    return getNvidiaGpuInfo();
+  }
+  return [];
 };
 
 /**

--- a/controller/src/services/shell-ui.ts
+++ b/controller/src/services/shell-ui.ts
@@ -1,0 +1,44 @@
+// CRITICAL
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+export interface Throbber {
+  update: (message: string) => void;
+  stop: (finalMessage: string) => void;
+}
+
+export const createThrobber = (): Throbber => {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let frame = 0;
+  let message = "";
+
+  const render = (): void => {
+    if (!process.stdout.isTTY) {
+      return;
+    }
+    const output = `\r${FRAMES[frame % FRAMES.length]} ${message}`;
+    process.stdout.write(`${output}\x1b[0K`);
+    frame += 1;
+  };
+
+  const update = (nextMessage: string): void => {
+    message = nextMessage;
+    if (!timer && process.stdout.isTTY) {
+      timer = setInterval(render, 120);
+    }
+    render();
+  };
+
+  const stop = (finalMessage: string): void => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    if (process.stdout.isTTY) {
+      process.stdout.write(`\r${finalMessage}\x1b[0K\n`);
+    } else {
+      console.log(finalMessage);
+    }
+  };
+
+  return { update, stop };
+};

--- a/controller/src/types/models.ts
+++ b/controller/src/types/models.ts
@@ -7,6 +7,29 @@ import type { RecipeId } from "./brand";
 export type Backend = "vllm" | "sglang" | "transformers" | "tabbyapi";
 
 /**
+ * Chat proxy routing mode.
+ */
+export type RoutingMode = "auto" | "direct" | "litellm";
+
+/**
+ * Target backend for chat completions.
+ */
+export interface BackendTarget {
+  mode: RoutingMode;
+  url: string;
+  name: string;
+}
+
+/**
+ * Backend availability status.
+ */
+export interface BackendAvailability {
+  litellm_available: boolean;
+  inference_available: boolean;
+  selected_mode: RoutingMode;
+}
+
+/**
  * Model launch configuration.
  */
 export interface Recipe {


### PR DESCRIPTION
## Summary
- Add optional LiteLLM routing with health-checked fallback to direct vLLM/SGLang.
- Add AMD rocm-smi support with matching GPU fields and a single startup status line.
- Add a startup throbber for transient controller status output.

## Details
- New env vars: VLLM_STUDIO_DIRECT_MODE, VLLM_STUDIO_LITELLM_URL, VLLM_STUDIO_INFERENCE_URL.
- Controller /v1/chat/completions now selects backend with fallback and clear 503 errors.
- rocm-smi stderr is suppressed for low-power idle warnings; startup prints idling once.

## Files
- controller/src/services/backend-health.ts
- controller/src/routes/proxy.ts
- controller/src/services/gpu.ts
- controller/src/services/shell-ui.ts
- controller/src/main.ts
- controller/src/config/env.ts
- controller/src/types/models.ts
- .env.example
