### PR TITLE
[security] fix(controller): restrict runtime job commands

### DIFF
--- a/controller/src/modules/engines/routes.test.ts
+++ b/controller/src/modules/engines/routes.test.ts
@@ -185,4 +185,43 @@ describe("engine routes", () => {
     expect(jobPayload.job.type).toBe("update");
     expect(jobPayload.job.message.length).toBeGreaterThan(0);
   });
+
+  it("rejects request-controlled runtime job commands", async () => {
+    const { app } = createEngineRoutesHarness();
+
+    const createResponse = await app.request("/runtime/jobs", {
+      method: "POST",
+      body: JSON.stringify({
+        backend: "sglang",
+        type: "update",
+        command: "/bin/sh",
+        args: ["-c", "id"],
+      }),
+    });
+
+    expect(createResponse.status).toBe(400);
+    const payload = (await createResponse.json()) as { error: string };
+    expect(payload.error).toContain(
+      "Runtime job commands and arguments must be configured server-side"
+    );
+
+    const jobsResponse = await app.request("/runtime/jobs");
+    const jobsPayload = (await jobsResponse.json()) as { jobs: unknown[] };
+    expect(jobsPayload.jobs).toEqual([]);
+  });
+
+  it("rejects command overrides on upgrade wrapper routes", async () => {
+    const { app } = createEngineRoutesHarness();
+
+    const createResponse = await app.request("/runtime/sglang/upgrade", {
+      method: "POST",
+      body: JSON.stringify({ command: "/bin/sh" }),
+    });
+
+    expect(createResponse.status).toBe(400);
+    const payload = (await createResponse.json()) as { error: string };
+    expect(payload.error).toContain(
+      "Runtime job commands and arguments must be configured server-side"
+    );
+  });
 });

--- a/controller/src/modules/engines/routes.ts
+++ b/controller/src/modules/engines/routes.ts
@@ -46,29 +46,25 @@ const parseRuntimeJobBody = async (ctx: {
   backend?: "vllm" | "sglang" | "llamacpp" | "cuda" | "rocm";
   targetId?: string;
   type?: "install" | "update" | "download" | "inspect";
-  command?: string;
-  args?: string[];
   version?: string;
   preferBundled?: boolean;
 }> => {
   const body = await ctx.req.json().catch(() => ({}));
   if (!body || typeof body !== "object" || Array.isArray(body)) throw badRequest("Invalid payload");
   const record = body as Record<string, unknown>;
+  if ("command" in record || "args" in record) {
+    throw badRequest("Runtime job commands and arguments must be configured server-side");
+  }
   const backend = typeof record["backend"] === "string" ? record["backend"] : undefined;
   if (backend && !["vllm", "sglang", "llamacpp", "cuda", "rocm"].includes(backend))
     throw badRequest("Invalid backend");
   const type = typeof record["type"] === "string" ? record["type"] : undefined;
   if (type && !["install", "update", "download", "inspect"].includes(type))
     throw badRequest("Invalid job type");
-  const args = Array.isArray(record["args"]) ? record["args"] : undefined;
-  if (args?.some((value) => typeof value !== "string"))
-    throw badRequest("args must be an array of strings");
   return {
     ...(backend ? { backend: backend as "vllm" | "sglang" | "llamacpp" | "cuda" | "rocm" } : {}),
     ...(typeof record["targetId"] === "string" ? { targetId: record["targetId"] } : {}),
     ...(type ? { type: type as "install" | "update" | "download" | "inspect" } : {}),
-    ...(typeof record["command"] === "string" ? { command: record["command"] } : {}),
-    ...(args ? { args: args as string[] } : {}),
     ...(typeof record["version"] === "string" ? { version: record["version"] } : {}),
     ...(typeof record["prefer_bundled"] === "boolean"
       ? { preferBundled: record["prefer_bundled"] }
@@ -288,8 +284,6 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
       backend: body.backend,
       type: body.type ?? "update",
       ...(body.targetId ? { targetId: body.targetId } : {}),
-      ...(body.command ? { command: body.command } : {}),
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version } : {}),
       ...(body.preferBundled !== undefined ? { preferBundled: body.preferBundled } : {}),
       runningProcess: current,
@@ -362,7 +356,6 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
     const job = createEngineJob(context.config, {
       backend: "vllm",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version.trim() } : {}),
       preferBundled: body.preferBundled ?? true,
     });
