### PR TITLE
[security] fix(agent): constrain filesystem API roots

### DIFF
--- a/frontend/src/app/api/agent/fs/file/route.ts
+++ b/frontend/src/app/api/agent/fs/file/route.ts
@@ -1,19 +1,34 @@
 import { NextRequest } from "next/server";
-import path from "node:path";
-import { readFileSnippet } from "@/lib/agent/fs-store";
+import {
+  configuredAgentFsRoots,
+  isAgentFsRequestAllowed,
+  readFileSnippet,
+  resolveAllowedWorkingDirectory,
+} from "@/lib/agent/fs-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
-  const cwd = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
+  const requestedCwd = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
   const relPath = request.nextUrl.searchParams.get("path")?.trim() ?? "";
-  if (!cwd || !relPath) {
+  if (!requestedCwd || !relPath) {
     return Response.json({ error: "cwd and path are required" }, { status: 400 });
   }
-  if (!path.isAbsolute(cwd)) {
-    return Response.json({ error: "cwd must be absolute" }, { status: 400 });
+
+  const roots = configuredAgentFsRoots();
+  if (!isAgentFsRequestAllowed(request.headers.get("host"), roots)) {
+    return Response.json(
+      { error: "Agent filesystem browsing is only available locally" },
+      { status: 403 },
+    );
   }
+
+  const cwd = resolveAllowedWorkingDirectory(requestedCwd, roots);
+  if (!cwd) {
+    return Response.json({ error: "cwd is outside the allowed directories" }, { status: 403 });
+  }
+
   try {
     const data = await readFileSnippet(cwd, relPath);
     return Response.json(data);

--- a/frontend/src/app/api/agent/fs/route.test.ts
+++ b/frontend/src/app/api/agent/fs/route.test.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GET as listFs } from "./route";
+import { GET as readFsFile } from "./file/route";
+
+const ROOTS_ENV_KEY = "VLLM_STUDIO_AGENT_FS_ROOTS";
+const REMOTE_FS_ENV_KEY = "VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS";
+
+async function responseJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("agent filesystem API", () => {
+  let sandbox: string;
+  let project: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    sandbox = await mkdtemp(path.join(os.tmpdir(), "vllm-studio-fs-test-"));
+    project = path.join(sandbox, "project");
+    outside = path.join(sandbox, "outside");
+    await mkdir(project);
+    await mkdir(outside);
+    await writeFile(path.join(project, "README.md"), "project file\n");
+    await writeFile(path.join(outside, "secret.txt"), "outside file\n");
+    process.env[ROOTS_ENV_KEY] = project;
+  });
+
+  afterEach(async () => {
+    delete process.env[ROOTS_ENV_KEY];
+    delete process.env[REMOTE_FS_ENV_KEY];
+    await rm(sandbox, { recursive: true, force: true });
+  });
+
+  it("lists files under an allowed project root", async () => {
+    const request = new NextRequest(
+      `http://localhost/api/agent/fs?cwd=${encodeURIComponent(project)}&path=`,
+      { headers: { host: "localhost" } },
+    );
+
+    const response = await listFs(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "README.md", rel: "README.md", kind: "file" }),
+      ]),
+    );
+  });
+
+  it("rejects cwd values outside configured agent filesystem roots", async () => {
+    const request = new NextRequest(
+      `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(path.parse(project).root)}&path=${encodeURIComponent(
+        path.relative(path.parse(project).root, path.join(outside, "secret.txt")),
+      )}`,
+      { headers: { host: "localhost" } },
+    );
+
+    const response = await readFsFile(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(403);
+    expect(payload.error).toBe("cwd is outside the allowed directories");
+  });
+
+  it("blocks relative traversal out of the project root", async () => {
+    const request = new NextRequest(
+      `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(project)}&path=${encodeURIComponent(
+        "../outside/secret.txt",
+      )}`,
+      { headers: { host: "localhost" } },
+    );
+
+    const response = await readFsFile(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Path escapes project root");
+  });
+
+  it("blocks symlink escapes out of the project root", async () => {
+    await symlink(path.join(outside, "secret.txt"), path.join(project, "linked-secret.txt"));
+    const request = new NextRequest(
+      `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(project)}&path=linked-secret.txt`,
+      { headers: { host: "localhost" } },
+    );
+
+    const response = await readFsFile(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Path escapes project root");
+  });
+
+  it("blocks remote host access unless explicitly enabled", async () => {
+    const request = new NextRequest(
+      `http://studio.example.test/api/agent/fs?cwd=${encodeURIComponent(project)}&path=`,
+      { headers: { host: "studio.example.test" } },
+    );
+
+    const response = await listFs(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(403);
+    expect(payload.error).toBe("Agent filesystem browsing is only available locally");
+  });
+
+  it("allows remote host access only after explicit opt-in", async () => {
+    process.env[REMOTE_FS_ENV_KEY] = "1";
+    const request = new NextRequest(
+      `http://studio.example.test/api/agent/fs?cwd=${encodeURIComponent(project)}&path=`,
+      { headers: { host: "studio.example.test" } },
+    );
+
+    const response = await listFs(request);
+    const payload = await responseJson(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "README.md", rel: "README.md", kind: "file" }),
+      ]),
+    );
+  });
+});

