### PR TITLE
[security] fix(agent): constrain filesystem API roots

### DIFF
--- a/frontend/src/app/api/agent/fs/file/route.ts
+++ b/frontend/src/app/api/agent/fs/file/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import path from "node:path";
+import { resolveRegisteredProjectRoot } from "@/lib/agent/fs-access";
 import { readFileSnippet } from "@/lib/agent/fs-store";
 
 export const runtime = "nodejs";
@@ -11,11 +11,9 @@ export async function GET(request: NextRequest) {
   if (!cwd || !relPath) {
     return Response.json({ error: "cwd and path are required" }, { status: 400 });
   }
-  if (!path.isAbsolute(cwd)) {
-    return Response.json({ error: "cwd must be absolute" }, { status: 400 });
-  }
   try {
-    const data = await readFileSnippet(cwd, relPath);
+    const root = resolveRegisteredProjectRoot(cwd);
+    const data = await readFileSnippet(root, relPath);
     return Response.json(data);
   } catch (error) {
     return Response.json(

--- a/frontend/src/app/api/agent/fs/route.test.ts
+++ b/frontend/src/app/api/agent/fs/route.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET as listFiles } from "./route";
+import { GET as readFile } from "./file/route";
+
+const projectsStoreMock = vi.hoisted(() => ({
+  listProjectsFromStore: vi.fn(),
+}));
+
+vi.mock("@/lib/agent/projects-store", () => projectsStoreMock);
+
+function request(url: string): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+describe("agent filesystem API project-root boundaries", () => {
+  let projectRoot: string;
+  let outsideRoot: string;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    projectRoot = mkdtempSync(path.join(os.tmpdir(), "vllm-fs-project-"));
+    outsideRoot = mkdtempSync(path.join(os.tmpdir(), "vllm-fs-outside-"));
+    writeFileSync(path.join(projectRoot, "inside.txt"), "allowed", "utf8");
+    writeFileSync(path.join(outsideRoot, "secret.txt"), "blocked", "utf8");
+    projectsStoreMock.listProjectsFromStore.mockReturnValue([
+      {
+        id: "project-1",
+        name: "project",
+        path: projectRoot,
+        addedAt: new Date(0).toISOString(),
+        exists: true,
+        hasGit: false,
+        branch: null,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(outsideRoot, { recursive: true, force: true });
+  });
+
+  it("lists files only when cwd is a registered project root", async () => {
+    const response = await listFiles(
+      request(`http://localhost/api/agent/fs?cwd=${encodeURIComponent(projectRoot)}&path=`),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { entries: Array<{ name: string }> };
+    expect(payload.entries.map((entry) => entry.name)).toContain("inside.txt");
+  });
+
+  it("rejects absolute cwd values that were not selected as projects", async () => {
+    const response = await listFiles(
+      request(`http://localhost/api/agent/fs?cwd=${encodeURIComponent(outsideRoot)}&path=`),
+    );
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toBe("cwd is not a registered project root");
+  });
+
+  it("reads files from registered roots and blocks traversal outside them", async () => {
+    const allowed = await readFile(
+      request(
+        `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(projectRoot)}&path=${encodeURIComponent("inside.txt")}`,
+      ),
+    );
+    expect(allowed.status).toBe(200);
+    await expect(allowed.json()).resolves.toMatchObject({ content: "allowed" });
+
+    const blocked = await readFile(
+      request(
+        `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(projectRoot)}&path=${encodeURIComponent("../secret.txt")}`,
+      ),
+    );
+    expect(blocked.status).toBe(400);
+  });
+
+  it("blocks symlinks that resolve outside the registered project root", async () => {
+    mkdirSync(path.join(projectRoot, "links"));
+    symlinkSync(
+      path.join(outsideRoot, "secret.txt"),
+      path.join(projectRoot, "links", "secret.txt"),
+    );
+
+    const response = await readFile(
+      request(
+        `http://localhost/api/agent/fs/file?cwd=${encodeURIComponent(projectRoot)}&path=${encodeURIComponent("links/secret.txt")}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toBe("Path escapes project root");
+  });
+});

--- a/frontend/src/app/api/agent/fs/route.ts
+++ b/frontend/src/app/api/agent/fs/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest } from "next/server";
-import path from "node:path";
-import { existsSync } from "node:fs";
+import { resolveRegisteredProjectRoot } from "@/lib/agent/fs-access";
 import { listDirectory } from "@/lib/agent/fs-store";
 
 export const runtime = "nodejs";
@@ -9,13 +8,9 @@ export const dynamic = "force-dynamic";
 export async function GET(request: NextRequest) {
   const cwd = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
   const relPath = request.nextUrl.searchParams.get("path")?.trim() ?? "";
-  if (!cwd) return Response.json({ error: "cwd is required" }, { status: 400 });
-  if (!path.isAbsolute(cwd)) {
-    return Response.json({ error: "cwd must be absolute" }, { status: 400 });
-  }
-  if (!existsSync(cwd)) return Response.json({ error: "cwd not found" }, { status: 404 });
   try {
-    const entries = listDirectory(cwd, relPath);
+    const root = resolveRegisteredProjectRoot(cwd);
+    const entries = listDirectory(root, relPath);
     return Response.json({ entries });
   } catch (error) {
     return Response.json(

--- a/frontend/src/lib/agent/fs-access.ts
+++ b/frontend/src/lib/agent/fs-access.ts
@@ -1,0 +1,39 @@
+import { realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import { listProjectsFromStore } from "@/lib/agent/projects-store";
+
+function normalizeRealPath(candidate: string): string {
+  return realpathSync(candidate);
+}
+
+export function resolveRegisteredProjectRoot(rawCwd: string): string {
+  const cwd = rawCwd.trim();
+  if (!cwd) throw new Error("cwd is required");
+  if (!path.isAbsolute(cwd)) throw new Error("cwd must be absolute");
+
+  let root: string;
+  try {
+    const stats = statSync(cwd);
+    if (!stats.isDirectory()) throw new Error("cwd must be a directory");
+    root = normalizeRealPath(cwd);
+  } catch (error) {
+    if (error instanceof Error && error.message === "cwd must be a directory") throw error;
+    throw new Error("cwd not found");
+  }
+
+  const allowedRoots = listProjectsFromStore()
+    .filter((project) => project.exists)
+    .flatMap((project) => {
+      try {
+        return [normalizeRealPath(project.path)];
+      } catch {
+        return [];
+      }
+    });
+
+  if (!allowedRoots.includes(root)) {
+    throw new Error("cwd is not a registered project root");
+  }
+
+  return root;
+}

--- a/frontend/src/lib/agent/fs-store.ts
+++ b/frontend/src/lib/agent/fs-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs, readdirSync, statSync } from "node:fs";
+import { existsSync, promises as fs, readdirSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 
 export type FsEntry = {
@@ -26,11 +26,13 @@ const IGNORE_DIRS = new Set([
 
 // Reject any path that escapes the project root, including via symlinks.
 function ensureInside(rootCwd: string, target: string): string {
-  const rel = path.relative(rootCwd, target);
+  const root = realpathSync(rootCwd);
+  const resolvedTarget = realpathSync(target);
+  const rel = path.relative(root, resolvedTarget);
   if (rel.startsWith("..") || path.isAbsolute(rel)) {
     throw new Error("Path escapes project root");
   }
-  return target;
+  return resolvedTarget;
 }
 
 export function listDirectory(rootCwd: string, relPath: string): FsEntry[] {


### PR DESCRIPTION
## Summary

This PR rebuilds and improves the superseded filesystem containment work from #76 on top of the current `main` branch.

The agent filesystem API previously treated caller-supplied absolute `cwd` values as the effective filesystem root. This patch moves that trust boundary back to the server-side project registry: absolute `cwd` values must resolve to a project root already recorded in the agent project store, and requested paths are checked after canonicalization so traversal and symlink escapes cannot broaden the allowed root.

## Security issues covered

- Agent filesystem listing and file-read routes accepted client-selected absolute roots.
- A caller could point `cwd` at a sensitive host directory and then read/list files relative to that arbitrary root.
- Symlink targets needed to be checked after resolution, not just by lexical path joining.

## Before this PR

- `/api/agent/fs` accepted arbitrary absolute `cwd` values from the request.
- `/api/agent/fs/file` read files relative to request-controlled `cwd` + `path`.
- Containment was based on the caller-selected root instead of a server-known project root.
- A symlink inside an otherwise allowed tree could resolve outside that tree unless the target was canonicalized.

## After this PR

- Absolute `cwd` must canonicalize to a registered project root from the agent project store.
- Unregistered absolute directories are rejected before listing or file reads occur.
- Allowed roots and requested targets are resolved with realpath-based canonicalization.
- Resolved target paths must remain under the registered project root.
- Existing relative-path behavior is preserved for compatibility, but absolute roots no longer come from arbitrary clients.

## Why this matters

The agent filesystem API is a host-filesystem boundary. A browser tab, local process, or exposed local deployment should not be able to transform a request parameter into a new trusted filesystem root.

Constraining the root to a registered project keeps the API aligned with the product model: users select projects, and filesystem browsing should stay inside those selected projects rather than accepting arbitrary host paths.

## How this differs from #76

This PR is the fresh-main rebuild requested after #76 was closed as superseded by current `main` and v1.20.3.

Compared with the older patch, this version uses the current project-store model as the primary trust boundary instead of only adding generic allowed-directory checks. That makes the rule narrower and easier to reason about:

- #76 addressed arbitrary absolute `cwd` handling on an older tree.
- This PR applies the fix to the current codebase.
- This PR requires absolute `cwd` values to match a registered project root.
- This PR adds regression coverage for unregistered roots, traversal attempts, valid project file reads, and symlink escape attempts.

## Attack flow

1. A caller reaches the local agent filesystem API.
2. The caller supplies an absolute `cwd` outside any user-selected project.
3. The API treats that request-controlled path as the root for listing or file reads.
4. The caller lists or reads host files that are outside the intended project boundary.

## Affected code

- `frontend/src/app/api/agent/fs/route.ts`
- `frontend/src/app/api/agent/fs/file/route.ts`
- `frontend/src/lib/agent/fs-store.ts`
- `frontend/src/lib/agent/fs-access.ts`

## Root cause

- The filesystem routes accepted a root directory from request input.
- The server did not require that root to correspond to a registered project.
- Containment checks needed to be performed on canonical paths so symlinks and traversal cannot bypass the boundary.

## CVSS assessment

- Issue: agent filesystem API arbitrary-root access
- CVSS v3.1: 7.1 High
- Vector: `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:L/A:N`
- Rationale: exploitation is local-service/browser-adjacent and depends on reaching the local API, but successful exploitation can expose arbitrary readable local files and may influence project-visible file operations.

## Safe reproduction steps

On vulnerable code, start the frontend locally and request a file outside a selected project root by using an arbitrary absolute `cwd`:

```bash
cd frontend
npm run dev -- --hostname 127.0.0.1 --port 31337
curl -i 'http://127.0.0.1:31337/api/agent/fs/file?cwd=/&path=etc/hosts'
```

A project-specific proof can also place a symlink inside a registered project that points outside the project and then request that symlink path through the file route.

## Expected vulnerable behavior

On vulnerable code, the API treats `cwd=/` or another arbitrary absolute directory as the trusted root and can return host-file content or directory listings outside a registered project.

After this PR, unregistered absolute roots and symlink escapes are rejected.

## Changes in this PR

- Adds `frontend/src/lib/agent/fs-access.ts` for canonical project-root and target-path checks.
- Requires absolute `cwd` values to resolve to a registered project root.
- Applies the shared access helper to both listing and file-read routes.
- Canonicalizes roots and targets with `realpathSync` before containment checks.
- Adds regression tests for allowed and rejected filesystem access cases.

## Files changed

- `frontend/src/lib/agent/fs-access.ts`: new filesystem access helper.
- `frontend/src/lib/agent/fs-store.ts`: project-root canonicalization support.
- `frontend/src/app/api/agent/fs/route.ts`: list route enforcement.
- `frontend/src/app/api/agent/fs/file/route.ts`: file route enforcement.
- `frontend/src/app/api/agent/fs/route.test.ts`: regression coverage.

## Maintainer impact

The intended project browsing workflow is preserved. The behavior change is limited to rejecting absolute roots that are not registered project roots and rejecting resolved targets that escape those roots.

This PR does not attempt to address unrelated dependency audit findings reported by `npm install`.

## Fix rationale

The safest boundary for this API is the server-known project registry, not a path chosen by each request. Realpath-based containment also ensures that filesystem aliases, symlinks, and traversal segments are evaluated against the actual host path before access is granted.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests
- [ ] Documentation-only change
- [ ] Refactor only

## Test plan

Commands run:

```bash
cd /tmp/vllm-studio-audit/frontend
npx prettier --write src/lib/agent/fs-access.ts src/lib/agent/fs-store.ts src/app/api/agent/fs/route.ts src/app/api/agent/fs/file/route.ts src/app/api/agent/fs/route.test.ts
npx eslint src/lib/agent/fs-access.ts src/lib/agent/fs-store.ts src/app/api/agent/fs/route.ts src/app/api/agent/fs/file/route.ts src/app/api/agent/fs/route.test.ts
npm test -- --run src/app/api/agent/fs/route.test.ts
git diff --check
```

Focused test result:

```text
✓ src/app/api/agent/fs/route.test.ts (4 tests)
Test Files 1 passed
Tests 4 passed
```

## Disclosure notes

This PR is intentionally scoped to the agent filesystem API root boundary. It is a fresh-main follow-up to the closed/superseded #76 and does not claim to cover unrelated dependency vulnerabilities or other host filesystem surfaces.

Related closed PR: #76.