@@ -370,41 +363,37 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
   });
 
   app.post("/runtime/sglang/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "sglang",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/llamacpp/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "llamacpp",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/cuda/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "cuda",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/rocm/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "rocm",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });


### PR DESCRIPTION
## Summary

This PR hardens the controller runtime-job boundary so HTTP clients cannot choose the executable or argv used by runtime upgrade jobs.

- Rejects request-controlled `command` and `args` fields before a runtime job is created.
- Keeps runtime upgrade commands server-controlled through the existing runtime logic and configured environment variables.
- Adds regression coverage for both the generic `/runtime/jobs` endpoint and upgrade wrapper routes.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Request-controlled runtime job command execution | An unauthenticated client that can reach the controller could ask the runtime job API to execute an arbitrary local command as the controller user. | High |

## Before this PR

- `POST /runtime/jobs` accepted request JSON containing `command` and `args`.
- Those fields were forwarded into `createEngineJob()` and then into the runtime upgrade path.
- The runtime upgrade path eventually executed the supplied executable and argv with `spawnSync()` / `spawn()`.
- Wrapper routes also accepted `args`, and the shared parser allowed `command`, making the command boundary less explicit than the route names suggest.

## After this PR

- The shared runtime-job body parser rejects any request body containing `command` or `args`.
- `/runtime/jobs` no longer forwards caller-controlled command fields into `createEngineJob()`.
- Runtime upgrade wrapper routes no longer forward caller-controlled argv.
- Regression tests assert that no job is queued when command fields are supplied.

## Why this matters

Runtime upgrade jobs are privileged control-plane operations: they install or update local runtime components and run commands on the host where the controller is running. The HTTP requester should be able to request a known runtime operation, but it should not be able to redefine the executable or arguments used for that operation.

When the controller is reachable without an API key, trusting request-controlled command fields turns a management endpoint into host command execution. A malicious local process, exposed controller port, or browser-origin localhost request can potentially trigger this path.

## How this differs from PR #66

PR #66 addressed a related command-execution family in recipe launch / runtime lifecycle handling, specifically around user-controlled recipe command fields such as `extra_args.exllama_command`.

This PR fixes a distinct remaining boundary:

- Different endpoint: `POST /runtime/jobs` and the runtime upgrade wrapper routes.
- Different input fields: top-level `command` / `args` in the runtime job request body.
- Different execution path: runtime job creation and runtime upgrade helpers rather than recipe launch.
- Different trigger shape: a caller does not need to create or launch a recipe; creating a runtime job is sufficient on vulnerable code.

Both fixes are useful because they protect different admission points into command execution.

## Attack flow

```text
POST /runtime/jobs with { "backend": "sglang", "command": "/bin/sh", "args": ["-c", "..."] }
    -> parseRuntimeJobBody()
        -> createEngineJob(... command, args ...)
            -> runtime upgrade helper
                -> spawnSync(command, args)
                    -> host command execution as the controller user
```

## Affected code

| Issue | Files |
|-------|-------|
| Request-controlled runtime job command execution | `controller/src/modules/engines/routes.ts`, `controller/src/modules/engines/runtimes/engine-jobs.ts`, `controller/src/modules/engines/runtimes/runtime-upgrade.ts`, `controller/src/modules/engines/runtimes/vllm-runtime.ts`, `controller/src/core/command.ts` |

## Root cause

Request-controlled runtime job command execution:

- The runtime job route treated `command` and `args` from JSON as valid runtime-job options.
- The command execution boundary was enforced too late: by the time runtime upgrade helpers ran, the executable and argv could already be supplied by the HTTP requester.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Request-controlled runtime job command execution | 8.8 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H` |

Rationale:

- Impact is high because successful exploitation can execute commands as the controller user.
- The `UI:R` metric reflects the localhost-CSRF/browser-origin trigger shape for default local deployments; if the controller is directly exposed to untrusted network clients without an API key, the effective user-interaction requirement may be lower.
- Configuring an API key blocks unauthenticated requests and materially reduces exposure.

## Safe reproduction steps

On vulnerable code, use a temporary marker file instead of a destructive command:

1. Start the controller in a local test environment without an API key.
2. Send a runtime job request such as:

```bash
curl -sS -X POST http://127.0.0.1:<controller-port>/runtime/jobs \
  -H 'content-type: application/json' \
  --data '{
    "backend":"sglang",
    "type":"update",
    "command":"/bin/sh",
    "args":["-c","id > /tmp/vllm-studio-runtime-job-marker"]
  }'
