### PR TITLE
[security] fix(controller): restrict runtime job commands

### DIFF
--- a/controller/src/modules/engines/routes.test.ts
+++ b/controller/src/modules/engines/routes.test.ts
@@ -219,4 +219,35 @@ describe("engine routes", () => {
     expect(jobPayload.job.type).toBe("update");
     expect(jobPayload.job.message.length).toBeGreaterThan(0);
   });
+
+  it("rejects request-controlled commands for runtime jobs", async () => {
+    const { app } = createEngineRoutesHarness();
+
+    const response = await app.request("/runtime/jobs", {
+      method: "POST",
+      body: JSON.stringify({
+        backend: "sglang",
+        type: "update",
+        command: "/bin/sh",
+        args: ["-c", "id"],
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toContain("Runtime job command and args are server-controlled");
+  });
+
+  it("rejects request-controlled args for runtime upgrade wrappers", async () => {
+    const { app } = createEngineRoutesHarness();
+
+    const response = await app.request("/runtime/llamacpp/upgrade", {
+      method: "POST",
+      body: JSON.stringify({ args: ["--post-install-hook=/bin/sh"] }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toContain("Runtime job command and args are server-controlled");
+  });
 });

--- a/controller/src/modules/engines/routes.ts
+++ b/controller/src/modules/engines/routes.ts
@@ -46,8 +46,6 @@ const parseRuntimeJobBody = async (ctx: {
   backend?: "vllm" | "sglang" | "llamacpp" | "cuda" | "rocm";
   targetId?: string;
   type?: "install" | "update" | "download" | "inspect";
-  command?: string;
-  args?: string[];
   version?: string;
   preferBundled?: boolean;
 }> => {
@@ -60,15 +58,13 @@ const parseRuntimeJobBody = async (ctx: {
   const type = typeof record["type"] === "string" ? record["type"] : undefined;
   if (type && !["install", "update", "download", "inspect"].includes(type))
     throw badRequest("Invalid job type");
-  const args = Array.isArray(record["args"]) ? record["args"] : undefined;
-  if (args?.some((value) => typeof value !== "string"))
-    throw badRequest("args must be an array of strings");
+  if ("command" in record || "args" in record) {
+    throw badRequest("Runtime job command and args are server-controlled");
+  }
   return {
     ...(backend ? { backend: backend as "vllm" | "sglang" | "llamacpp" | "cuda" | "rocm" } : {}),
     ...(typeof record["targetId"] === "string" ? { targetId: record["targetId"] } : {}),
     ...(type ? { type: type as "install" | "update" | "download" | "inspect" } : {}),
-    ...(typeof record["command"] === "string" ? { command: record["command"] } : {}),
-    ...(args ? { args: args as string[] } : {}),
     ...(typeof record["version"] === "string" ? { version: record["version"] } : {}),
     ...(typeof record["prefer_bundled"] === "boolean"
       ? { preferBundled: record["prefer_bundled"] }
@@ -328,8 +324,6 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
       backend: body.backend,
       type: body.type ?? "update",
       ...(body.targetId ? { targetId: body.targetId } : {}),
-      ...(body.command ? { command: body.command } : {}),
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version } : {}),
       ...(body.preferBundled !== undefined ? { preferBundled: body.preferBundled } : {}),
       runningProcess: current,
@@ -402,8 +396,6 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
       backend: "vllm",
       type: "update",
       ...(body.targetId ? { targetId: body.targetId } : {}),
-      ...(body.command ? { command: body.command } : {}),
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version.trim() } : {}),
       ...(body.preferBundled !== undefined ? { preferBundled: body.preferBundled } : {}),
       runningProcess: current,
@@ -412,41 +404,37 @@ export const registerEngineRoutes = (app: Hono, context: AppContext): void => {
   });
 
   app.post("/runtime/sglang/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "sglang",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/llamacpp/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "llamacpp",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/cuda/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "cuda",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/rocm/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "rocm",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });


### PR DESCRIPTION
## Summary

This PR rebuilds the superseded runtime-job command-boundary hardening from #77 on top of the current `main` branch.

The runtime job API accepted `command` and `args` fields from request JSON and forwarded them into runtime job creation. Those jobs eventually execute server-side upgrade commands. This patch makes the command and argv for runtime jobs server-controlled: request bodies may choose supported runtime metadata, but they may not supply the executable or argument vector.

## Security issues covered

- Runtime job creation accepted request-controlled `command` and `args`.
- Runtime upgrade wrapper routes forwarded request-controlled `args` into server-side jobs.
- The shared request parser allowed unsafe execution fields to enter the job model.

## Before this PR

- `POST /runtime/jobs` parsed `command` and `args` from request JSON.
- Those fields were passed to `createEngineJob()`.
- Runtime upgrade wrappers also accepted and forwarded request-controlled `args`.
- A caller who could reach the local controller API could influence the process and argv used by a runtime job.

## After this PR

- `command` and `args` are rejected at runtime-job request parsing time.
- `/runtime/jobs` no longer forwards request-controlled executable fields into `createEngineJob()`.
- Runtime upgrade wrapper routes parse the body only to reject unsupported execution fields and then create jobs with server-controlled backend/type values.
- Server-side configured runtime upgrade behavior remains intact.

## Why this matters

Runtime upgrade jobs are a command-execution boundary. The API should expose high-level runtime operations, not a way for callers to choose the executable or argv that the controller launches.

Keeping command selection server-controlled reduces the risk from browser-adjacent localhost requests, untrusted local processes, or accidentally exposed controller deployments.

## How this differs from #66

This PR is same-family command-surface hardening, but it is not the same route as #66.

- #66 concerns recipe/ExLlama launch command behavior.
- This PR concerns the runtime job updater API and upgrade wrapper routes.
- The vulnerable path here is `POST /runtime/jobs` or a runtime upgrade wrapper into `parseRuntimeJobBody()` and `createEngineJob()`.
- The fix here is to reject request-controlled `command` and `args` before those fields can enter the runtime job model.

## Attack flow

1. A caller reaches the local controller runtime API.
2. The caller sends a runtime job request containing `command` and `args`.
3. The request parser accepts those fields.
4. The route forwards them into `createEngineJob()`.
5. The runtime job execution path can launch the caller-selected command/argv.

## Affected code

- `controller/src/modules/engines/routes.ts`
- `controller/src/modules/engines/routes.test.ts`

## Root cause

- Runtime job request parsing treated execution fields as valid user input.
- Routes forwarded those fields into a server-side job model.
- Upgrade wrapper routes accepted request-controlled argv even though the operation should be server-defined.

## CVSS assessment

- Issue: runtime job request-controlled command/argv
- CVSS v3.1: 8.4 High
- Vector: `CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
- Rationale: the controller defaults to a local service boundary, so the attack vector is local by default. Within that boundary, successful exploitation can control process execution with high confidentiality, integrity, and availability impact.

## Safe reproduction steps

On vulnerable code, send a runtime job request with a harmless marker command through the controller route harness or local controller API:

```bash
curl -i 'http://127.0.0.1:8080/runtime/jobs' \
  -H 'content-type: application/json' \
  --data '{"backend":"sglang","type":"update","command":"/bin/sh","args":["-c","id > /tmp/vllm-studio-runtime-job-marker"]}'
```

A similar check can be performed against an upgrade wrapper by attempting to provide request-controlled `args`.

## Expected vulnerable behavior

On vulnerable code, the request-controlled command and/or argv can be accepted into the runtime job and executed by the runtime job runner.

After this PR, these requests return `400` with `Runtime job command and args are server-controlled`.

## Changes in this PR

- Removes `command` and `args` from the accepted runtime job request body shape.
- Rejects either field in `parseRuntimeJobBody()` before job creation.
- Stops forwarding request-controlled command data from `/runtime/jobs`.
- Stops forwarding request-controlled args from runtime upgrade wrapper routes.
- Adds regression tests for both direct runtime jobs and upgrade wrapper routes.

## Files changed

- `controller/src/modules/engines/routes.ts`: runtime job parser and route forwarding hardening.
- `controller/src/modules/engines/routes.test.ts`: regression tests for rejected request-controlled command/args.

## Maintainer impact

Legitimate runtime update/install/download/inspect job creation remains available through the existing backend/type/version/prefer-bundled fields. The change only removes the ability for API clients to choose the executable or argv directly.

Server-side runtime configuration continues to determine the actual command behavior.

## Fix rationale

The controller should expose explicit runtime operations, not a generic command launcher. Rejecting unsafe fields in the shared parser ensures every route that uses the parser gets the same admission-layer protection and prevents future route additions from accidentally forwarding these execution fields.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests
- [ ] Documentation-only change
- [ ] Refactor only

## Test plan

Commands run:

```bash
cd /tmp/vllm-studio-audit/controller
./node_modules/.bin/prettier --write src/modules/engines/routes.ts src/modules/engines/routes.test.ts
npm run typecheck -- --pretty false
npm run lint -- src/modules/engines/routes.ts src/modules/engines/routes.test.ts
npx --yes bun test src/modules/engines/routes.test.ts
npx --yes bun test
git diff --check
```

Result:

```text
Focused route tests: 4 pass, 0 fail
Full controller tests: 107 pass, 0 fail
```

## Disclosure notes

This PR is intentionally scoped to the runtime job command boundary. It is a fresh-main follow-up to the closed/superseded #77 and is framed as same-family hardening adjacent to #66, not as a duplicate of the recipe launch issue.

Related closed PR: #77.