--- a/frontend/src/app/api/agent/fs/route.ts
+++ b/frontend/src/app/api/agent/fs/route.ts
@@ -1,17 +1,31 @@
 import { NextRequest } from "next/server";
-import path from "node:path";
 import { existsSync } from "node:fs";
-import { listDirectory } from "@/lib/agent/fs-store";
+import {
+  configuredAgentFsRoots,
+  isAgentFsRequestAllowed,
+  listDirectory,
+  resolveAllowedWorkingDirectory,
+} from "@/lib/agent/fs-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
-  const cwd = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
+  const requestedCwd = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
   const relPath = request.nextUrl.searchParams.get("path")?.trim() ?? "";
-  if (!cwd) return Response.json({ error: "cwd is required" }, { status: 400 });
-  if (!path.isAbsolute(cwd)) {
-    return Response.json({ error: "cwd must be absolute" }, { status: 400 });
+  if (!requestedCwd) return Response.json({ error: "cwd is required" }, { status: 400 });
+
+  const roots = configuredAgentFsRoots();
+  if (!isAgentFsRequestAllowed(request.headers.get("host"), roots)) {
+    return Response.json(
+      { error: "Agent filesystem browsing is only available locally" },
+      { status: 403 },
+    );
+  }
+
+  const cwd = resolveAllowedWorkingDirectory(requestedCwd, roots);
+  if (!cwd) {
+    return Response.json({ error: "cwd is outside the allowed directories" }, { status: 403 });
   }
   if (!existsSync(cwd)) return Response.json({ error: "cwd not found" }, { status: 404 });
   try {

--- a/frontend/src/lib/agent/fs-store.ts
+++ b/frontend/src/lib/agent/fs-store.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 export type FsEntry = {
@@ -25,17 +26,72 @@ const IGNORE_DIRS = new Set([
   ".vllm-studio",
 ]);
 
-// Reject any path that escapes the project root, including via symlinks.
+function splitConfiguredRoots(raw: string | undefined): string[] {
+  if (!raw) return [path.resolve(os.homedir())];
+  return raw
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => path.resolve(entry));
+}
+
+function realpathIfExists(candidate: string): string | null {
+  try {
+    return realpathSync(candidate);
+  } catch {
+    return null;
+  }
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+export function configuredAgentFsRoots(): string[] {
+  return splitConfiguredRoots(process.env.VLLM_STUDIO_AGENT_FS_ROOTS);
+}
+
+export function isLoopbackHost(host: string | null): boolean {
+  const value = host ?? "";
+  const hostname = value.startsWith("[")
+    ? value.slice(1, value.indexOf("]"))
+    : value.split(":")[0]?.toLowerCase();
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+export function isAgentFsRequestAllowed(host: string | null, roots: string[]): boolean {
+  const remoteBrowserEnabled = process.env.VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS === "1";
+  return isLoopbackHost(host) || (remoteBrowserEnabled && roots.length > 0);
+}
+
+export function resolveAllowedWorkingDirectory(input: string, roots: string[]): string | null {
+  if (!path.isAbsolute(input)) return null;
+
+  const candidate = realpathIfExists(path.resolve(input));
+  if (!candidate) return null;
+
+  const allowedRoots = roots
+    .map((root) => realpathIfExists(path.resolve(root)))
+    .filter(Boolean) as string[];
+  return allowedRoots.some((root) => isWithinRoot(candidate, root)) ? candidate : null;
+}
+
+// Reject any path that escapes the allowed project root, including via symlinks.
 function ensureInside(rootCwd: string, target: string): string {
-  const rel = path.relative(rootCwd, target);
-  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+  const root = realpathIfExists(rootCwd);
+  const resolvedTarget = realpathIfExists(target);
+  if (!root || !resolvedTarget || !isWithinRoot(resolvedTarget, root)) {
     throw new Error("Path escapes project root");
   }
-  return target;
+  return resolvedTarget;
 }
 
 export function listDirectory(rootCwd: string, relPath: string): FsEntry[] {
-  const target = ensureInside(rootCwd, path.resolve(rootCwd, relPath || "."));
+  const root = ensureInside(rootCwd, rootCwd);
+  const target = ensureInside(root, path.resolve(root, relPath || "."));
   if (!existsSync(target)) throw new Error("Not found");
   const stats = statSync(target);
   if (!stats.isDirectory()) throw new Error("Not a directory");
@@ -46,16 +102,18 @@ export function listDirectory(rootCwd: string, relPath: string): FsEntry[] {
     if (IGNORE_DIRS.has(name)) continue;
     if (name.startsWith(".") && name !== ".env.example") continue;
     const abs = path.join(target, name);
+    let resolvedAbs: string;
     let s: ReturnType<typeof statSync>;
     try {
-      s = statSync(abs);
+      resolvedAbs = ensureInside(root, abs);
+      s = statSync(resolvedAbs);
     } catch {
       continue;
     }
     entries.push({
       name,
-      path: abs,
-      rel: path.relative(rootCwd, abs),
+      path: resolvedAbs,
+      rel: path.relative(root, resolvedAbs),
       kind: s.isDirectory() ? "directory" : "file",
       size: s.isFile() ? s.size : undefined,
       modifiedAt: s.mtime.toISOString(),
@@ -73,7 +131,8 @@ export async function readFileSnippet(
   relPath: string,
   maxBytes = 5 * 1024 * 1024,
 ): Promise<{ content: string; truncated: boolean; size: number }> {
-  const target = ensureInside(rootCwd, path.resolve(rootCwd, relPath));
+  const root = ensureInside(rootCwd, rootCwd);
+  const target = ensureInside(root, path.resolve(root, relPath));
   const stats = await fs.stat(target);
   if (!stats.isFile()) throw new Error("Not a file");
   if (stats.size > maxBytes) {


### PR DESCRIPTION
## Summary

This PR hardens the frontend agent filesystem APIs so clients can no longer choose an arbitrary absolute `cwd` such as `/` and then read or enumerate local files from that base.

The patch moves the trust boundary to server-controlled allowed roots, defaults those roots to the current user's home directory, and keeps remote filesystem browsing disabled unless it is explicitly opted in with `VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS=1`.

## Security issues covered

| Issue | Impact | Status |
| --- | --- | --- |
| Caller-controlled agent filesystem root | A client could set `cwd=/` and use `/api/agent/fs/file` to read local text files such as `etc/hosts`, or use `/api/agent/fs` to enumerate the filesystem root. | Fixed |
| Path traversal and symlink escape from an allowed workspace | A requested path could resolve outside the intended project directory if containment was only checked before resolving the final target. | Fixed |
| Remote access to local filesystem browsing APIs | Agent filesystem browsing is local-development-oriented and should not be exposed to non-loopback hosts by default. | Hardened |

## Before this PR

- `/api/agent/fs` and `/api/agent/fs/file` accepted a caller-supplied absolute `cwd`.
- The containment check was relative to that caller-supplied `cwd`.
- If a client selected `cwd=/`, any local path was considered inside the allowed base.
- The file route could read local text files reachable from that base.
- Remote hosts were not rejected before filesystem resolution.

## After this PR

- Allowed filesystem roots are server-controlled through `VLLM_STUDIO_AGENT_FS_ROOTS`.
- If no explicit root is configured, the default root is the current user's home directory.
- Requested `cwd` values are resolved with `realpath` and must be inside one of the configured roots.
- File and directory targets are resolved with `realpath` before containment checks.
- Symlink escapes and `../` traversal outside the allowed root are rejected.
- Non-loopback hosts are rejected unless `VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS=1` is set and at least one allowed root is configured.

## Why this matters

These APIs run on the server side and interact with the host filesystem. Treating an HTTP query parameter as the filesystem trust boundary lets a remote caller turn a path that should be project-scoped into a host-scoped read/enumeration primitive.

For example, the vulnerable behavior allowed a request like `cwd=/&path=etc/hosts` to read a local text file through `/api/agent/fs/file`. The same root-selection issue also allowed root directory enumeration through `/api/agent/fs`.

## How this differs from #71

This is in the same trust-boundary family as the public discussion in #71 about unauthenticated directory browsing, but it fixes a distinct surface and a stronger failure mode:

- #71 discussed the sibling directory-browser route under `frontend/src/app/api/agent/directories/route.ts`.
- This PR fixes the `/api/agent/fs` and `/api/agent/fs/file` routes.
- The file route is not only a directory enumeration issue: it can return text file contents from the host filesystem when the client chooses `/` as `cwd`.
- This PR also adds resolved-path containment for file reads and symlink escapes, so the fix is not limited to route-level enumeration behavior.

## Attack flow

1. Start the frontend server.
2. Send a request to `/api/agent/fs/file` with a caller-controlled root:

```text
GET /api/agent/fs/file?cwd=/&path=etc/hosts
```

3. The old code treated `/` as the project root because it trusted the client-supplied `cwd`.
4. The route returned local text-file content from the server host.

## Affected code

| Area | Files |
| --- | --- |
| Agent filesystem list route | `frontend/src/app/api/agent/fs/route.ts` |
| Agent filesystem file-read route | `frontend/src/app/api/agent/fs/file/route.ts` |
| Agent filesystem containment helpers | `frontend/src/lib/agent/fs-store.ts` |
| Regression coverage | `frontend/src/app/api/agent/fs/route.test.ts` |

## Root cause

- The filesystem helper treated `cwd` as the security boundary.
- `cwd` came directly from the request query string.
- A containment check against attacker-selected `/` does not protect the host filesystem.
- File targets were not resolved with `realpath` before enforcing the final containment decision.

## CVSS assessment

- Issue: unauthenticated local filesystem text-file read and filesystem enumeration through frontend agent APIs
- CVSS v3.1: 8.1 High
- Vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L`

Rationale: the route is network reachable in the running web app, requires no privileges or user interaction, and can disclose local text files accessible to the server process. Availability impact is limited to directory/file probing work performed by the endpoint.

## Safe reproduction steps

On a vulnerable checkout:

```bash
cd frontend
npm run dev -- --hostname 127.0.0.1 --port 31337
curl -i 'http://127.0.0.1:31337/api/agent/fs/file?cwd=/&path=etc/hosts'
curl -i 'http://127.0.0.1:31337/api/agent/fs?cwd=/&path='
```

## Expected vulnerable behavior

- The file route returns HTTP 200 with local host-file text content.
- The list route returns HTTP 200 and lists filesystem-root entries.

## Changes in this PR

- Adds `VLLM_STUDIO_AGENT_FS_ROOTS` to configure server-side allowed filesystem roots.
- Defaults allowed roots to the current user's home directory.
- Resolves configured roots, requested working directories, and target files/directories through `realpath`.
- Rejects requested `cwd` values outside the configured roots.
- Rejects relative traversal and symlink escapes from the resolved working directory.
- Adds loopback-only default behavior for the agent filesystem endpoints.
- Adds `VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS=1` as an explicit remote-access opt-in.
- Adds focused regression tests covering allowed reads, rejected `cwd=/`, traversal, symlink escape, remote rejection, and remote opt-in behavior.

## Files changed

| File | What changed |
| --- | --- |
| `frontend/src/lib/agent/fs-store.ts` | Adds allowed-root parsing, resolved containment checks, loopback/remote opt-in helpers, and symlink-safe target resolution. |
| `frontend/src/app/api/agent/fs/route.ts` | Uses server-controlled roots and rejects non-local remote access by default before listing directories. |
| `frontend/src/app/api/agent/fs/file/route.ts` | Uses server-controlled roots and rejects non-local remote access by default before reading file snippets. |
| `frontend/src/app/api/agent/fs/route.test.ts` | Adds regression coverage for root containment, traversal, symlink escape, and remote access controls. |

## Maintainer impact

- Existing local development usage continues to work for paths under the user's home directory by default.
- Deployments that need a narrower scope can set `VLLM_STUDIO_AGENT_FS_ROOTS` to one or more allowed directories separated by the platform path delimiter.
- Deployments that intentionally expose these APIs to non-loopback hosts must explicitly set `VLLM_STUDIO_ENABLE_REMOTE_AGENT_FS=1`.
- The PR does not add authentication; it narrows and hardens the filesystem boundary used by the existing agent filesystem routes.

## Fix rationale

The server, not the client, needs to define the outer filesystem boundary. Resolving both the configured roots and requested targets before containment checks prevents bypasses through `..` segments and symlinks. Keeping remote access disabled by default matches the local-agent nature of this functionality and makes accidental network exposure safer.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests added
- [ ] Documentation-only change
- [ ] Refactor only

## Test plan

Passed:

```bash
npx prettier --write src/lib/agent/fs-store.ts \
  src/app/api/agent/fs/route.ts \
  src/app/api/agent/fs/file/route.ts \
  src/app/api/agent/fs/route.test.ts

npx eslint src/lib/agent/fs-store.ts \
  src/app/api/agent/fs/route.ts \
  src/app/api/agent/fs/file/route.ts \
  src/app/api/agent/fs/route.test.ts

npm test -- src/app/api/agent/fs/route.test.ts

git diff --check
```

Focused test result:

```text
✓ src/app/api/agent/fs/route.test.ts (6 tests)
Test Files  1 passed
Tests       6 passed
```

Manual validation after the patch:

```text
GET /api/agent/fs/file?cwd=/&path=etc/hosts
=> 403 {"error":"cwd is outside the allowed directories"}

GET /api/agent/fs?cwd=/tmp&path= with Host: studio.example.test
=> 403 {"error":"Agent filesystem browsing is only available locally"}
```

Also checked:

```bash
npm run build
```

That currently fails on unrelated pre-existing missing UI modules:

```text
./src/app/discover/_components/discover/discover-header.tsx
Module not found: Can't resolve '../../../../ui/refresh-button'

./src/app/usage/page.tsx
Module not found: Can't resolve '../../ui/page-state'

./src/app/usage/page.tsx
Module not found: Can't resolve '../../ui/refresh-button'
```

## Disclosure notes

This PR is intentionally scoped to the `/api/agent/fs` and `/api/agent/fs/file` filesystem boundary. It is related to, but distinct from, the public #71 directory-browser discussion because this route family also exposed text-file reads through attacker-selected roots. No secrets or host-specific sensitive file contents are included in this PR.