```

3. Poll the returned job ID or inspect `/tmp/vllm-studio-runtime-job-marker`.
4. On vulnerable code, the marker file contains the controller user's `id` output.
5. With this PR, the request is rejected with HTTP 400 and no job is queued.

## Expected vulnerable behavior

- The pre-patch controller accepted `command` / `args` in runtime-job JSON.
- The job status eventually reported the supplied command, and the marker file was written by the controller process.
- A `text/plain` browser-simple request shape could also trigger the same operation in local testing, which is relevant for localhost-CSRF style exposure.

## Changes in this PR

- Reject `command` and `args` in the shared runtime-job request parser.
- Remove forwarding of request-controlled `command` and `args` from `/runtime/jobs`.
- Remove forwarding of request-controlled `args` from runtime upgrade wrapper routes.
- Add regression tests for the generic runtime-job route and an upgrade wrapper route.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Controller routes | `controller/src/modules/engines/routes.ts` | Runtime job body parsing now rejects request-controlled command fields and no longer forwards them into job creation. |
| Tests | `controller/src/modules/engines/routes.test.ts` | Added regression tests that assert command overrides are rejected and no job is created. |

## Maintainer impact

- The patch is intentionally narrow and limited to the runtime job HTTP admission layer.
- Server-side configured upgrade commands remain available through the existing runtime/environment configuration paths.
- Frontend code and unrelated recipe launch behavior are not changed by this PR.
- The new tests make the intended trust boundary explicit for future route changes.

## Fix rationale

The controller should own the executable and argv for runtime upgrade jobs. HTTP clients can request a supported operation, backend, version, or target, but should not be allowed to turn the runtime job API into a generic process launcher.

Rejecting `command` / `args` at request parsing time is a durable boundary because it prevents unsafe fields from entering the job model at all, rather than relying on each runtime backend to remember to ignore them later.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Format touched controller files.
- [x] Typecheck the controller package.
- [x] Lint the touched controller files.
- [x] Run focused engine route regression tests.
- [x] Run the full controller test suite.
- [x] Check the git diff for whitespace errors.

Executed with:

```bash
./node_modules/.bin/prettier --write src/modules/engines/routes.ts src/modules/engines/routes.test.ts
npm run typecheck -- --pretty false
npm run lint -- src/modules/engines/routes.ts src/modules/engines/routes.test.ts
npx --yes bun test src/modules/engines/routes.test.ts
npx --yes bun test
git diff --check
```

Observed locally:

```text
Focused route tests: 4 pass, 0 fail
Full controller tests: 107 pass, 0 fail
```

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: Token accounting was not available as reliable telemetry for the full multi-turn validation and PR preparation flow.

## Disclosure notes

- This PR is bounded to the runtime job API command boundary.
- It does not claim that all local-controller risks are removed when the controller is intentionally run without an API key.
- It preserves server-side configured upgrade commands while preventing HTTP clients from supplying arbitrary executables or argv.
- No unrelated files were changed.
