### PR TITLE
Align chat queue with Pi steer/follow-up semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,17 @@ Access these in scripts via environment variables or load them from `.env.local`
 - **Agent surface**: `http://localhost:3001/agent`
 - **Run**: `cd frontend && PORT=3001 npm run dev`
 - Use this local server for fast browser verification unless the user explicitly asks for a different port or deployment target.
+- **Desktop dev mode for iterative UI work**: launch Electron against the local dev server so frontend changes show up without rebuilding the installed app:
+
+```bash
+# Terminal 1
+cd frontend && PORT=3001 npm run dev
+
+# Terminal 2
+cd frontend && npm run desktop:build:main && VLLM_STUDIO_DESKTOP_DEV_SERVER_URL=http://127.0.0.1:3001 npm run desktop:start
+```
+
+- Prefer this desktop dev mode while debugging/iterating on the Mac app. Still run `desktop:dist` and replace `/Applications/vLLM Studio.app` before calling the feature finished.
 
 ## Deployment Workflow
 

--- a/frontend/desktop/electron-builder.yml
+++ b/frontend/desktop/electron-builder.yml
@@ -16,7 +16,15 @@ extraResources:
     filter:
       - "**/*"
   - from: .next/static
+    to: app/frontend/.next/standalone/.next/static
+    filter:
+      - "**/*"
+  - from: .next/static
     to: app/frontend/.next/standalone/frontend/.next/static
+    filter:
+      - "**/*"
+  - from: public
+    to: app/frontend/.next/standalone/public
     filter:
       - "**/*"
   - from: public

--- a/frontend/desktop/logic/projects-store.ts
+++ b/frontend/desktop/logic/projects-store.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { app } from "electron";
+
+const CHATS_PROJECT_ID = "chats";
 
 export interface ProjectRecord {
   id: string;
@@ -92,12 +95,27 @@ export interface ProjectListEntry extends ProjectRecord {
 
 export function listProjectsWithMeta(): ProjectListEntry[] {
   const document = readDocument(projectsFilePath());
-  return document.projects.map((project) => ({
-    ...project,
-    exists: isExistingDirectory(project.path),
-    hasGit: existsSync(path.join(project.path, ".git")),
-    branch: gitBranchFor(project.path),
-  }));
+  const chatsPath = path.join(homedir(), ".vllm-studio");
+  mkdirSync(chatsPath, { recursive: true });
+  return [
+    {
+      id: CHATS_PROJECT_ID,
+      name: "Chats",
+      path: chatsPath,
+      addedAt: "1970-01-01T00:00:00.000Z",
+      exists: isExistingDirectory(chatsPath),
+      hasGit: existsSync(path.join(chatsPath, ".git")),
+      branch: gitBranchFor(chatsPath),
+    },
+    ...document.projects
+      .filter((project) => project.id !== CHATS_PROJECT_ID)
+      .map((project) => ({
+        ...project,
+        exists: isExistingDirectory(project.path),
+        hasGit: existsSync(path.join(project.path, ".git")),
+        branch: gitBranchFor(project.path),
+      })),
+  ];
 }
 
 export function addProject(rawPath: string): ProjectListEntry {
@@ -135,6 +153,7 @@ export function addProject(rawPath: string): ProjectListEntry {
 }
 
 export function removeProject(id: string): void {
+  if (id === CHATS_PROJECT_ID) return;
   const filePath = projectsFilePath();
   const document = readDocument(filePath);
   if (!document.projects.some((entry) => entry.id === id)) return;

--- a/frontend/src/app/agent/_components/agent-workspace-shell.tsx
+++ b/frontend/src/app/agent/_components/agent-workspace-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   consumeAgentSessionNavTitle,
@@ -13,6 +13,7 @@ import type { AgentModel, PaneId, WorkspaceState } from "@/lib/agent/workspace/t
 import { useProjects, type ProjectsContextValue } from "@/lib/agent/projects/context";
 import { useTools } from "@/lib/agent/tools/context";
 import type { Project } from "@/lib/agent/projects/types";
+import { useClickOutside } from "@/hooks/use-click-outside";
 import { focusedSession, materializePaneSessions } from "@/lib/agent/sessions/selectors";
 import { AgentBrowserPanel } from "./agent-browser-panel";
 import { ChatPane } from "./chat-pane";
@@ -323,26 +324,81 @@ function renderProjectSelector(
 ) {
   if (!paneProject || projects.length === 0) return null;
   return (
-    <select
-      value={paneProject.id}
-      onChange={(event) => {
-        const project = projects.find((entry) => entry.id === event.target.value);
-        if (project) handles.selectPaneProject(paneId, project);
-      }}
-      disabled={!paneTabIsNew}
-      className="!h-7 !min-h-7 max-w-full min-w-0 truncate rounded-md border-0 bg-transparent px-2 py-0 font-mono !text-[11px] text-(--dim) outline-none hover:bg-(--surface) hover:text-(--fg) disabled:opacity-100"
-      style={{
-        width: `${Math.min(Math.max(paneProject.path.length + 3, 12), 54)}ch`,
-      }}
-      title={paneTabIsNew ? "Change directory for this new session" : paneProject.path}
-      aria-label="Session directory"
-    >
-      {projects.map((project) => (
-        <option key={project.id} value={project.id}>
-          {project.path}
-        </option>
-      ))}
-    </select>
+    <ProjectSelector
+      paneId={paneId}
+      projects={projects}
+      paneProject={paneProject}
+      paneTabIsNew={paneTabIsNew}
+      handles={handles}
+    />
+  );
+}
+
+function basenameOfPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.split("/").filter(Boolean).pop() || value;
+}
+
+function ProjectSelector({
+  paneId,
+  projects,
+  paneProject,
+  paneTabIsNew,
+  handles,
+}: {
+  paneId: PaneId;
+  projects: Project[];
+  paneProject: Project;
+  paneTabIsNew: boolean;
+  handles: WorkspaceHandles;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, open, () => setOpen(false));
+  const label = paneProject.name || basenameOfPath(paneProject.path);
+  return (
+    <div ref={ref} className="relative min-w-0">
+      <button
+        type="button"
+        onClick={() => {
+          if (paneTabIsNew) setOpen((value) => !value);
+        }}
+        disabled={!paneTabIsNew}
+        className="inline-flex !h-6 !min-h-6 max-w-full min-w-0 items-center gap-1 rounded-md border-0 bg-transparent px-1.5 py-0 font-mono !text-[10px] text-(--dim) outline-none hover:bg-(--surface) hover:text-(--fg) disabled:opacity-100"
+        title={paneTabIsNew ? "Change directory for this new session" : paneProject.path}
+        aria-label="Session directory"
+        aria-expanded={open}
+      >
+        <span className="min-w-0 max-w-[18ch] truncate">{label}</span>
+        {paneTabIsNew ? (
+          <ChevronDownIcon
+            className={`h-2.5 w-2.5 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        ) : null}
+      </button>
+      {open ? (
+        <div className="absolute bottom-full left-0 z-50 mb-1 max-h-60 min-w-[min(34rem,70vw)] overflow-y-auto rounded-md border border-(--border) bg-[#151515] p-1 text-[11px] text-(--fg) shadow-[0_8px_28px_rgba(0,0,0,0.65)]">
+          {projects.map((project) => (
+            <button
+              type="button"
+              key={project.id}
+              onClick={() => {
+                handles.selectPaneProject(paneId, project);
+                setOpen(false);
+              }}
+              className={`flex w-full min-w-0 items-center gap-2 rounded-sm px-2 py-1.5 text-left font-mono ${
+                project.id === paneProject.id
+                  ? "bg-(--hover) text-(--fg)"
+                  : "text-(--dim) hover:bg-(--hover) hover:text-(--fg)"
+              }`}
+              title={project.path}
+            >
+              <span className="min-w-0 flex-1 truncate">{project.path}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/frontend/src/app/agent/_components/chat-pane.test.ts
+++ b/frontend/src/app/agent/_components/chat-pane.test.ts
@@ -131,16 +131,29 @@ describe("reconcileQueueWithPiEvent", () => {
     const result = reconcileQueueWithPiEvent(
       [
         { id: "local", mode: "follow_up", text: "local only" },
+        { id: "optimistic", mode: "follow_up", text: "claimed by pi" },
         { id: "sent-follow", mode: "follow_up", text: "kept", sent: true },
         { id: "sent-steer", mode: "steer", text: "delivered", sent: true },
       ],
-      { type: "queue_update", steering: ["new steer"], followUp: ["kept"] },
+      { type: "queue_update", steering: ["new steer"], followUp: ["claimed by pi", "kept"] },
     );
     expect(result).toEqual([
       { id: "local", mode: "follow_up", text: "local only" },
+      { id: "optimistic", mode: "follow_up", text: "claimed by pi", sent: true },
       { id: "sent-follow", mode: "follow_up", text: "kept", sent: true },
       { id: expect.any(String), mode: "steer", text: "new steer", sent: true },
     ]);
+  });
+  it("removes Pi-accepted follow-ups when Pi reports an empty queue", () => {
+    expect(
+      reconcileQueueWithPiEvent(
+        [
+          { id: "accepted", mode: "follow_up", text: "already in pi", sent: true },
+          { id: "local", mode: "follow_up", text: "retry locally", sent: false },
+        ],
+        { type: "queue_update", steering: [], followUp: [] },
+      ),
+    ).toEqual([{ id: "local", mode: "follow_up", text: "retry locally", sent: false }]);
   });
 });
 describe("mergeCanonicalAndRuntimeEvents", () => {

--- a/frontend/src/app/agent/_components/chat-pane.test.ts
+++ b/frontend/src/app/agent/_components/chat-pane.test.ts
@@ -40,16 +40,13 @@ describe("parseAgentTurnSsePayload", () => {
   });
 });
 describe("visibleQueuedMessages", () => {
-  it("shows follow-up and steer queue items", () => {
+  it("shows follow-up queue items without surfacing steers", () => {
     expect(
       visibleQueuedMessages([
         { id: "steer", mode: "steer", text: "interrupt", sent: true },
         { id: "follow", mode: "follow_up", text: "next" },
       ]),
-    ).toEqual([
-      { id: "steer", mode: "steer", text: "interrupt", sent: true },
-      { id: "follow", mode: "follow_up", text: "next" },
-    ]);
+    ).toEqual([{ id: "follow", mode: "follow_up", text: "next" }]);
   });
 });
 describe("statusAfterControlPhase", () => {
@@ -131,7 +128,7 @@ describe("drainQueueAfterAgentEnd", () => {
   });
 });
 describe("reconcileQueueWithPiEvent", () => {
-  it("mirrors Pi queue updates without dropping local unsent follow-ups", () => {
+  it("mirrors Pi follow-up queue updates without showing steering entries", () => {
     const result = reconcileQueueWithPiEvent(
       [
         { id: "local", mode: "follow_up", text: "local only" },
@@ -145,7 +142,6 @@ describe("reconcileQueueWithPiEvent", () => {
       { id: "local", mode: "follow_up", text: "local only" },
       { id: "optimistic", mode: "follow_up", text: "claimed by pi", sent: true },
       { id: "sent-follow", mode: "follow_up", text: "kept", sent: true },
-      { id: expect.any(String), mode: "steer", text: "new steer", sent: true },
     ]);
   });
   it("removes Pi-accepted follow-ups when Pi reports an empty queue", () => {
@@ -159,7 +155,7 @@ describe("reconcileQueueWithPiEvent", () => {
       ),
     ).toEqual([{ id: "local", mode: "follow_up", text: "retry locally", sent: false }]);
   });
-  it("matches Pi context-wrapped queue text to the local composer text", () => {
+  it("drops Pi steering updates from the follow-up queue model", () => {
     const result = reconcileQueueWithPiEvent(
       [{ id: "optimistic", mode: "steer", text: "focus on the queue bug", sent: true }],
       {
@@ -170,9 +166,7 @@ describe("reconcileQueueWithPiEvent", () => {
         followUp: [],
       },
     );
-    expect(result).toEqual([
-      { id: "optimistic", mode: "steer", text: "focus on the queue bug", sent: true },
-    ]);
+    expect(result).toEqual([]);
   });
   it("displays context-wrapped canonical Pi queue items as user text", () => {
     const result = reconcileQueueWithPiEvent([], {

--- a/frontend/src/app/agent/_components/chat-pane.test.ts
+++ b/frontend/src/app/agent/_components/chat-pane.test.ts
@@ -5,6 +5,7 @@ import {
   mergeCanonicalAndRuntimeEvents,
   parseAgentTurnSsePayload,
   reconcileQueueWithPiEvent,
+  removeDeliveredQueuedMessage,
   replayCursorAfterRuntimeHydration,
   replaySessionEvents,
   runtimeStatusLooksActive,
@@ -39,13 +40,16 @@ describe("parseAgentTurnSsePayload", () => {
   });
 });
 describe("visibleQueuedMessages", () => {
-  it("shows only follow-up queue items, not transient steers", () => {
+  it("shows follow-up and steer queue items", () => {
     expect(
       visibleQueuedMessages([
         { id: "steer", mode: "steer", text: "interrupt", sent: true },
         { id: "follow", mode: "follow_up", text: "next" },
       ]),
-    ).toEqual([{ id: "follow", mode: "follow_up", text: "next" }]);
+    ).toEqual([
+      { id: "steer", mode: "steer", text: "interrupt", sent: true },
+      { id: "follow", mode: "follow_up", text: "next" },
+    ]);
   });
 });
 describe("statusAfterControlPhase", () => {
@@ -154,6 +158,44 @@ describe("reconcileQueueWithPiEvent", () => {
         { type: "queue_update", steering: [], followUp: [] },
       ),
     ).toEqual([{ id: "local", mode: "follow_up", text: "retry locally", sent: false }]);
+  });
+  it("matches Pi context-wrapped queue text to the local composer text", () => {
+    const result = reconcileQueueWithPiEvent(
+      [{ id: "optimistic", mode: "steer", text: "focus on the queue bug", sent: true }],
+      {
+        type: "queue_update",
+        steering: [
+          "Composer context:\nEnabled plugins: @browser.\n\nUser prompt:\nfocus on the queue bug",
+        ],
+        followUp: [],
+      },
+    );
+    expect(result).toEqual([
+      { id: "optimistic", mode: "steer", text: "focus on the queue bug", sent: true },
+    ]);
+  });
+  it("displays context-wrapped canonical Pi queue items as user text", () => {
+    const result = reconcileQueueWithPiEvent([], {
+      type: "queue_update",
+      steering: [],
+      followUp: ["Composer context:\nEnabled skills: docs.\n\nUser prompt:\nthen summarize"],
+    });
+    expect(result).toEqual([
+      { id: expect.any(String), mode: "follow_up", text: "then summarize", sent: true },
+    ]);
+  });
+});
+describe("removeDeliveredQueuedMessage", () => {
+  it("removes the queued chip once Pi starts the delivered user message", () => {
+    expect(
+      removeDeliveredQueuedMessage(
+        [
+          { id: "steer", mode: "steer", text: "focus on tests", sent: true },
+          { id: "follow", mode: "follow_up", text: "then summarize", sent: true },
+        ],
+        "Composer context:\nEnabled plugins: @browser.\n\nUser prompt:\nfocus on tests",
+      ),
+    ).toEqual([{ id: "follow", mode: "follow_up", text: "then summarize", sent: true }]);
   });
 });
 describe("mergeCanonicalAndRuntimeEvents", () => {

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -314,10 +314,7 @@ export function ChatPane({
         ...(cwdHint ? { cwd: t.cwd || cwdHint } : {}),
         input: "",
         error: "",
-        queue: [
-          ...(t.queue ?? []),
-          { id: queuedId, mode, text, ...(mode === "steer" ? { sent: true } : {}) },
-        ],
+        queue: [...(t.queue ?? []), { id: queuedId, mode, text, sent: true }],
       }));
       const result = await engine.sendControl(mode, text, runtime, tab.id, tab.piSessionId);
       updateTab(tab.id, (t) => ({

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -314,7 +314,10 @@ export function ChatPane({
         ...(cwdHint ? { cwd: t.cwd || cwdHint } : {}),
         input: "",
         error: "",
-        queue: [...(t.queue ?? []), { id: queuedId, mode, text, sent: true }],
+        queue:
+          mode === "follow_up"
+            ? [...(t.queue ?? []), { id: queuedId, mode, text, sent: true }]
+            : t.queue,
       }));
       const result = await engine.sendControl(mode, text, runtime, tab.id, tab.piSessionId);
       updateTab(tab.id, (t) => ({

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -131,11 +131,10 @@ export function ChatPane({
   onClose,
   onRegisterHandle,
 }: Props) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const stickToBottomRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isMultiline, setIsMultiline] = useState(false);
+  const [stickToBottom, setStickToBottom] = useState(true);
   const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
   const [readingAttachments, setReadingAttachments] = useState(false);
   const [composerDragActive, setComposerDragActive] = useState(false);
@@ -159,6 +158,9 @@ export function ChatPane({
     ),
   );
   const showEmptyPrompt = activeTab && activeTab.messages.length === 0 && !running;
+  useEffect(() => {
+    setStickToBottom(true);
+  }, [activeTab?.id]);
   const mentionRows = useMemo(() => {
     if (!mention) return [];
     return mention.kind === "plugin"
@@ -242,13 +244,6 @@ export function ChatPane({
     },
     [activeTab, tools],
   );
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element) return;
-    if (stickToBottomRef.current) {
-      requestAnimationFrame(() => element.scrollTo({ top: element.scrollHeight }));
-    }
-  }, [activeTab?.messages, activeTab?.status]);
   const updateSession = useCallback(
     (sessionId: string, patch: (session: SessionTab) => SessionTab) => updateTab(sessionId, patch),
     [updateTab],
@@ -291,7 +286,7 @@ export function ChatPane({
       if (!targetId) return;
       if ((!rawText.trim() && attachments.length === 0) || !modelId || readingAttachments) return;
       const args = buildPromptArgs(targetId, rawText);
-      stickToBottomRef.current = true;
+      setStickToBottom(true);
       setAttachments([]);
       setIsMultiline(false);
       if (textareaRef.current) textareaRef.current.style.height = "";
@@ -538,13 +533,9 @@ export function ChatPane({
       ) : null}
       <div className="flex min-h-0 flex-1">
         <Timeline
-          scrollRef={scrollRef}
-          onScroll={(event) => {
-            const element = event.currentTarget;
-            const distanceFromBottom =
-              element.scrollHeight - element.scrollTop - element.clientHeight;
-            stickToBottomRef.current = distanceFromBottom <= 80;
-          }}
+          key={activeTab?.id ?? "empty"}
+          stickToBottom={stickToBottom}
+          onStickToBottomChange={setStickToBottom}
           messages={activeTab?.messages ?? []}
           running={Boolean(running)}
           statusLabel={activeTab?.status}

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -890,9 +890,9 @@ export function ChatPane({
             </div>
           </div>{" "}
         </div>
-        <div className="mx-auto mt-0.5 flex max-w-[var(--composer-w)] items-center gap-2 overflow-hidden font-mono text-[10px] text-(--dim)">
+        <div className="relative z-20 mx-auto mt-0.5 flex max-w-[var(--composer-w)] items-center gap-2 overflow-visible font-mono text-[10px] text-(--dim)">
           {" "}
-          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-visible">
             <button
               type="button"
               onClick={() => void compactSession()}
@@ -905,7 +905,7 @@ export function ChatPane({
               compact{" "}
             </button>
             <span className="shrink-0 text-(--border)">·</span>{" "}
-            <div className="min-w-0 max-w-[42%] shrink">
+            <div className="min-w-0 max-w-[42%] shrink overflow-visible">
               {projectSelector ? (
                 projectSelector
               ) : cwd ? (

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -542,7 +542,7 @@ export function ChatPane({
           emptyPrompt={Boolean(showEmptyPrompt)}
         />
       </div>
-      <form onSubmit={sendMessage} className="shrink-0 bg-(--bg) px-6 pb-2 pt-1">
+      <form onSubmit={sendMessage} className="shrink-0 bg-(--bg) px-6 pb-2 pt-0">
         {visibleQueueItems.length > 0 ? (
           <div className="mx-auto mb-1 w-[85%] max-w-[var(--composer-w)] overflow-hidden rounded-lg bg-(--composer) px-4 py-2 text-[11px] text-(--fg)">
             <button

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -319,12 +319,7 @@ export function ChatPane({
       const result = await engine.sendControl(mode, text, runtime, tab.id, tab.piSessionId);
       updateTab(tab.id, (t) => ({
         ...t,
-        queue:
-          mode === "steer"
-            ? (t.queue ?? []).filter((item) => item.id !== queuedId)
-            : (t.queue ?? []).map((item) =>
-                item.id === queuedId ? { ...item, sent: result.ok } : item,
-              ),
+        queue: result.ok ? t.queue : (t.queue ?? []).filter((item) => item.id !== queuedId),
         ...(result.ok ? {} : { input: text, error: result.error || "Message failed" }),
       }));
     },

--- a/frontend/src/app/agent/_components/filesystem-panel.tsx
+++ b/frontend/src/app/agent/_components/filesystem-panel.tsx
@@ -654,14 +654,20 @@ function FileViewer({
             >
               {lineNumber}{" "}
             </span>
-            <pre
-              className="min-w-0 flex-1 whitespace-pre font-mono text-(--fg)"
-              style={{ fontSize, lineHeight: `${lineHeight}px` }}
-              {...(html ? { dangerouslySetInnerHTML: { __html: html || " " } } : undefined)}
-            >
-              {" "}
-              {!html ? text || "\u00a0" : undefined}
-            </pre>{" "}
+            {html ? (
+              <pre
+                className="min-w-0 flex-1 whitespace-pre font-mono text-(--fg)"
+                style={{ fontSize, lineHeight: `${lineHeight}px` }}
+                dangerouslySetInnerHTML={{ __html: html || "&nbsp;" }}
+              />
+            ) : (
+              <pre
+                className="min-w-0 flex-1 whitespace-pre font-mono text-(--fg)"
+                style={{ fontSize, lineHeight: `${lineHeight}px` }}
+              >
+                {text || "\u00a0"}
+              </pre>
+            )}{" "}
             {lineComments.length > 0 ? (
               <span className="ml-1 inline-flex shrink-0 items-center gap-0.5 rounded border border-(--border) px-1 font-mono text-[9px] text-(--dim)">
                 {" "}

--- a/frontend/src/app/agent/_components/timeline/message-view.tsx
+++ b/frontend/src/app/agent/_components/timeline/message-view.tsx
@@ -1,56 +1,6 @@
 import type { ChatMessage } from "@/lib/agent/session";
-import { AssistantMarkdown } from "../assistant-markdown";
-import { ToolBlockView } from "./tool-block-view";
+import { SessionPaneBlockRouter } from "./session-pane-block-router";
 
 export function MessageView({ message }: { message: ChatMessage }) {
-  if (message.role === "user") {
-    return (
-      <article className="flex justify-end">
-        <div className="max-w-[72%] rounded-xl bg-(--surface) px-3.5 py-2 text-sm leading-6 text-(--fg)">
-          <div className="whitespace-pre-wrap break-words">{message.text}</div>
-        </div>
-      </article>
-    );
-  }
-  const blocks = message.blocks ?? [];
-  return (
-    <article className="min-w-0">
-      {blocks.length === 0 ? (
-        <div className="text-sm leading-6 text-(--dim)">…</div>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {blocks.map((block) => {
-            if (block.kind === "thinking") {
-              return (
-                <details key={block.id} className="text-xs" open>
-                  <summary className="cursor-pointer list-none text-[11px] italic text-(--dim) hover:text-(--fg)">
-                    Thinking
-                  </summary>
-                  <pre className="mt-2 max-w-full whitespace-pre-wrap break-words border-l-2 border-(--border) pl-3 font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
-                    {block.text}
-                  </pre>
-                </details>
-              );
-            }
-            if (block.kind === "text") {
-              return <AssistantMarkdown key={block.id} text={block.text} />;
-            }
-            if (block.kind === "event") {
-              return (
-                <div
-                  key={block.id}
-                  className="flex items-center gap-3 py-1 text-[11px] text-(--dim)"
-                >
-                  <span className="h-px flex-1 bg-(--border)" />
-                  <span>{block.text}</span>
-                  <span className="h-px flex-1 bg-(--border)" />
-                </div>
-              );
-            }
-            return <ToolBlockView key={block.id} block={block} />;
-          })}
-        </div>
-      )}
-    </article>
-  );
+  return <SessionPaneBlockRouter message={message} />;
 }

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
@@ -1,0 +1,76 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { AssistantBlock, ChatMessage } from "@/lib/agent/session";
+import { groupAssistantBlocks, SessionPaneBlockRouter } from "./session-pane-block-router";
+
+describe("groupAssistantBlocks", () => {
+  it("groups consecutive reasoning and tool calls without swallowing content", () => {
+    const blocks: AssistantBlock[] = [
+      { kind: "thinking", id: "think", text: "plan" },
+      { kind: "thinking", id: "think-2", text: "more plan" },
+      { kind: "tool", id: "tool-1", name: "read_file", status: "done", text: "" },
+      { kind: "tool", id: "tool-2", name: "write_file", status: "done", text: "" },
+      { kind: "text", id: "text", text: "done" },
+      { kind: "tool", id: "tool-3", name: "bash", status: "done", text: "" },
+    ];
+
+    expect(groupAssistantBlocks(blocks)).toEqual([
+      { kind: "reasoning-group", id: "reasoning-think", blocks: [blocks[0], blocks[1]] },
+      { kind: "tool-group", id: "tools-tool-1", blocks: [blocks[2], blocks[3]] },
+      { kind: "content", block: blocks[4] },
+      { kind: "tool-group", id: "tools-tool-3", blocks: [blocks[5]] },
+    ]);
+  });
+
+  it("keeps interleaved reasoning and tools in ordered phases", () => {
+    const blocks: AssistantBlock[] = [
+      { kind: "thinking", id: "think-1", text: "inspect" },
+      { kind: "tool", id: "tool-1", name: "read_file", status: "done", text: "" },
+      { kind: "thinking", id: "think-2", text: "adjust" },
+      { kind: "tool", id: "tool-2", name: "apply_patch", status: "done", text: "" },
+    ];
+
+    expect(groupAssistantBlocks(blocks).map((block) => block.kind)).toEqual([
+      "reasoning-group",
+      "tool-group",
+      "reasoning-group",
+      "tool-group",
+    ]);
+  });
+});
+
+describe("SessionPaneBlockRouter", () => {
+  it("renders collapsed tool group previews without mounting completed tool details", () => {
+    const message: ChatMessage = {
+      id: "assistant",
+      role: "assistant",
+      text: "",
+      blocks: [
+        {
+          kind: "tool",
+          id: "tool-1",
+          name: "write_file",
+          status: "done",
+          text: "",
+          args: { path: "src/example.ts", content: "const value = 1;" },
+        },
+        {
+          kind: "tool",
+          id: "tool-2",
+          name: "bash",
+          status: "done",
+          text: "",
+          args: { cmd: "npm test -- tool-block-view.test.tsx" },
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(<SessionPaneBlockRouter message={message} />);
+
+    expect(html).toContain("2 tools");
+    expect(html).toContain("edit example.ts");
+    expect(html).toContain("npm test");
+    expect(html).not.toContain("border border-(--border)/70");
+    expect(html).not.toContain("language-ts");
+  });
+});

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
@@ -4,7 +4,7 @@ import type { AssistantBlock, ChatMessage } from "@/lib/agent/session";
 import { groupAssistantBlocks, SessionPaneBlockRouter } from "./session-pane-block-router";
 
 describe("groupAssistantBlocks", () => {
-  it("groups consecutive reasoning and tool calls without swallowing content", () => {
+  it("groups reasoning and tool activity without swallowing content", () => {
     const blocks: AssistantBlock[] = [
       { kind: "thinking", id: "think", text: "plan" },
       { kind: "thinking", id: "think-2", text: "more plan" },
@@ -15,14 +15,24 @@ describe("groupAssistantBlocks", () => {
     ];
 
     expect(groupAssistantBlocks(blocks)).toEqual([
-      { kind: "reasoning-group", id: "reasoning-think", blocks: [blocks[0], blocks[1]] },
-      { kind: "tool-group", id: "tools-tool-1", blocks: [blocks[2], blocks[3]] },
+      {
+        kind: "activity-group",
+        id: "activity-reasoning-think",
+        segments: [
+          { kind: "reasoning", id: "reasoning-think", blocks: [blocks[0], blocks[1]] },
+          { kind: "tools", id: "tools-tool-1", blocks: [blocks[2], blocks[3]] },
+        ],
+      },
       { kind: "content", block: blocks[4] },
-      { kind: "tool-group", id: "tools-tool-3", blocks: [blocks[5]] },
+      {
+        kind: "activity-group",
+        id: "activity-tools-tool-3",
+        segments: [{ kind: "tools", id: "tools-tool-3", blocks: [blocks[5]] }],
+      },
     ]);
   });
 
-  it("keeps interleaved reasoning and tools in ordered phases", () => {
+  it("keeps interleaved reasoning and tools in one ordered activity group", () => {
     const blocks: AssistantBlock[] = [
       { kind: "thinking", id: "think-1", text: "inspect" },
       { kind: "tool", id: "tool-1", name: "read_file", status: "done", text: "" },
@@ -30,11 +40,17 @@ describe("groupAssistantBlocks", () => {
       { kind: "tool", id: "tool-2", name: "apply_patch", status: "done", text: "" },
     ];
 
-    expect(groupAssistantBlocks(blocks).map((block) => block.kind)).toEqual([
-      "reasoning-group",
-      "tool-group",
-      "reasoning-group",
-      "tool-group",
+    expect(groupAssistantBlocks(blocks)).toEqual([
+      {
+        kind: "activity-group",
+        id: "activity-reasoning-think-1",
+        segments: [
+          { kind: "reasoning", id: "reasoning-think-1", blocks: [blocks[0]] },
+          { kind: "tools", id: "tools-tool-1", blocks: [blocks[1]] },
+          { kind: "reasoning", id: "reasoning-think-2", blocks: [blocks[2]] },
+          { kind: "tools", id: "tools-tool-2", blocks: [blocks[3]] },
+        ],
+      },
     ]);
   });
 });

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type {
+  AssistantBlock,
+  ChatMessage,
+  EventBlock,
+  TextBlock,
+  ThinkingBlock,
+  ToolBlock,
+} from "@/lib/agent/session";
+import { AssistantMarkdown } from "../assistant-markdown";
+import { ToolBlockView } from "./tool-block-view";
+import {
+  classifyTool,
+  compactToolText,
+  fileBasename,
+  humanizeToolName,
+  toolArg,
+} from "./tool-metadata";
+
+type RoutedBlock =
+  | { kind: "reasoning-group"; id: string; blocks: ThinkingBlock[] }
+  | { kind: "content"; block: TextBlock }
+  | { kind: "event"; block: EventBlock }
+  | { kind: "tool-group"; id: string; blocks: ToolBlock[] };
+
+export function groupAssistantBlocks(blocks: AssistantBlock[]): RoutedBlock[] {
+  const routed: RoutedBlock[] = [];
+  let reasoningGroup: ThinkingBlock[] = [];
+  let toolGroup: ToolBlock[] = [];
+
+  const flushReasoningGroup = () => {
+    if (reasoningGroup.length === 0) return;
+    routed.push({
+      kind: "reasoning-group",
+      id: `reasoning-${reasoningGroup[0]?.id ?? routed.length}`,
+      blocks: reasoningGroup,
+    });
+    reasoningGroup = [];
+  };
+
+  const flushToolGroup = () => {
+    if (toolGroup.length === 0) return;
+    routed.push({
+      kind: "tool-group",
+      id: `tools-${toolGroup[0]?.id ?? routed.length}`,
+      blocks: toolGroup,
+    });
+    toolGroup = [];
+  };
+
+  for (const block of blocks) {
+    if (block.kind === "tool") {
+      flushReasoningGroup();
+      toolGroup.push(block);
+      continue;
+    }
+    if (block.kind === "thinking") {
+      flushToolGroup();
+      reasoningGroup.push(block);
+      continue;
+    }
+    flushToolGroup();
+    flushReasoningGroup();
+    if (block.kind === "text") {
+      routed.push({ kind: "content", block });
+    } else {
+      routed.push({ kind: "event", block });
+    }
+  }
+  flushToolGroup();
+  flushReasoningGroup();
+
+  return routed;
+}
+
+export function SessionPaneBlockRouter({ message }: { message: ChatMessage }) {
+  if (message.role === "user") {
+    return (
+      <article className="flex justify-end">
+        <div className="max-w-[72%] rounded-xl bg-(--surface) px-3.5 py-2 text-sm leading-6 text-(--fg)">
+          <div className="whitespace-pre-wrap break-words">{message.text}</div>
+        </div>
+      </article>
+    );
+  }
+
+  const routedBlocks = groupAssistantBlocks(message.blocks ?? []);
+  return (
+    <article className="min-w-0">
+      {routedBlocks.length === 0 ? (
+        <div className="text-sm leading-6 text-(--dim)">…</div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {routedBlocks.map((item) => {
+            if (item.kind === "tool-group") {
+              return <ToolCallGroup key={item.id} blocks={item.blocks} />;
+            }
+            if (item.kind === "reasoning-group") {
+              return <ReasoningGroup key={item.id} blocks={item.blocks} />;
+            }
+            if (item.kind === "content") {
+              return <AssistantMarkdown key={item.block.id} text={item.block.text} />;
+            }
+            return <EventBlockView key={item.block.id} block={item.block} />;
+          })}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function ReasoningGroup({ blocks }: { blocks: ThinkingBlock[] }) {
+  const text = blocks.map((block) => block.text).join("\n\n");
+  return (
+    <details className="text-xs" open>
+      <summary className="cursor-pointer list-none text-[11px] italic text-(--dim) hover:text-(--fg) [&::-webkit-details-marker]:hidden">
+        Reasoning{blocks.length > 1 ? ` · ${blocks.length}` : ""}
+      </summary>
+      <pre className="mt-2 max-w-full whitespace-pre-wrap break-words border-l-2 border-(--border) pl-3 font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
+        {text}
+      </pre>
+    </details>
+  );
+}
+
+function EventBlockView({ block }: { block: EventBlock }) {
+  return (
+    <div className="flex items-center gap-3 py-1 text-[11px] text-(--dim)">
+      <span className="h-px flex-1 bg-(--border)" />
+      <span>{block.text}</span>
+      <span className="h-px flex-1 bg-(--border)" />
+    </div>
+  );
+}
+
+function ToolCallGroup({ blocks }: { blocks: ToolBlock[] }) {
+  const hasActiveTool = blocks.some((block) => block.status === "running");
+  const hasError = blocks.some((block) => block.status === "error");
+  const [expanded, setExpanded] = useState(hasActiveTool);
+  const open = hasActiveTool || expanded;
+  const preview = toolGroupPreview(blocks);
+
+  return (
+    <details className="group min-w-0" open={open}>
+      <summary
+        className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-1.5 py-1 text-[11px] text-(--fg) hover:bg-(--hover) [&::-webkit-details-marker]:hidden"
+        onClick={(event) => {
+          event.preventDefault();
+          setExpanded((value) => !value);
+        }}
+      >
+        <ChevronDown
+          className={`h-3 w-3 shrink-0 text-(--fg)/70 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+        <span className="shrink-0 font-medium text-(--fg)/90">
+          {blocks.length === 1 ? "1 tool" : `${blocks.length} tools`}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-(--fg)/75">
+          {preview}
+        </span>
+        {hasActiveTool ? (
+          <span className="shrink-0 text-[10px] text-(--accent)">running</span>
+        ) : hasError ? (
+          <span className="shrink-0 text-[10px] text-(--err)">error</span>
+        ) : null}
+      </summary>
+      {open ? (
+        <div className="ml-3 mt-1.5 border-l border-(--border)/70 pl-2">
+          {blocks.map((block, index) => (
+            <div key={block.id} className="relative pb-1.5 last:pb-0">
+              <span className="absolute -left-2 top-4 h-px w-2 bg-(--border)/80" />
+              <div className={index === 0 ? "" : "pt-0.5"}>
+                <ToolBlockView block={block} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </details>
+  );
+}
+
+function toolGroupPreview(blocks: ToolBlock[]): string {
+  const previewItems = blocks.slice(0, 4).map(toolPreview);
+  const remaining = blocks.length - previewItems.length;
+  return `${previewItems.join(" · ")}${remaining > 0 ? ` · +${remaining} more` : ""}`;
+}
+
+function toolPreview(block: ToolBlock): string {
+  const path = toolArg(block, [
+    "path",
+    "file_path",
+    "filePath",
+    "file",
+    "filename",
+    "target_file",
+    "uri",
+    "ref_id",
+  ]);
+  const query = toolArg(block, ["query", "q", "pattern", "search", "search_query", "needle"]);
+  const command = toolArg(block, ["cmd", "command", "script", "shell", "input"]);
+  const basename = fileBasename(path);
+
+  switch (classifyTool(block)) {
+    case "edit":
+      return basename ? `edit ${basename}` : humanizeToolName(block.name);
+    case "read":
+      return basename ? `read ${basename}` : humanizeToolName(block.name);
+    case "search":
+      return compactToolText(query, 42) ? `search ${compactToolText(query, 42)}` : "search";
+    case "exec":
+      return compactToolText(command, 42) ?? "command";
+    case "browser":
+      return "browser";
+    default:
+      return humanizeToolName(block.name);
+  }
+}

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -18,58 +18,72 @@ import {
   toolArg,
 } from "./tool-metadata";
 
+type ActivitySegment =
+  | { kind: "reasoning"; id: string; blocks: ThinkingBlock[] }
+  | { kind: "tools"; id: string; blocks: ToolBlock[] };
+
 type RoutedBlock =
-  | { kind: "reasoning-group"; id: string; blocks: ThinkingBlock[] }
+  | { kind: "activity-group"; id: string; segments: ActivitySegment[] }
   | { kind: "content"; block: TextBlock }
-  | { kind: "event"; block: EventBlock }
-  | { kind: "tool-group"; id: string; blocks: ToolBlock[] };
+  | { kind: "event"; block: EventBlock };
 
 export function groupAssistantBlocks(blocks: AssistantBlock[]): RoutedBlock[] {
   const routed: RoutedBlock[] = [];
+  let activitySegments: ActivitySegment[] = [];
   let reasoningGroup: ThinkingBlock[] = [];
   let toolGroup: ToolBlock[] = [];
 
-  const flushReasoningGroup = () => {
+  const flushReasoningSegment = () => {
     if (reasoningGroup.length === 0) return;
-    routed.push({
-      kind: "reasoning-group",
+    activitySegments.push({
+      kind: "reasoning",
       id: `reasoning-${reasoningGroup[0]?.id ?? routed.length}`,
       blocks: reasoningGroup,
     });
     reasoningGroup = [];
   };
 
-  const flushToolGroup = () => {
+  const flushToolSegment = () => {
     if (toolGroup.length === 0) return;
-    routed.push({
-      kind: "tool-group",
+    activitySegments.push({
+      kind: "tools",
       id: `tools-${toolGroup[0]?.id ?? routed.length}`,
       blocks: toolGroup,
     });
     toolGroup = [];
   };
 
+  const flushActivityGroup = () => {
+    flushReasoningSegment();
+    flushToolSegment();
+    if (activitySegments.length === 0) return;
+    routed.push({
+      kind: "activity-group",
+      id: `activity-${activitySegments[0]?.id ?? routed.length}`,
+      segments: activitySegments,
+    });
+    activitySegments = [];
+  };
+
   for (const block of blocks) {
     if (block.kind === "tool") {
-      flushReasoningGroup();
+      flushReasoningSegment();
       toolGroup.push(block);
       continue;
     }
     if (block.kind === "thinking") {
-      flushToolGroup();
+      flushToolSegment();
       reasoningGroup.push(block);
       continue;
     }
-    flushToolGroup();
-    flushReasoningGroup();
+    flushActivityGroup();
     if (block.kind === "text") {
       routed.push({ kind: "content", block });
     } else {
       routed.push({ kind: "event", block });
     }
   }
-  flushToolGroup();
-  flushReasoningGroup();
+  flushActivityGroup();
 
   return routed;
 }
@@ -93,11 +107,8 @@ export function SessionPaneBlockRouter({ message }: { message: ChatMessage }) {
       ) : (
         <div className="flex flex-col gap-3">
           {routedBlocks.map((item) => {
-            if (item.kind === "tool-group") {
-              return <ToolCallGroup key={item.id} blocks={item.blocks} />;
-            }
-            if (item.kind === "reasoning-group") {
-              return <ReasoningGroup key={item.id} blocks={item.blocks} />;
+            if (item.kind === "activity-group") {
+              return <AssistantActivityGroup key={item.id} segments={item.segments} />;
             }
             if (item.kind === "content") {
               return <AssistantMarkdown key={item.block.id} text={item.block.text} />;
@@ -107,6 +118,58 @@ export function SessionPaneBlockRouter({ message }: { message: ChatMessage }) {
         </div>
       )}
     </article>
+  );
+}
+
+function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
+  const hasActiveTool = segments.some(
+    (segment) =>
+      segment.kind === "tools" && segment.blocks.some((block) => block.status === "running"),
+  );
+  const isMixed =
+    segments.some((segment) => segment.kind === "reasoning") &&
+    segments.some((segment) => segment.kind === "tools");
+  const [expanded, setExpanded] = useState(isMixed || hasActiveTool);
+  const open = hasActiveTool || expanded;
+
+  if (segments.length === 1) {
+    const [segment] = segments;
+    if (segment.kind === "reasoning") return <ReasoningGroup blocks={segment.blocks} />;
+    return <ToolCallGroup blocks={segment.blocks} />;
+  }
+
+  return (
+    <details className="group min-w-0" open={open}>
+      <summary
+        className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-1.5 py-1 text-[11px] text-(--fg) hover:bg-(--hover) [&::-webkit-details-marker]:hidden"
+        onClick={(event) => {
+          event.preventDefault();
+          setExpanded((value) => !value);
+        }}
+      >
+        <ChevronDown
+          className={`h-3 w-3 shrink-0 text-(--fg)/70 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+        <span className="shrink-0 font-medium text-(--fg)/90">{activityLabel(segments)}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-(--fg)/75">
+          {activityPreview(segments)}
+        </span>
+        {hasActiveTool ? (
+          <span className="shrink-0 text-[10px] text-(--accent)">running</span>
+        ) : null}
+      </summary>
+      {open ? (
+        <div className="mt-1.5 flex min-w-0 flex-col gap-2">
+          {segments.map((segment) =>
+            segment.kind === "reasoning" ? (
+              <ReasoningGroup key={segment.id} blocks={segment.blocks} />
+            ) : (
+              <ToolCallGroup key={segment.id} blocks={segment.blocks} />
+            ),
+          )}
+        </div>
+      ) : null}
+    </details>
   );
 }
 
@@ -179,6 +242,30 @@ function ToolCallGroup({ blocks }: { blocks: ToolBlock[] }) {
       ) : null}
     </details>
   );
+}
+
+function activityLabel(segments: ActivitySegment[]): string {
+  const reasoningCount = segments
+    .filter((segment) => segment.kind === "reasoning")
+    .reduce((count, segment) => count + segment.blocks.length, 0);
+  const toolCount = segments
+    .filter((segment) => segment.kind === "tools")
+    .reduce((count, segment) => count + segment.blocks.length, 0);
+  const pieces = [];
+  if (reasoningCount > 0)
+    pieces.push(reasoningCount === 1 ? "Reasoning" : `${reasoningCount} reasoning`);
+  if (toolCount > 0) pieces.push(toolCount === 1 ? "1 tool" : `${toolCount} tools`);
+  return pieces.join(" + ");
+}
+
+function activityPreview(segments: ActivitySegment[]): string {
+  const tools = segments.flatMap((segment) => (segment.kind === "tools" ? segment.blocks : []));
+  if (tools.length > 0) return toolGroupPreview(tools);
+  const reasoning = segments
+    .flatMap((segment) => (segment.kind === "reasoning" ? segment.blocks : []))
+    .map((block) => compactToolText(block.text, 72))
+    .filter(Boolean);
+  return reasoning.join(" · ");
 }
 
 function toolGroupPreview(blocks: ToolBlock[]): string {

--- a/frontend/src/app/agent/_components/timeline/timeline.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/timeline.test.tsx
@@ -1,0 +1,120 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "@/lib/agent/session";
+import { Timeline } from "./timeline";
+
+const virtuosoMock = vi.hoisted(() => ({
+  calls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("react-virtuoso", async () => {
+  const React = await import("react");
+
+  return {
+    Virtuoso: (props: {
+      components?: {
+        Footer?: React.ComponentType;
+        Item?: React.ComponentType<{ children?: React.ReactNode }>;
+        List?: React.ComponentType<{ children?: React.ReactNode }>;
+      };
+      computeItemKey: (index: number, message: ChatMessage) => string;
+      data: ChatMessage[];
+      itemContent: (index: number, message: ChatMessage) => React.ReactNode;
+    }) => {
+      virtuosoMock.calls.push(props as unknown as Record<string, unknown>);
+
+      const Footer = props.components?.Footer;
+      const Item =
+        props.components?.Item ?? (({ children }) => React.createElement("div", null, children));
+      const List =
+        props.components?.List ?? (({ children }) => React.createElement("div", null, children));
+
+      return React.createElement(
+        "div",
+        { "data-virtuoso": "true", "data-count": props.data.length },
+        React.createElement(
+          List,
+          null,
+          props.data.map((message, index) =>
+            React.createElement(
+              Item,
+              { key: props.computeItemKey(index, message) },
+              props.itemContent(index, message),
+            ),
+          ),
+        ),
+        Footer ? React.createElement(Footer) : null,
+      );
+    },
+  };
+});
+
+vi.mock("./message-view", async () => {
+  const React = await import("react");
+
+  return {
+    MessageView: ({ message }: { message: ChatMessage }) =>
+      React.createElement("div", { "data-message-id": message.id }, message.text),
+  };
+});
+
+const messages: ChatMessage[] = [
+  { id: "sys", role: "system", text: "hidden system note" },
+  { id: "user", role: "user", text: "hello" },
+  { id: "assistant", role: "assistant", text: "answer", blocks: [] },
+];
+
+describe("Timeline", () => {
+  beforeEach(() => {
+    virtuosoMock.calls = [];
+  });
+
+  it("keeps the empty prompt outside the virtualized list", () => {
+    const html = renderToStaticMarkup(<Timeline messages={messages} running={false} emptyPrompt />);
+
+    expect(html).toContain("A dream is something you build for yourself.");
+    expect(html).not.toContain("data-virtuoso");
+    expect(virtuosoMock.calls).toHaveLength(0);
+  });
+
+  it("filters system messages before rendering virtualized rows", () => {
+    const html = renderToStaticMarkup(<Timeline messages={messages} running={false} />);
+    const call = virtuosoMock.calls[0] as {
+      alignToBottom: boolean;
+      atBottomThreshold: number;
+      computeItemKey: (index: number, message: ChatMessage) => string;
+      data: ChatMessage[];
+    };
+
+    expect(html).toContain('data-count="2"');
+    expect(html).not.toContain("hidden system note");
+    expect(call.data.map((message) => message.id)).toEqual(["user", "assistant"]);
+    expect(call.computeItemKey(0, call.data[0])).toBe("user");
+    expect(call.alignToBottom).toBe(true);
+    expect(call.atBottomThreshold).toBe(80);
+  });
+
+  it("wires follow-bottom state through Virtuoso instead of a raw scroll div", () => {
+    const onStickToBottomChange = vi.fn();
+
+    renderToStaticMarkup(
+      <Timeline
+        messages={messages}
+        running
+        statusLabel="running"
+        stickToBottom={false}
+        onStickToBottomChange={onStickToBottomChange}
+      />,
+    );
+    const call = virtuosoMock.calls[0] as {
+      atBottomStateChange: (value: boolean) => void;
+      followOutput: () => "auto" | false;
+    };
+
+    expect(call.atBottomStateChange).toBe(onStickToBottomChange);
+    expect(call.followOutput()).toBe(false);
+
+    call.atBottomStateChange(true);
+    expect(onStickToBottomChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/app/agent/_components/timeline/timeline.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/timeline.test.tsx
@@ -94,7 +94,7 @@ describe("Timeline", () => {
     expect(call.atBottomThreshold).toBe(80);
   });
 
-  it("wires follow-bottom state through Virtuoso instead of a raw scroll div", () => {
+  it("keeps following output while running even if bottom state briefly drifts", () => {
     const onStickToBottomChange = vi.fn();
 
     renderToStaticMarkup(
@@ -111,10 +111,16 @@ describe("Timeline", () => {
       followOutput: () => "auto" | false;
     };
 
-    expect(call.atBottomStateChange).toBe(onStickToBottomChange);
-    expect(call.followOutput()).toBe(false);
+    expect(call.followOutput()).toBe("auto");
 
     call.atBottomStateChange(true);
     expect(onStickToBottomChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not follow output after the user scrolls away from an idle session", () => {
+    renderToStaticMarkup(<Timeline messages={messages} running={false} stickToBottom={false} />);
+    const call = virtuosoMock.calls[0] as { followOutput: () => "auto" | false };
+
+    expect(call.followOutput()).toBe(false);
   });
 });

--- a/frontend/src/app/agent/_components/timeline/timeline.tsx
+++ b/frontend/src/app/agent/_components/timeline/timeline.tsx
@@ -1,4 +1,5 @@
-import type { RefObject, UIEventHandler } from "react";
+import { forwardRef, useMemo, type ComponentPropsWithoutRef } from "react";
+import { Virtuoso } from "react-virtuoso";
 import type { ChatMessage } from "@/lib/agent/session";
 import { MessageView } from "./message-view";
 
@@ -7,26 +8,54 @@ type TimelineProps = {
   running: boolean;
   statusLabel?: string;
   emptyPrompt?: boolean;
-  scrollRef?: RefObject<HTMLDivElement | null>;
-  onScroll?: UIEventHandler<HTMLDivElement>;
+  stickToBottom?: boolean;
+  onStickToBottomChange?: (value: boolean) => void;
 };
+
+const TimelineList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
+  ({ className, ...props }, ref) => (
+    <div
+      {...props}
+      ref={ref}
+      className={`mx-auto flex w-full max-w-[var(--thread-w)] flex-col ${className ?? ""}`}
+    />
+  ),
+);
+TimelineList.displayName = "TimelineList";
+
+function TimelineItem({ className, ...props }: ComponentPropsWithoutRef<"div">) {
+  return <div {...props} className={`pb-5 ${className ?? ""}`} />;
+}
 
 export function Timeline({
   messages,
   running,
   statusLabel,
   emptyPrompt = false,
-  scrollRef,
-  onScroll,
+  stickToBottom = true,
+  onStickToBottomChange,
 }: TimelineProps) {
-  return (
-    <div
-      ref={scrollRef}
-      onScroll={onScroll}
-      className={`min-h-0 flex-1 overflow-y-auto px-6 pb-10 pt-2 ${emptyPrompt ? "flex" : ""}`}
-    >
-      <div className={`mx-auto w-full max-w-[var(--thread-w)] ${emptyPrompt ? "flex flex-1" : ""}`}>
-        {emptyPrompt ? (
+  const visibleMessages = useMemo(
+    () => messages.filter((message) => message.role !== "system"),
+    [messages],
+  );
+  const footer = useMemo(
+    () =>
+      running
+        ? () => (
+            <div className="mx-auto flex w-full max-w-[var(--thread-w)] items-center gap-2 py-4 text-xs text-(--dim)">
+              <span className="inline-flex h-1.5 w-1.5 animate-pulse rounded-full bg-(--accent)" />
+              <span className="animate-pulse">Pi is {statusLabel ?? "running"}…</span>
+            </div>
+          )
+        : undefined,
+    [running, statusLabel],
+  );
+
+  if (emptyPrompt) {
+    return (
+      <div className="flex min-h-0 flex-1 overflow-y-auto px-6 pb-10 pt-2">
+        <div className="mx-auto flex w-full max-w-[var(--thread-w)] flex-1">
           <div className="flex flex-1 items-center justify-center text-center text-[26px] font-medium leading-[1.35] text-(--fg)">
             <p className="max-w-[680px]">
               A dream is something you build for yourself.
@@ -34,22 +63,31 @@ export function Timeline({
               Just talk to it.
             </p>
           </div>
-        ) : (
-          <div className="flex flex-col gap-5">
-            {messages
-              .filter((m) => m.role !== "system")
-              .map((message) => (
-                <MessageView key={message.id} message={message} />
-              ))}
-            {running ? (
-              <div className="flex items-center gap-2 py-4 text-xs text-(--dim)">
-                <span className="inline-flex h-1.5 w-1.5 animate-pulse rounded-full bg-(--accent)" />
-                <span className="animate-pulse">Pi is {statusLabel ?? "running"}…</span>
-              </div>
-            ) : null}
-          </div>
-        )}
+        </div>
       </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 px-6 pb-10 pt-2">
+      <Virtuoso
+        className="h-full"
+        data={visibleMessages}
+        computeItemKey={(_, message) => message.id}
+        defaultItemHeight={180}
+        increaseViewportBy={{ top: 700, bottom: 1000 }}
+        alignToBottom
+        atBottomThreshold={80}
+        atBottomStateChange={onStickToBottomChange}
+        followOutput={() => (stickToBottom ? "auto" : false)}
+        initialTopMostItemIndex={Math.max(0, visibleMessages.length - 1)}
+        components={{
+          Footer: footer,
+          Item: TimelineItem,
+          List: TimelineList,
+        }}
+        itemContent={(_, message) => <MessageView message={message} />}
+      />
     </div>
   );
 }

--- a/frontend/src/app/agent/_components/timeline/timeline.tsx
+++ b/frontend/src/app/agent/_components/timeline/timeline.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useMemo, type ComponentPropsWithoutRef } from "react";
-import { Virtuoso } from "react-virtuoso";
+import { forwardRef, useCallback, useMemo, useRef, type ComponentPropsWithoutRef } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import { useTimelineFollowEffects } from "@/hooks/agent/use-timeline-follow-effects";
 import type { ChatMessage } from "@/lib/agent/session";
 import { MessageView } from "./message-view";
 
@@ -35,10 +36,12 @@ export function Timeline({
   stickToBottom = true,
   onStickToBottomChange,
 }: TimelineProps) {
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
   const visibleMessages = useMemo(
     () => messages.filter((message) => message.role !== "system"),
     [messages],
   );
+  const shouldFollowOutput = stickToBottom || running;
   const footer = useMemo(
     () =>
       running
@@ -51,6 +54,25 @@ export function Timeline({
         : undefined,
     [running, statusLabel],
   );
+  const handleAtBottomStateChange = useCallback(
+    (atBottom: boolean) => {
+      if (atBottom || !running) {
+        onStickToBottomChange?.(atBottom);
+        return;
+      }
+      if (stickToBottom) {
+        requestAnimationFrame(() => virtuosoRef.current?.autoscrollToBottom());
+      }
+    },
+    [onStickToBottomChange, running, stickToBottom],
+  );
+
+  useTimelineFollowEffects({
+    enabled: shouldFollowOutput,
+    itemCount: visibleMessages.length,
+    statusLabel,
+    virtuosoRef,
+  });
 
   if (emptyPrompt) {
     return (
@@ -69,8 +91,9 @@ export function Timeline({
   }
 
   return (
-    <div className="min-h-0 flex-1 px-6 pb-10 pt-2">
+    <div className="min-h-0 flex-1 px-6 pb-1 pt-2">
       <Virtuoso
+        ref={virtuosoRef}
         className="h-full"
         data={visibleMessages}
         computeItemKey={(_, message) => message.id}
@@ -78,8 +101,8 @@ export function Timeline({
         increaseViewportBy={{ top: 700, bottom: 1000 }}
         alignToBottom
         atBottomThreshold={80}
-        atBottomStateChange={onStickToBottomChange}
-        followOutput={() => (stickToBottom ? "auto" : false)}
+        atBottomStateChange={handleAtBottomStateChange}
+        followOutput={() => (shouldFollowOutput ? "auto" : false)}
         initialTopMostItemIndex={Math.max(0, visibleMessages.length - 1)}
         components={{
           Footer: footer,

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ToolBlock } from "@/lib/agent/session";
+import { ToolBlockView } from "./tool-block-view";
+
+describe("ToolBlockView", () => {
+  it("renders highlighted source for file write previews", () => {
+    const block: ToolBlock = {
+      kind: "tool",
+      id: "write-1",
+      name: "write_file",
+      status: "done",
+      text: "",
+      args: {
+        path: "src/example.ts",
+        content: "const value: number = 1;\n",
+      },
+    };
+
+    const html = renderToStaticMarkup(<ToolBlockView block={block} />);
+
+    expect(html).toContain("language-ts");
+    expect(html).toContain("hljs-keyword");
+  });
+
+  it("renders edit patches with diff highlighting", () => {
+    const block: ToolBlock = {
+      kind: "tool",
+      id: "patch-1",
+      name: "apply_patch",
+      status: "done",
+      text: "",
+      args: {
+        path: "src/example.ts",
+        patch: "+const value = 1;\n-const value = 0;\n",
+      },
+    };
+
+    const html = renderToStaticMarkup(<ToolBlockView block={block} />);
+
+    expect(html).toContain("language-diff");
+    expect(html).toContain("hljs-addition");
+    expect(html).toContain("hljs-deletion");
+  });
+});

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
@@ -28,17 +28,17 @@ type ToolMeta = { icon: ReactNode; label: string; detail: string | null };
 function iconForKind(kind: ToolKind): ReactNode {
   switch (kind) {
     case "edit":
-      return <PencilLine className="h-4 w-4" />;
+      return <PencilLine className="h-3 w-3" />;
     case "search":
-      return <Search className="h-4 w-4" />;
+      return <Search className="h-3 w-3" />;
     case "read":
-      return <FileText className="h-4 w-4" />;
+      return <FileText className="h-3 w-3" />;
     case "exec":
-      return <TerminalSquare className="h-4 w-4" />;
+      return <TerminalSquare className="h-3 w-3" />;
     case "browser":
-      return <GlobeIcon className="h-4 w-4" />;
+      return <GlobeIcon className="h-3 w-3" />;
     default:
-      return <Wrench className="h-4 w-4" />;
+      return <Wrench className="h-3 w-3" />;
   }
 }
 
@@ -98,7 +98,7 @@ function toolMeta(block: ToolBlock, filePath?: string | null): ToolMeta {
 function ToolStatus({ status }: { status: ToolBlock["status"] }) {
   if (status === "running") {
     return (
-      <span className="inline-flex items-center gap-1 text-[11px] text-(--dim)">
+      <span className="inline-flex items-center gap-1 text-[10px] text-(--accent)">
         <Loader2 className="h-3 w-3 animate-spin" />
         running
       </span>
@@ -106,7 +106,7 @@ function ToolStatus({ status }: { status: ToolBlock["status"] }) {
   }
   if (status === "error") {
     return (
-      <span className="inline-flex items-center gap-1 text-[11px] text-(--err)">
+      <span className="inline-flex items-center gap-1 text-[10px] text-(--err)">
         <AlertTriangle className="h-3 w-3" />
         error
       </span>
@@ -129,31 +129,33 @@ function ToolSummary({
   const meta = toolMeta(block, filePath);
   return (
     <details className="group py-0.5" open={open}>
-      <summary className="flex cursor-pointer list-none items-start gap-2 rounded-md py-1 text-(--dim) hover:text-(--fg) [&::-webkit-details-marker]:hidden">
-        <span className="mt-1 flex h-4 w-4 shrink-0 items-center justify-center opacity-80">
+      <summary className="flex cursor-pointer list-none items-start gap-1.5 rounded-md px-1.5 py-1 text-(--fg) hover:bg-(--hover) [&::-webkit-details-marker]:hidden">
+        <span className="mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center text-(--fg)/75">
           {meta.icon}
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] leading-6">{meta.label}</span>
+          <span className="block truncate text-[11.5px] leading-5 text-(--fg)/90">
+            {meta.label}
+          </span>
           {meta.detail ? (
-            <span className="block truncate font-mono text-[11px] leading-4 opacity-70">
+            <span className="block truncate font-mono text-[10px] leading-4 text-(--fg)/60">
               {meta.detail}
             </span>
           ) : null}
         </span>
         <ToolStatus status={block.status} />
         {children ? (
-          <ChevronDownIcon className="mt-1 h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180" />
+          <ChevronDownIcon className="mt-0.5 h-3 w-3 shrink-0 text-(--fg)/60 transition-transform group-open:rotate-180" />
         ) : null}
       </summary>
-      {children ? <div className="ml-6 mt-1">{children}</div> : null}
+      {children ? <div className="ml-5 mt-1 min-w-0">{children}</div> : null}
     </details>
   );
 }
 
 function ToolOutput({ children }: { children: ReactNode }) {
   return (
-    <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
+    <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap font-mono text-[10.5px] leading-5 text-(--fg)/70 [overflow-wrap:anywhere]">
       {children}
     </pre>
   );
@@ -172,7 +174,7 @@ function HighlightedToolSource({ body, lang }: { body: string; lang: string }) {
   }, [body, lang]);
 
   const className =
-    "max-h-[420px] overflow-auto whitespace-pre-wrap rounded-md border border-(--border)/70 bg-(--surface)/35 p-2 font-mono text-[11px] leading-5 text-(--fg)";
+    "max-h-[420px] overflow-auto whitespace-pre-wrap rounded-md border border-(--border)/60 bg-(--surface)/30 p-2 font-mono text-[10.5px] leading-5 text-(--fg)";
 
   if (highlighted === null) {
     return <pre className={className}>{body}</pre>;

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
+import hljs from "highlight.js";
 import {
   AlertTriangle,
   FileText,
@@ -158,56 +159,116 @@ function ToolOutput({ children }: { children: ReactNode }) {
   );
 }
 
-export function ToolBlockView({ block }: { block: ToolBlock }) {
-  const isFileWrite = FILE_WRITE_TOOL_NAMES.has(block.name.toLowerCase());
-  const filePath = isFileWrite
-    ? extractFromArgs(block.args, block.argsText, ["path", "file_path", "filePath", "file"])
-    : null;
-  const fileContent = isFileWrite
-    ? extractFromArgs(block.args, block.argsText, ["content", "text", "newText", "new_content"])
-    : null;
-  const patchContent = isFileWrite
-    ? extractFromArgs(block.args, block.argsText, ["patch", "diff", "edits"])
-    : null;
+function HighlightedToolSource({ body, lang }: { body: string; lang: string }) {
+  const highlighted = useMemo(() => {
+    if (!body) return "";
+    try {
+      const result =
+        lang && hljs.getLanguage(lang) ? hljs.highlight(body, { language: lang }) : null;
+      return result ? result.value : hljs.highlightAuto(body).value;
+    } catch {
+      return null;
+    }
+  }, [body, lang]);
+
+  const className =
+    "max-h-[420px] overflow-auto whitespace-pre-wrap rounded-md border border-(--border)/70 bg-(--surface)/35 p-2 font-mono text-[11px] leading-5 text-(--fg)";
+
+  if (highlighted === null) {
+    return <pre className={className}>{body}</pre>;
+  }
+
+  return (
+    <pre className={className}>
+      <code
+        className={lang ? `language-${lang}` : undefined}
+        dangerouslySetInnerHTML={{ __html: highlighted || "&nbsp;" }}
+      />
+    </pre>
+  );
+}
+
+type FileWritePreviewData = {
+  filePath: string | null;
+  fileContent: string | null;
+  patchContent: string | null;
+};
+
+function fileWritePreviewData(block: ToolBlock): FileWritePreviewData | null {
+  const filePath = extractFromArgs(block.args, block.argsText, [
+    "path",
+    "file_path",
+    "filePath",
+    "file",
+  ]);
+  const fileContent = extractFromArgs(block.args, block.argsText, [
+    "content",
+    "text",
+    "newText",
+    "new_content",
+  ]);
+  const patchContent = extractFromArgs(block.args, block.argsText, ["patch", "diff", "edits"]);
+
+  if (fileContent === null && patchContent === null) return null;
+  return { filePath, fileContent, patchContent };
+}
+
+function FileWritePreview({
+  block,
+  filePath,
+  fileContent,
+  patchContent,
+}: {
+  block: ToolBlock;
+  filePath: string | null;
+  fileContent: string | null;
+  patchContent: string | null;
+}) {
   const lang = detectLang(filePath);
   const isHtml = lang === "html";
   const [showPreview, setShowPreview] = useState(false);
+  const body = fileContent ?? patchContent ?? "";
+  const sourceLang = fileContent === null && patchContent !== null ? "diff" : lang;
 
-  if (isFileWrite && (fileContent !== null || patchContent !== null)) {
-    const body = fileContent ?? patchContent ?? "";
-    return (
-      <ToolSummary block={block} filePath={filePath} open={block.status === "running"}>
-        <div className="mb-1 flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.08em] text-(--dim)">
-          <span>{lang || "source"}</span>
-          {isHtml ? (
-            <button
-              type="button"
-              onClick={() => setShowPreview((value) => !value)}
-              className="rounded-md px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-(--dim) hover:bg-(--hover) hover:text-(--fg)"
-            >
-              {showPreview ? "Source" : "Preview"}
-            </button>
-          ) : null}
-        </div>
-        {isHtml && showPreview ? (
-          <iframe
-            sandbox=""
-            srcDoc={body}
-            className="h-72 w-full rounded-md border border-(--border) bg-white"
-            title={filePath ?? "preview"}
-          />
-        ) : (
-          <pre className="max-h-[420px] overflow-auto whitespace-pre-wrap rounded-md border border-(--border)/70 bg-(--surface)/35 p-2 font-mono text-[11px] leading-5 text-(--fg)">
-            {body}
-          </pre>
-        )}
-        {block.resultText ? (
-          <div className="mt-1 font-mono text-[10px] text-(--dim)">
-            <ToolOutput>{block.resultText}</ToolOutput>
-          </div>
+  return (
+    <ToolSummary block={block} filePath={filePath} open={block.status === "running"}>
+      <div className="mb-1 flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.08em] text-(--dim)">
+        <span>{sourceLang || "source"}</span>
+        {isHtml ? (
+          <button
+            type="button"
+            onClick={() => setShowPreview((value) => !value)}
+            className="rounded-md px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-(--dim) hover:bg-(--hover) hover:text-(--fg)"
+          >
+            {showPreview ? "Source" : "Preview"}
+          </button>
         ) : null}
-      </ToolSummary>
-    );
+      </div>
+      {isHtml && showPreview ? (
+        <iframe
+          sandbox=""
+          srcDoc={body}
+          className="h-72 w-full rounded-md border border-(--border) bg-white"
+          title={filePath ?? "preview"}
+        />
+      ) : (
+        <HighlightedToolSource body={body} lang={sourceLang} />
+      )}
+      {block.resultText ? (
+        <div className="mt-1 font-mono text-[10px] text-(--dim)">
+          <ToolOutput>{block.resultText}</ToolOutput>
+        </div>
+      ) : null}
+    </ToolSummary>
+  );
+}
+
+export function ToolBlockView({ block }: { block: ToolBlock }) {
+  const fileWritePreview = FILE_WRITE_TOOL_NAMES.has(block.name.toLowerCase())
+    ? fileWritePreviewData(block)
+    : null;
+  if (fileWritePreview) {
+    return <FileWritePreview block={block} {...fileWritePreview} />;
   }
 
   // Generic fallback (shells, reads, searches, browser tools, etc.).

--- a/frontend/src/components/left-sidebar.tsx
+++ b/frontend/src/components/left-sidebar.tsx
@@ -162,15 +162,15 @@ export function LeftSidebar({ children }: { children: React.ReactNode }) {
               <button
                 type="button"
                 onClick={() => setSearchOpen(true)}
-                className="mb-1 flex h-8 items-center gap-3 rounded-md px-3 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+                className="mb-1 flex h-7 items-center gap-2 rounded-md px-2.5 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
                 title="Search sessions (⌘K)"
               >
-                <SearchIcon className="h-4 w-4 shrink-0" />
-                <span className="flex-1 truncate text-left text-[14px]">Search</span>
-                <kbd className="px-1 py-0.5 text-[11px] font-mono text-(--dim)">⌘K</kbd>
+                <SearchIcon className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 truncate text-left text-[12px]">Search</span>
+                <kbd className="px-1 py-0.5 text-[10px] font-mono text-(--dim)">⌘K</kbd>
               </button>
 
-              <div className="mb-1 mt-4 px-3 text-[12px] font-medium text-(--dim)">Workspace</div>
+              <div className="mb-1 mt-3 px-2.5 text-[11px] font-medium text-(--dim)">Workspace</div>
               {tabs.map((tab) => (
                 <NavItemDesktop
                   key={tab.href}
@@ -342,13 +342,13 @@ function NavItemDesktop({
     <Link
       href={href}
       title={label}
-      className={`h-8 flex items-center gap-3 rounded-md px-3 transition-colors shrink-0 ${
+      className={`h-7 flex items-center gap-2 rounded-md px-2.5 transition-colors shrink-0 ${
         active ? "bg-(--hover) text-(--fg)" : "text-(--dim) hover:bg-(--hover) hover:text-(--fg)"
       }`}
     >
-      <Icon className="w-[18px] h-[18px] shrink-0" />
+      <Icon className="w-4 h-4 shrink-0" />
       <span
-        className={`text-[14px] font-medium whitespace-nowrap transition-opacity duration-100 ${
+        className={`text-[12px] font-medium whitespace-nowrap transition-opacity duration-100 ${
           expanded ? "opacity-100" : "opacity-0"
         }`}
       >

--- a/frontend/src/components/left-sidebar.tsx
+++ b/frontend/src/components/left-sidebar.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 import {
   BarChart3,
   ChevronLeft,
@@ -43,6 +50,14 @@ const tabs = [
   { href: "/server", label: "Server", icon: Server },
 ];
 
+const SIDEBAR_MIN_WIDTH = 210;
+const SIDEBAR_MAX_WIDTH = 420;
+
+function clampSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return 250;
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
 function isRouteActive(pathname: string, href: string): boolean {
   if (href === "/") {
     return pathname === "/" || pathname === "/discover";
@@ -58,18 +73,24 @@ function isRouteActive(pathname: string, href: string): boolean {
  * app bar with a hamburger drawer instead of a bottom tab bar, keeping the
  * viewport clear for dense telemetry and agent panes.
  */
-export function LeftSidebar({ children }: { children: React.ReactNode }) {
+export function LeftSidebar({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  const { desktopSidebarPinnedOpen, setDesktopSidebarPinnedOpen } = useAppStore(
-    useShallow((s) => ({
-      desktopSidebarPinnedOpen: s.desktopSidebarPinnedOpen,
-      setDesktopSidebarPinnedOpen: s.setDesktopSidebarPinnedOpen,
-    })),
-  );
+  const { desktopSidebarPinnedOpen, setDesktopSidebarPinnedOpen, sidebarWidth, setSidebarWidth } =
+    useAppStore(
+      useShallow((s) => ({
+        desktopSidebarPinnedOpen: s.desktopSidebarPinnedOpen,
+        setDesktopSidebarPinnedOpen: s.setDesktopSidebarPinnedOpen,
+        sidebarWidth: s.sidebarWidth,
+        setSidebarWidth: s.setSidebarWidth,
+      })),
+    );
   const isExpanded = desktopSidebarPinnedOpen;
+  const clampedSidebarWidth = clampSidebarWidth(sidebarWidth);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [activeSessions, setActiveSessions] = useState<ActiveSessionDetail[]>([]);
+  const [sidebarResizing, setSidebarResizing] = useState(false);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!mobileMenuOpen) return;
@@ -103,6 +124,45 @@ export function LeftSidebar({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener(ACTIVE_AGENT_SESSIONS_EVENT, onActive);
   }, []);
 
+  useEffect(
+    () => () => {
+      resizeCleanupRef.current?.();
+    },
+    [],
+  );
+
+  const startSidebarResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (!isExpanded) return;
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = clampedSidebarWidth;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      setSidebarResizing(true);
+
+      const cleanup = () => {
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", cleanup);
+        resizeCleanupRef.current = null;
+        setSidebarResizing(false);
+      };
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        setSidebarWidth(clampSidebarWidth(startWidth + moveEvent.clientX - startX));
+      };
+
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = cleanup;
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", cleanup);
+    },
+    [clampedSidebarWidth, isExpanded, setSidebarWidth],
+  );
+
   if (pathname.startsWith("/setup")) {
     return <div className="h-full w-full">{children}</div>;
   }
@@ -120,81 +180,104 @@ export function LeftSidebar({ children }: { children: React.ReactNode }) {
         </button>
       ) : null}
       <aside
-        className={`hidden md:flex sticky top-0 h-[100dvh] transition-[width] duration-150 ease-out border-r border-(--border) bg-(--rail) flex-col shrink-0 z-40 overflow-hidden ${
-          isExpanded ? "w-[var(--sidebar-w)]" : "w-0 border-r-0"
-        }`}
+        className={`relative hidden md:flex sticky top-0 h-[100dvh] border-r border-(--border) bg-(--rail) flex-col shrink-0 z-40 overflow-hidden ${
+          sidebarResizing ? "" : "transition-[width] duration-150 ease-out"
+        } ${isExpanded ? "" : "w-0 border-r-0"}`}
+        style={{
+          width: isExpanded ? `${clampedSidebarWidth}px` : 0,
+        }}
         aria-hidden={!isExpanded}
       >
         {isExpanded ? (
-          <>
-            {/* Header with window controls + nav arrows */}
-            <div className="sticky top-0 z-50 flex h-12 shrink-0 items-center justify-between px-4 bg-(--rail)">
-              <button
-                onClick={() => setDesktopSidebarPinnedOpen(false)}
-                className="flex h-7 w-7 items-center justify-center rounded-md text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
-                title="Collapse sidebar"
-                aria-label="Collapse sidebar"
-              >
-                <Square className="h-3.5 w-3.5" />
-              </button>
-              <div className="flex items-center gap-1">
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize sidebar"
+            title="Resize sidebar"
+            onMouseDown={startSidebarResize}
+            className={`absolute right-0 top-0 z-[60] h-full w-2 translate-x-1 cursor-col-resize transition-colors ${
+              sidebarResizing ? "bg-(--accent)/25" : "hover:bg-(--accent)/20"
+            }`}
+          />
+        ) : null}
+        <div
+          className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+            isExpanded ? "opacity-100" : "pointer-events-none opacity-0"
+          }`}
+        >
+          {isExpanded ? (
+            <>
+              {/* Header with window controls + nav arrows */}
+              <div className="sticky top-0 z-50 flex h-12 shrink-0 items-center justify-between px-4 bg-(--rail)">
                 <button
-                  onClick={() => window.history.back()}
+                  onClick={() => setDesktopSidebarPinnedOpen(false)}
                   className="flex h-7 w-7 items-center justify-center rounded-md text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
-                  title="Go back"
-                  aria-label="Go back"
+                  title="Collapse sidebar"
+                  aria-label="Collapse sidebar"
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <Square className="h-3.5 w-3.5" />
                 </button>
-                <button
-                  onClick={() => window.history.forward()}
-                  className="flex h-7 w-7 items-center justify-center rounded-md text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
-                  title="Go forward"
-                  aria-label="Go forward"
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => window.history.back()}
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+                    title="Go back"
+                    aria-label="Go back"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => window.history.forward()}
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+                    title="Go forward"
+                    aria-label="Go forward"
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </button>
+                </div>
               </div>
-            </div>
 
-            {/* Primary nav */}
-            <nav className="flex-1 min-h-0 flex flex-col px-2 py-1 overflow-y-auto overflow-x-hidden">
-              <button
-                type="button"
-                onClick={() => setSearchOpen(true)}
-                className="mb-1 flex h-7 items-center gap-2 rounded-md px-2.5 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
-                title="Search sessions (⌘K)"
-              >
-                <SearchIcon className="h-3.5 w-3.5 shrink-0" />
-                <span className="flex-1 truncate text-left text-[12px]">Search</span>
-                <kbd className="px-1 py-0.5 text-[10px] font-mono text-(--dim)">⌘K</kbd>
-              </button>
+              {/* Primary nav */}
+              <nav className="flex-1 min-h-0 flex flex-col px-2 py-1 overflow-y-auto overflow-x-hidden">
+                <button
+                  type="button"
+                  onClick={() => setSearchOpen(true)}
+                  className="mb-1 flex h-7 items-center gap-2 rounded-md px-2.5 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+                  title="Search sessions (⌘K)"
+                >
+                  <SearchIcon className="h-3.5 w-3.5 shrink-0" />
+                  <span className="flex-1 truncate text-left text-[12px]">Search</span>
+                  <kbd className="px-1 py-0.5 text-[10px] font-mono text-(--dim)">⌘K</kbd>
+                </button>
 
-              <div className="mb-1 mt-3 px-2.5 text-[11px] font-medium text-(--dim)">Workspace</div>
-              {tabs.map((tab) => (
+                <div className="mb-1 mt-3 px-2.5 text-[11px] font-medium text-(--dim)">
+                  Workspace
+                </div>
+                {tabs.map((tab) => (
+                  <NavItemDesktop
+                    key={tab.href}
+                    href={tab.href}
+                    label={tab.label}
+                    Icon={tab.icon}
+                    active={isRouteActive(pathname, tab.href)}
+                    expanded={isExpanded}
+                  />
+                ))}
+                <ProjectsNavSection expanded={isExpanded} />
+              </nav>
+
+              <div className="shrink-0 px-2 py-3">
                 <NavItemDesktop
-                  key={tab.href}
-                  href={tab.href}
-                  label={tab.label}
-                  Icon={tab.icon}
-                  active={isRouteActive(pathname, tab.href)}
+                  href="/settings"
+                  label="Settings"
+                  Icon={Settings}
+                  active={isRouteActive(pathname, "/settings")}
                   expanded={isExpanded}
                 />
-              ))}
-              <ProjectsNavSection expanded={isExpanded} />
-            </nav>
-
-            <div className="shrink-0 px-2 py-3">
-              <NavItemDesktop
-                href="/settings"
-                label="Settings"
-                Icon={Settings}
-                active={isRouteActive(pathname, "/settings")}
-                expanded={isExpanded}
-              />
-            </div>
-          </>
-        ) : null}
+              </div>
+            </>
+          ) : null}
+        </div>
       </aside>
 
       {/* Mobile/PWA: top app bar + hamburger drawer (no footer nav). */}

--- a/frontend/src/components/projects-nav-section.tsx
+++ b/frontend/src/components/projects-nav-section.tsx
@@ -541,18 +541,32 @@ function ProjectDirectoryPickerModal({
             label="Chats"
             open={chatsExpanded}
             onToggle={() => setChatsExpanded((value) => !value)}
+            action={
+              <Link
+                href={`/agent?project=${encodeURIComponent(chatProject.id)}&new=1`}
+                onClick={(event) => {
+                  if (window.location.pathname !== "/agent") return;
+                  event.preventDefault();
+                  window.dispatchEvent(
+                    new CustomEvent(NEW_AGENT_SESSION_EVENT, {
+                      detail: { projectId: chatProject.id },
+                    }),
+                  );
+                }}
+                className="rounded p-0.5 text-(--dim) transition-colors hover:text-(--fg)"
+                title="New chat"
+                aria-label="New chat"
+              >
+                <PlusIcon className="h-3.5 w-3.5" />{" "}
+              </Link>
+            }
           />
           {chatsExpanded ? (
-            <ProjectRow
+            <ProjectSessions
               project={chatProject}
-              open={openIds.has(chatProject.id)}
-              activeSessions={activeSessions.filter(
-                (session) => session.projectId === chatProject.id,
-              )}
+              activeSessions={activeSessions}
               prefs={prefs}
               excludedIds={pinnedRenderedIds}
-              icon="chat"
-              onToggle={() => toggle(chatProject.id)}
             />
           ) : null}
         </>

--- a/frontend/src/components/projects-nav-section.tsx
+++ b/frontend/src/components/projects-nav-section.tsx
@@ -1,8 +1,19 @@
 "use client";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 import {
   CloseIcon,
+  ChatIcon,
+  ChevronDownIcon,
   EyeOffIcon,
   Folder,
   FolderOpen,
@@ -40,7 +51,7 @@ import {
   type SessionPref,
   type SessionPrefs,
 } from "@/lib/agent/session/prefs";
-import type { Project as ProjectEntry } from "@/lib/agent/projects/types";
+import { isChatsProject, type Project as ProjectEntry } from "@/lib/agent/projects/types";
 type SessionSummary = {
   id: string;
   filename: string;
@@ -313,6 +324,8 @@ function ProjectDirectoryPickerModal({
  */ export function ProjectsNavSection({ expanded }: { expanded: boolean }) {
   const projectsContext = useProjects();
   const projects = projectsContext.projects;
+  const chatProject = projects.find(isChatsProject) ?? null;
+  const fileProjects = projects.filter((project) => !isChatsProject(project));
   const upsertProject = projectsContext.upsertProject;
   const removeProject = projectsContext.removeProject;
   const refreshProjects = projectsContext.refresh;
@@ -420,6 +433,8 @@ function ProjectDirectoryPickerModal({
       else next.add(id);
       return next;
     });
+  const [chatsExpanded, setChatsExpanded] = useState(true);
+  const [projectsExpanded, setProjectsExpanded] = useState(true);
   useEffect(() => {
     window.addEventListener(ADD_PROJECT_EVENT, handleAddProject);
     return () => window.removeEventListener(ADD_PROJECT_EVENT, handleAddProject);
@@ -499,7 +514,7 @@ function ProjectDirectoryPickerModal({
       />
       {pinnedSessions.length > 0 || pinnedActiveSessions.length > 0 ? (
         <div className="flex flex-col pb-1">
-          <div className="mt-5 flex h-7 items-center px-3 text-[12px] font-medium text-(--dim)">
+          <div className="mt-4 flex h-6 items-center px-3 text-[11px] font-medium text-(--dim)">
             Pinned
           </div>{" "}
           {pinnedActiveSessions.map(({ session, project }) => (
@@ -520,47 +535,103 @@ function ProjectDirectoryPickerModal({
           ))}{" "}
         </div>
       ) : null}{" "}
-      <div className="mt-5 flex h-7 items-center justify-between px-3 text-[12px] font-medium text-(--dim)">
-        <span>Projects</span>{" "}
-        <button
-          type="button"
-          onClick={handleAddProject}
-          className="rounded p-0.5 text-(--dim) transition-colors hover:text-(--fg)"
-          title="Add folder"
-          aria-label="Add folder"
-        >
-          <PlusIcon className="h-4 w-4" />{" "}
-        </button>
-      </div>{" "}
-      {projects.length === 0 ? (
-        <button
-          type="button"
-          onClick={handleAddProject}
-          className="px-3 py-1 text-left text-[13px] text-(--dim) hover:text-(--fg)"
-        >
-          {" "}
-          No projects yet — pick a folder to get started.
-        </button>
-      ) : (
-        projects.map((project) => (
-          <ProjectRow
-            key={project.id}
-            project={project}
-            open={openIds.has(project.id)}
-            activeSessions={activeSessions.filter((session) => session.projectId === project.id)}
-            prefs={prefs}
-            excludedIds={pinnedRenderedIds}
-            onToggle={() => toggle(project.id)}
-            onRemove={() => {
-              setAddError("");
-              void removeProjectAndCloseRow(project.id).catch((error) => {
-                setAddError(error instanceof Error ? error.message : "Failed to remove project");
-              });
-            }}
+      {chatProject ? (
+        <>
+          <SidebarSectionHeader
+            label="Chats"
+            open={chatsExpanded}
+            onToggle={() => setChatsExpanded((value) => !value)}
           />
-        ))
-      )}
+          {chatsExpanded ? (
+            <ProjectRow
+              project={chatProject}
+              open={openIds.has(chatProject.id)}
+              activeSessions={activeSessions.filter(
+                (session) => session.projectId === chatProject.id,
+              )}
+              prefs={prefs}
+              excludedIds={pinnedRenderedIds}
+              icon="chat"
+              onToggle={() => toggle(chatProject.id)}
+            />
+          ) : null}
+        </>
+      ) : null}
+      <SidebarSectionHeader
+        label="Projects"
+        open={projectsExpanded}
+        onToggle={() => setProjectsExpanded((value) => !value)}
+        action={
+          <button
+            type="button"
+            onClick={handleAddProject}
+            className="rounded p-0.5 text-(--dim) transition-colors hover:text-(--fg)"
+            title="Add folder"
+            aria-label="Add folder"
+          >
+            <PlusIcon className="h-3.5 w-3.5" />{" "}
+          </button>
+        }
+      />
+      {projectsExpanded ? (
+        fileProjects.length === 0 ? (
+          <button
+            type="button"
+            onClick={handleAddProject}
+            className="px-3 py-1 text-left text-[12px] text-(--dim) hover:text-(--fg)"
+          >
+            {" "}
+            No projects yet — pick a folder to get started.
+          </button>
+        ) : (
+          fileProjects.map((project) => (
+            <ProjectRow
+              key={project.id}
+              project={project}
+              open={openIds.has(project.id)}
+              activeSessions={activeSessions.filter((session) => session.projectId === project.id)}
+              prefs={prefs}
+              excludedIds={pinnedRenderedIds}
+              onToggle={() => toggle(project.id)}
+              onRemove={() => {
+                setAddError("");
+                void removeProjectAndCloseRow(project.id).catch((error) => {
+                  setAddError(error instanceof Error ? error.message : "Failed to remove project");
+                });
+              }}
+            />
+          ))
+        )
+      ) : null}
       {addError ? <div className="px-3 py-1 text-[11px] text-red-400">{addError}</div> : null}{" "}
+    </div>
+  );
+}
+function SidebarSectionHeader({
+  label,
+  open,
+  onToggle,
+  action,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="mt-4 flex h-6 items-center justify-between px-3 text-[11px] font-medium text-(--dim)">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex min-w-0 items-center gap-1.5 text-left hover:text-(--fg)"
+        aria-expanded={open}
+      >
+        <ChevronDownIcon
+          className={`h-2.5 w-2.5 shrink-0 transition-transform ${open ? "" : "-rotate-90"}`}
+        />
+        <span>{label}</span>
+      </button>
+      {action}
     </div>
   );
 }
@@ -572,14 +643,16 @@ function ProjectRow({
   activeSessions,
   prefs,
   excludedIds,
+  icon = "folder",
 }: {
   project: ProjectEntry;
   open: boolean;
   onToggle: () => void;
-  onRemove: () => void;
+  onRemove?: () => void;
   activeSessions: ActiveAgentSession[];
   prefs: SessionPrefs;
   excludedIds: ReadonlySet<string>;
+  icon?: "folder" | "chat";
 }) {
   const [missingErrorVisible, setMissingErrorVisible] = useState(false);
   const handleToggle = () => {
@@ -592,24 +665,28 @@ function ProjectRow({
   };
   return (
     <div className="flex flex-col">
-      <div className="group relative flex h-8 items-center rounded-md pl-3 pr-2 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)">
+      <div className="group relative flex h-7 items-center rounded-md pl-3 pr-2 text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg)">
         {" "}
         <button
           type="button"
           onClick={handleToggle}
           title={project.path}
-          className="flex min-w-0 flex-1 items-center gap-3 px-0 pr-8 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2 px-0 pr-8 text-left"
         >
-          <span className="relative h-4 w-4 shrink-0 text-(--dim)">
-            {" "}
-            <Folder
-              className={`absolute inset-0 h-4 w-4 transition-all duration-150 ${open ? "scale-90 opacity-0" : "scale-100 opacity-80"}`}
-            />
-            <FolderOpen
-              className={`absolute inset-0 h-4 w-4 transition-all duration-150 ${open ? "scale-100 opacity-80" : "scale-90 opacity-0"}`}
-            />{" "}
-          </span>
-          <span className="truncate text-[14px] font-medium text-(--fg)">{project.name}</span>{" "}
+          {icon === "chat" ? (
+            <ChatIcon className="h-3.5 w-3.5 shrink-0 text-(--dim)" />
+          ) : (
+            <span className="relative h-3.5 w-3.5 shrink-0 text-(--dim)">
+              {" "}
+              <Folder
+                className={`absolute inset-0 h-3.5 w-3.5 transition-all duration-150 ${open ? "scale-90 opacity-0" : "scale-100 opacity-80"}`}
+              />
+              <FolderOpen
+                className={`absolute inset-0 h-3.5 w-3.5 transition-all duration-150 ${open ? "scale-100 opacity-80" : "scale-90 opacity-0"}`}
+              />{" "}
+            </span>
+          )}
+          <span className="truncate text-[13px] font-medium text-(--fg)">{project.name}</span>{" "}
           {!project.exists ? (
             <span
               className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400"
@@ -631,22 +708,24 @@ function ProjectRow({
           title="New chat"
           aria-label={`New chat in ${project.name}`}
         >
-          <PlusIcon className="h-4 w-4" />{" "}
+          <PlusIcon className="h-3.5 w-3.5" />{" "}
         </Link>
-        <button
-          type="button"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onRemove();
-          }}
-          className="absolute right-7 top-1/2 -translate-y-1/2 p-0.5 text-(--dim) opacity-0 hover:text-(--err) group-hover:opacity-100"
-          title="Remove from list"
-          aria-label="Remove project"
-        >
-          {" "}
-          <TrashIcon className="h-4 w-4" />
-        </button>{" "}
+        {onRemove ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onRemove();
+            }}
+            className="absolute right-7 top-1/2 -translate-y-1/2 p-0.5 text-(--dim) opacity-0 hover:text-(--err) group-hover:opacity-100"
+            title="Remove from list"
+            aria-label="Remove project"
+          >
+            {" "}
+            <TrashIcon className="h-3.5 w-3.5" />
+          </button>
+        ) : null}{" "}
       </div>
       {missingErrorVisible && !project.exists ? (
         <div className="pl-12 pr-2 pb-1 text-[12px] text-red-400">
@@ -654,6 +733,7 @@ function ProjectRow({
           <button
             type="button"
             onClick={onRemove}
+            disabled={!onRemove}
             className="ml-2 text-(--dim) underline underline-offset-2 hover:text-(--fg)"
           >
             Remove{" "}
@@ -772,9 +852,9 @@ function ProjectSessions({
         />
       ))}
       {loading && !sessions ? (
-        <div className="pl-10 pr-4 py-1 text-[13px] text-(--dim)">Loading…</div>
+        <div className="pl-10 pr-4 py-1 text-[12px] text-(--dim)">Loading…</div>
       ) : allRecent.length === 0 && visibleActiveSessions.length === 0 ? (
-        <div className="pl-10 pr-4 py-1 text-[13px] text-(--dim)">No chats</div>
+        <div className="pl-10 pr-4 py-1 text-[12px] text-(--dim)">No chats</div>
       ) : (
         <>
           {" "}
@@ -790,7 +870,7 @@ function ProjectSessions({
             <button
               type="button"
               onClick={toggleShowHidden}
-              className="flex h-6 items-center gap-1 pl-10 pr-4 text-[13px] text-(--dim) hover:text-(--fg)"
+              className="flex h-6 items-center gap-1 pl-10 pr-4 text-[12px] text-(--dim) hover:text-(--fg)"
               title={showHidden ? "Hide hidden sessions" : "Show hidden sessions"}
             >
               <EyeOffIcon className="w-3 h-3 shrink-0" />{" "}
@@ -893,15 +973,15 @@ function SessionNavRow({
   const content = (
     <>
       {" "}
-      <span className="min-w-0 flex-1 truncate text-[12px] font-normal leading-7">{label}</span>
+      <span className="min-w-0 flex-1 truncate text-[11px] font-normal leading-6">{label}</span>
       {age ? (
-        <span className="shrink-0 pl-2 pr-1 font-mono text-[10px] text-(--dim)">{age}</span>
+        <span className="shrink-0 pl-2 pr-1 font-mono text-[9px] text-(--dim)">{age}</span>
       ) : null}{" "}
     </>
   );
   const openProps = canDoubleClickRename
     ? {
-        onDoubleClick: (event: React.MouseEvent) => {
+        onDoubleClick: (event: ReactMouseEvent) => {
           event.preventDefault();
           startRename();
         },
@@ -1037,7 +1117,7 @@ function ActiveSessionRow({
 }) {
   const label = pref.title || session.title || "Current session";
   const isActive = session.active === true;
-  const rowClass = `group relative flex h-7 items-center gap-1 pl-4 pr-2 transition-colors ${isActive ? "text-(--fg) before:absolute before:inset-y-1 before:left-0 before:w-[2px] before:rounded-full before:bg-(--accent) before:content-['']" : "text-(--dim) hover:text-(--fg)"}`;
+  const rowClass = `group relative flex h-6 items-center gap-1 pl-4 pr-2 transition-colors ${isActive ? "text-(--fg) before:absolute before:inset-y-1 before:left-0 before:w-[2px] before:rounded-full before:bg-(--accent) before:content-['']" : "text-(--dim) hover:text-(--fg)"}`;
   return (
     <SessionNavRow
       pref={pref}
@@ -1073,8 +1153,8 @@ function ActiveSessionRow({
       onDragStart={(event) => setAgentSessionDragData(event, session)}
       isRunning={session.status !== "idle" && session.status !== "done"}
       canDoubleClickRename
-      menuIconClass="h-4 w-4"
-      renameInputClass="text-[13px]"
+      menuIconClass="h-3.5 w-3.5"
+      renameInputClass="text-[12px]"
     />
   );
 }
@@ -1094,8 +1174,8 @@ function SessionRow({
       label={label}
       initialDraft={pref.title ?? session.firstUserMessage ?? ""}
       age={relativeAge(session.startedAt)}
-      rowClass="group relative flex h-7 items-center gap-1 pl-4 pr-2 text-(--dim) transition-colors hover:text-(--fg)"
-      renameRowClass="flex h-7 items-center gap-1 bg-(--surface)/60 pl-4 pr-2"
+      rowClass="group relative flex h-6 items-center gap-1 pl-4 pr-2 text-(--dim) transition-colors hover:text-(--fg)"
+      renameRowClass="flex h-6 items-center gap-1 bg-(--surface)/60 pl-4 pr-2"
       href={`/agent?project=${encodeURIComponent(project.id)}&session=${encodeURIComponent(session.id)}`}
       onPatchPref={(patch) => patchSessionPref(session.id, patch)}
       onRememberTitle={() => rememberAgentSessionNavTitle(session.id, label)}
@@ -1142,13 +1222,7 @@ function SessionPinButton({
     </button>
   );
 }
-function SessionMenuItem({
-  onClick,
-  children,
-}: {
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
+function SessionMenuItem({ onClick, children }: { onClick: () => void; children: ReactNode }) {
   return (
     <button
       type="button"

--- a/frontend/src/hooks/agent/use-timeline-follow-effects.ts
+++ b/frontend/src/hooks/agent/use-timeline-follow-effects.ts
@@ -1,0 +1,23 @@
+import { useEffect, type RefObject } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
+
+export function useTimelineFollowEffects({
+  enabled,
+  itemCount,
+  statusLabel,
+  virtuosoRef,
+}: {
+  enabled: boolean;
+  itemCount: number;
+  statusLabel?: string;
+  virtuosoRef: RefObject<VirtuosoHandle | null>;
+}) {
+  useEffect(() => {
+    if (!enabled || itemCount === 0) return;
+    const frame = requestAnimationFrame(() => {
+      virtuosoRef.current?.scrollToIndex({ align: "end", index: "LAST" });
+      virtuosoRef.current?.autoscrollToBottom();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [enabled, itemCount, statusLabel, virtuosoRef]);
+}

--- a/frontend/src/lib/agent/git/service.test.ts
+++ b/frontend/src/lib/agent/git/service.test.ts
@@ -1,0 +1,60 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadGitState, numstatStats } from "./service";
+
+const execFileAsync = promisify(execFile);
+const tempDirs: string[] = [];
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_PREFIX;
+  await execFileAsync("git", args, { cwd, env });
+}
+
+async function makeRepo(): Promise<string> {
+  const cwd = await mkdtemp(path.join(os.tmpdir(), "vllm-studio-git-state-"));
+  tempDirs.push(cwd);
+  await git(cwd, ["init"]);
+  await git(cwd, ["config", "user.email", "test@example.com"]);
+  await git(cwd, ["config", "user.name", "Test User"]);
+  await writeFile(path.join(cwd, "tracked.txt"), "one\n");
+  await git(cwd, ["add", "tracked.txt"]);
+  await git(cwd, ["commit", "-m", "initial"]);
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("git service", () => {
+  it("parses git numstat output and ignores binary placeholders", () => {
+    expect(numstatStats("2\t1\tsrc/a.ts\n-\t-\timage.png\n")).toEqual({
+      additions: 2,
+      deletions: 1,
+    });
+  });
+
+  it("counts staged, unstaged, and untracked file changes in git state totals", async () => {
+    const cwd = await makeRepo();
+    await writeFile(path.join(cwd, "tracked.txt"), "one\ntwo\n");
+    await writeFile(path.join(cwd, "staged.txt"), "alpha\nbeta\n");
+    await git(cwd, ["add", "staged.txt"]);
+    await writeFile(path.join(cwd, "untracked.txt"), "red\ngreen\nblue\n");
+
+    const state = await loadGitState(cwd);
+
+    expect(state.additions).toBe(6);
+    expect(state.deletions).toBe(0);
+    expect(state.status).toEqual(
+      expect.arrayContaining([" M tracked.txt", "A  staged.txt", "?? untracked.txt"]),
+    );
+  });
+});

--- a/frontend/src/lib/agent/git/service.ts
+++ b/frontend/src/lib/agent/git/service.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -41,25 +42,53 @@ export function assertGitCwd(
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, { cwd, maxBuffer: 12 * 1024 * 1024 });
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    env: cleanGitEnv(),
+    maxBuffer: 12 * 1024 * 1024,
+  });
   return stdout;
+}
+
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_PREFIX;
+  return env;
 }
 
 export async function loadGitState(cwd: string): Promise<GitState> {
   const inside = await git(cwd, ["rev-parse", "--is-inside-work-tree"]).catch(() => "");
   if (inside.trim() !== "true") return emptyGitState(false);
-  const [branch, statusRaw, diff, refsRaw, upstream, remoteUrl] = await Promise.all([
-    git(cwd, ["branch", "--show-current"]).catch(() => ""),
-    git(cwd, ["status", "--short"]),
-    git(cwd, ["diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/"]),
-    git(cwd, ["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"]).catch(
-      () => "",
-    ),
-    git(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]).catch(() => ""),
-    git(cwd, ["remote", "get-url", "origin"]).catch(() => ""),
-  ]);
+  const hasHead = Boolean(
+    (await git(cwd, ["rev-parse", "--verify", "HEAD"]).catch(() => "")).trim(),
+  );
+  const diffArgs = hasHead
+    ? ["diff", "--no-ext-diff", "HEAD", "--src-prefix=a/", "--dst-prefix=b/"]
+    : ["diff", "--no-ext-diff", "--cached", "--src-prefix=a/", "--dst-prefix=b/"];
+  const numstatArgs = hasHead
+    ? ["diff", "--numstat", "HEAD", "--"]
+    : ["diff", "--numstat", "--cached", "--"];
+  const [branch, statusRaw, diff, numstat, untrackedRaw, refsRaw, upstream, remoteUrl] =
+    await Promise.all([
+      git(cwd, ["branch", "--show-current"]).catch(() => ""),
+      git(cwd, ["status", "--short"]),
+      git(cwd, diffArgs),
+      git(cwd, numstatArgs).catch(() => ""),
+      git(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]).catch(() => ""),
+      git(cwd, ["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"]).catch(
+        () => "",
+      ),
+      git(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]).catch(() => ""),
+      git(cwd, ["remote", "get-url", "origin"]).catch(() => ""),
+    ]);
   const current = branch.trim() || null;
-  const { additions, deletions } = diffStats(diff);
+  const trackedStats = numstatStats(numstat);
+  const untrackedStats = await untrackedFileStats(cwd, untrackedRaw);
+  const additions = trackedStats.additions + untrackedStats.additions;
+  const deletions = trackedStats.deletions + untrackedStats.deletions;
   return {
     isRepo: true,
     branch: current,
@@ -135,15 +164,38 @@ function parseRefs(raw: string, current: string | null): GitRef[] {
     .map((name) => ({ name, current: name === current, remote: name.includes("/") }));
 }
 
-function diffStats(diff: string): { additions: number; deletions: number } {
+export function numstatStats(numstat: string): { additions: number; deletions: number } {
   let additions = 0;
   let deletions = 0;
-  for (const line of diff.split("\n")) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
-    if (line.startsWith("+")) additions += 1;
-    if (line.startsWith("-")) deletions += 1;
+  for (const line of numstat.split("\n")) {
+    const [added, deleted] = line.split("\t");
+    const addedCount = Number.parseInt(added ?? "", 10);
+    const deletedCount = Number.parseInt(deleted ?? "", 10);
+    if (Number.isFinite(addedCount)) additions += addedCount;
+    if (Number.isFinite(deletedCount)) deletions += deletedCount;
   }
   return { additions, deletions };
+}
+
+async function untrackedFileStats(
+  cwd: string,
+  raw: string,
+): Promise<{ additions: number; deletions: number }> {
+  const files = raw.split("\0").filter(Boolean);
+  const additions = await files.reduce(async (pending, file) => {
+    const count = await pending;
+    const absolutePath = path.resolve(cwd, file);
+    const relative = path.relative(cwd, absolutePath);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) return count;
+    try {
+      const contents = await readFile(absolutePath, "utf8");
+      if (!contents) return count;
+      return count + contents.split("\n").length - (contents.endsWith("\n") ? 1 : 0);
+    } catch {
+      return count;
+    }
+  }, Promise.resolve(0));
+  return { additions, deletions: 0 };
 }
 
 function pullRequestUrl(remoteUrl: string, branch: string | null): string | null {

--- a/frontend/src/lib/agent/mcp-plugin-extension.test.ts
+++ b/frontend/src/lib/agent/mcp-plugin-extension.test.ts
@@ -33,13 +33,14 @@ describe("mcp plugin extension", () => {
           tools.push(tool);
         },
       } as Parameters<typeof registerMcpPlugins>[0]);
-      await new Promise((resolve) => setTimeout(resolve, 80));
       const statusTool = tools.find((tool) => tool.name === "mcp_plugin_status");
       expect(statusTool).toBeTruthy();
       expect(typeof statusTool?.execute).toBe("function");
-      const result = await (statusTool?.execute as () => Promise<StatusResult>)();
-      expect(result.content[0]?.text).toContain("fake-plugin/fake-mcp: failed");
-      expect(result.content[0]?.text).toContain("code=42");
+      const text = await waitForStatusText(
+        statusTool?.execute as () => Promise<StatusResult>,
+        "fake-plugin/fake-mcp: failed",
+      );
+      expect(text).toContain("code=42");
     } finally {
       if (previous === undefined) delete process.env.VLLM_STUDIO_MCP_PLUGIN_CONFIGS;
       else process.env.VLLM_STUDIO_MCP_PLUGIN_CONFIGS = previous;
@@ -81,6 +82,22 @@ describe("mcp plugin extension", () => {
     }
   });
 });
+
+async function waitForStatusText(
+  execute: () => Promise<StatusResult>,
+  expected: string,
+): Promise<string> {
+  const deadline = Date.now() + 1000;
+  let text = "";
+  while (Date.now() < deadline) {
+    const result = await execute();
+    text = result.content[0]?.text ?? "";
+    if (text.includes(expected)) return text;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  expect(text).toContain(expected);
+  return text;
+}
 
 function fakeMcpServerSource() {
   return `

--- a/frontend/src/lib/agent/projects-store.test.ts
+++ b/frontend/src/lib/agent/projects-store.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { addProjectToStore, listProjectsFromStore, removeProjectFromStore } from "./projects-store";
+import { CHATS_PROJECT_ID } from "./projects/types";
 
 const roots: string[] = [];
 const originalEnv = { ...process.env };
@@ -49,7 +50,10 @@ describe("projects store", () => {
       branch: "feature/refactor",
     });
     expect(duplicate).toEqual(created);
-    expect(listProjectsFromStore()).toEqual([created]);
+    expect(listProjectsFromStore()).toEqual([
+      expect.objectContaining({ id: CHATS_PROJECT_ID, name: "Chats" }),
+      created,
+    ]);
     expect(JSON.parse(readFileSync(storeFile, "utf8"))).toMatchObject({
       projects: [expect.objectContaining({ path: projectPath })],
     });
@@ -64,14 +68,18 @@ describe("projects store", () => {
     mkdirSync(path.dirname(storeFile), { recursive: true });
     writeFileSync(storeFile, "not json");
 
-    expect(listProjectsFromStore()).toEqual([]);
+    expect(listProjectsFromStore()).toEqual([
+      expect.objectContaining({ id: CHATS_PROJECT_ID, name: "Chats" }),
+    ]);
     expect(() => addProjectToStore("   ")).toThrow("path is required");
     expect(() => addProjectToStore(path.join(root, "missing"))).toThrow("Path is not a directory");
 
     const created = addProjectToStore(projectPath);
     removeProjectFromStore("missing");
-    expect(listProjectsFromStore()).toHaveLength(1);
+    expect(listProjectsFromStore()).toHaveLength(2);
     removeProjectFromStore(created.id);
-    expect(listProjectsFromStore()).toEqual([]);
+    expect(listProjectsFromStore()).toEqual([
+      expect.objectContaining({ id: CHATS_PROJECT_ID, name: "Chats" }),
+    ]);
   });
 });

--- a/frontend/src/lib/agent/projects-store.ts
+++ b/frontend/src/lib/agent/projects-store.ts
@@ -1,5 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
+import { CHATS_PROJECT_ID } from "@/lib/agent/projects/types";
 
 export interface ProjectEntry {
   id: string;
@@ -103,8 +105,22 @@ function withMeta(record: ProjectRecord): ProjectEntry {
   };
 }
 
+function chatsProject(): ProjectEntry {
+  const chatsPath = path.join(homedir(), ".vllm-studio");
+  mkdirSync(chatsPath, { recursive: true });
+  return withMeta({
+    id: CHATS_PROJECT_ID,
+    name: "Chats",
+    path: chatsPath,
+    addedAt: "1970-01-01T00:00:00.000Z",
+  });
+}
+
 export function listProjectsFromStore(): ProjectEntry[] {
-  return readDocument(projectsFilePath()).projects.map(withMeta);
+  const projects = readDocument(projectsFilePath())
+    .projects.filter((project) => project.id !== CHATS_PROJECT_ID)
+    .map(withMeta);
+  return [chatsProject(), ...projects];
 }
 
 export function addProjectToStore(rawPath: string): ProjectEntry {
@@ -128,6 +144,7 @@ export function addProjectToStore(rawPath: string): ProjectEntry {
 }
 
 export function removeProjectFromStore(id: string): void {
+  if (id === CHATS_PROJECT_ID) return;
   const filePath = projectsFilePath();
   const document = readDocument(filePath);
   if (!document.projects.some((entry) => entry.id === id)) return;

--- a/frontend/src/lib/agent/projects/store.test.ts
+++ b/frontend/src/lib/agent/projects/store.test.ts
@@ -53,11 +53,12 @@ describe("createProjectsStore", () => {
       .fn()
       .mockResolvedValueOnce([project("p1"), project("p2")])
       .mockResolvedValueOnce([project("p2")]);
+    const loadGitSummary = vi.fn(async () => gitSummary);
     const writeSelectedProjectId = vi.fn();
     const store = createProjectsStore({
       api: {
         initGit: vi.fn(),
-        loadGitSummary: vi.fn(async () => gitSummary),
+        loadGitSummary,
         loadProjects,
         removeProject: vi.fn(),
       },
@@ -73,6 +74,8 @@ describe("createProjectsStore", () => {
 
     expect(store.getSnapshot().selectedId).toBe("p2");
     expect(writeSelectedProjectId).not.toHaveBeenCalledWith("p1");
+    expect(loadGitSummary).toHaveBeenCalledTimes(2);
+    expect(loadGitSummary).toHaveBeenLastCalledWith("/work/p2");
     unsubscribe();
   });
 

--- a/frontend/src/lib/agent/projects/store.ts
+++ b/frontend/src/lib/agent/projects/store.ts
@@ -86,6 +86,7 @@ export function createProjectsStore(dependencies: ProjectsStoreDependencies = {}
   };
 
   const loadGitSummary = async (cwd: string): Promise<GitSummary | null> => {
+    if (!cwd) return null;
     try {
       const summary = await api.loadGitSummary(cwd);
       const next = new Map(snapshot.gitSummaries);
@@ -119,7 +120,7 @@ export function createProjectsStore(dependencies: ProjectsStoreDependencies = {}
     const selectedId = resolveSelectedProjectId(previousSelectedId, projects);
     update({ ...snapshot, projects, loaded: true, selectedId });
     if (selectedId !== previousSelectedId) writeSelection(selectedId);
-    loadGitSummaryOnce(projectPathById(projects, selectedId));
+    void loadGitSummary(projectPathById(projects, selectedId));
     if (!firstLoad) {
       firstLoad = true;
       getWindow()?.dispatchEvent(loadedEvent(projects));

--- a/frontend/src/lib/agent/projects/types.ts
+++ b/frontend/src/lib/agent/projects/types.ts
@@ -1,5 +1,7 @@
 export type ProjectId = string;
 
+export const CHATS_PROJECT_ID = "chats";
+
 export type Project = {
   id: ProjectId;
   name: string;
@@ -17,3 +19,7 @@ export type GitSummary = {
   deletions: number;
   statusCount: number;
 };
+
+export function isChatsProject(project: Pick<Project, "id"> | null | undefined): boolean {
+  return project?.id === CHATS_PROJECT_ID;
+}

--- a/frontend/src/lib/agent/session/helpers.ts
+++ b/frontend/src/lib/agent/session/helpers.ts
@@ -209,7 +209,11 @@ export function reconcileQueueWithPiEvent(
     steer: stringArray(event.steering),
     follow_up: stringArray(event.followUp),
   };
-  const next = queue.filter((item) => !item.sent || pending[item.mode].includes(item.text));
+  const next = queue.flatMap((item) => {
+    const acceptedByPi = pending[item.mode].includes(item.text);
+    if (acceptedByPi) return [{ ...item, sent: true }];
+    return item.sent ? [] : [item];
+  });
   const seen = new Set(next.map((item) => `${item.mode}:${item.text}`));
   for (const [mode, messages] of Object.entries(pending) as Array<
     [QueuedMessage["mode"], string[]]

--- a/frontend/src/lib/agent/session/helpers.ts
+++ b/frontend/src/lib/agent/session/helpers.ts
@@ -182,7 +182,7 @@ export function replayCursorAfterRuntimeHydration(
 // ----- queue helpers -----
 
 export function visibleQueuedMessages(queue: QueuedMessage[]): QueuedMessage[] {
-  return queue;
+  return queue.filter((item) => item.mode === "follow_up");
 }
 
 export function drainQueueAfterAgentEnd(queue: QueuedMessage[]): {
@@ -234,10 +234,10 @@ export function reconcileQueueWithPiEvent(
       pending.set(key, [...(pending.get(key) ?? []), text]);
     }
   };
-  addPending("steer", stringArray(event.steering));
   addPending("follow_up", stringArray(event.followUp));
 
   const next = queue.flatMap((item) => {
+    if (item.mode !== "follow_up") return [];
     const acceptedByPi = consumePending(pending, item.mode, item.text);
     if (acceptedByPi) return [{ ...item, text: queueDisplayText(acceptedByPi), sent: true }];
     return item.sent ? [] : [item];

--- a/frontend/src/lib/agent/session/helpers.ts
+++ b/frontend/src/lib/agent/session/helpers.ts
@@ -182,7 +182,7 @@ export function replayCursorAfterRuntimeHydration(
 // ----- queue helpers -----
 
 export function visibleQueuedMessages(queue: QueuedMessage[]): QueuedMessage[] {
-  return queue.filter((item) => item.mode === "follow_up");
+  return queue;
 }
 
 export function drainQueueAfterAgentEnd(queue: QueuedMessage[]): {
@@ -200,32 +200,67 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
+function queueDisplayText(text: string): string {
+  return visibleUserTextFromPi(text) || text.trim();
+}
+
+function queueKey(mode: QueuedMessage["mode"], text: string): string {
+  return `${mode}:${queueDisplayText(text)}`;
+}
+
+function consumePending(
+  pending: Map<string, string[]>,
+  mode: QueuedMessage["mode"],
+  text: string,
+): string | null {
+  const key = queueKey(mode, text);
+  const values = pending.get(key);
+  if (!values || values.length === 0) return null;
+  const [value, ...remaining] = values;
+  if (remaining.length > 0) pending.set(key, remaining);
+  else pending.delete(key);
+  return value ?? null;
+}
+
 export function reconcileQueueWithPiEvent(
   queue: QueuedMessage[],
   event: Record<string, unknown>,
 ): QueuedMessage[] {
   if (event.type !== "queue_update") return queue;
-  const pending = {
-    steer: stringArray(event.steering),
-    follow_up: stringArray(event.followUp),
+  const pending = new Map<string, string[]>();
+  const addPending = (mode: QueuedMessage["mode"], messages: string[]) => {
+    for (const text of messages) {
+      const key = queueKey(mode, text);
+      pending.set(key, [...(pending.get(key) ?? []), text]);
+    }
   };
+  addPending("steer", stringArray(event.steering));
+  addPending("follow_up", stringArray(event.followUp));
+
   const next = queue.flatMap((item) => {
-    const acceptedByPi = pending[item.mode].includes(item.text);
-    if (acceptedByPi) return [{ ...item, sent: true }];
+    const acceptedByPi = consumePending(pending, item.mode, item.text);
+    if (acceptedByPi) return [{ ...item, text: queueDisplayText(acceptedByPi), sent: true }];
     return item.sent ? [] : [item];
   });
-  const seen = new Set(next.map((item) => `${item.mode}:${item.text}`));
-  for (const [mode, messages] of Object.entries(pending) as Array<
-    [QueuedMessage["mode"], string[]]
-  >) {
+
+  for (const [key, messages] of pending) {
+    const separator = key.indexOf(":");
+    const mode = key.slice(0, separator) as QueuedMessage["mode"];
     for (const text of messages) {
-      const key = `${mode}:${text}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      next.push({ id: newId("queue"), mode, text, sent: true });
+      next.push({ id: newId("queue"), mode, text: queueDisplayText(text), sent: true });
     }
   }
   return next;
+}
+
+export function removeDeliveredQueuedMessage(
+  queue: QueuedMessage[],
+  deliveredText: string,
+): QueuedMessage[] {
+  const delivered = queueDisplayText(deliveredText);
+  const index = queue.findIndex((item) => queueDisplayText(item.text) === delivered);
+  if (index === -1) return queue;
+  return [...queue.slice(0, index), ...queue.slice(index + 1)];
 }
 
 // ----- canonical + runtime event merge -----

--- a/frontend/src/lib/agent/session/types.ts
+++ b/frontend/src/lib/agent/session/types.ts
@@ -84,8 +84,9 @@ export type SessionTab = {
   lastEventSeq?: number;
   plugins?: ComposerPluginRef[];
   skills?: ComposerSkillRef[];
-  // Outgoing pending messages (steer + follow_up). Drawn as chips above the
-  // input until Pi `queue_update` reconciles the canonical queue.
+  // Outgoing pending follow-up messages. Drawn as chips above the input until
+  // Pi `queue_update` reconciles the canonical queue. Steering messages are
+  // sent as immediate control messages and are not surfaced in this queue UI.
   queue?: QueuedMessage[];
 };
 

--- a/frontend/src/lib/agent/session/types.ts
+++ b/frontend/src/lib/agent/session/types.ts
@@ -47,7 +47,8 @@ export type TokenStats = {
 export type QueuedMessage = {
   id: string;
   // "steer" interrupts the current turn between tool runs and the next LLM
-  // call; "follow_up" waits until the agent completely finishes.
+  // call; "follow_up" is queued inside Pi for the next turn. `sent: false`
+  // is reserved for local fallback work that Pi did not accept.
   mode: "steer" | "follow_up";
   text: string;
   sent?: boolean;
@@ -84,7 +85,7 @@ export type SessionTab = {
   plugins?: ComposerPluginRef[];
   skills?: ComposerSkillRef[];
   // Outgoing pending messages (steer + follow_up). Drawn as chips above the
-  // input. Steers fire immediately; follow-ups wait for `agent_end`.
+  // input until Pi `queue_update` reconciles the canonical queue.
   queue?: QueuedMessage[];
 };
 

--- a/frontend/src/lib/agent/sessions/pi-event-applier.test.ts
+++ b/frontend/src/lib/agent/sessions/pi-event-applier.test.ts
@@ -63,6 +63,28 @@ describe("applyPiEventToSession", () => {
     expect(deps.tabsRef.current[0].messages).toHaveLength(1);
   });
 
+  it("dedupes back-to-back Pi user start/end echoes for queued follow-ups", () => {
+    const deps = harness([
+      session({
+        id: "s1",
+        queue: [{ id: "q1", mode: "follow_up", text: "Hello agent", sent: true }],
+      }),
+    ]);
+
+    applyPiEventToSession(deps, "s1", "assistant-1", {
+      type: "message_start",
+      message: { role: "user", content: "Hello agent" },
+    });
+    applyPiEventToSession(deps, "s1", "assistant-1", {
+      type: "message_end",
+      message: { role: "user", content: "Hello agent" },
+    });
+
+    const messages = deps.tabsRef.current[0].messages;
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(deps.tabsRef.current[0].queue).toEqual([]);
+  });
+
   it("routes assistant block events to the current live assistant", () => {
     const deps = harness([
       session({

--- a/frontend/src/lib/agent/sessions/pi-event-applier.ts
+++ b/frontend/src/lib/agent/sessions/pi-event-applier.ts
@@ -73,28 +73,28 @@ function appendUserMessageFromPiEvent(
   if (msg?.role !== "user") return false;
   const text = visibleUserTextFromPi(messageText(msg.content));
   if (!text) return true;
-  if (hasMatchingLastUserMessage(deps.tabsRef.current, sessionId, text)) {
-    deps.updateSession(sessionId, (session) => ({
+  let appended = false;
+  deps.updateSession(sessionId, (session) => {
+    const queue = removeDeliveredQueuedMessage(session.queue ?? [], text);
+    if (hasMatchingLastUserMessage(session.messages, text)) {
+      return { ...session, queue };
+    }
+    appended = true;
+    return {
       ...session,
-      queue: removeDeliveredQueuedMessage(session.queue ?? [], text),
-    }));
-    return true;
-  }
-  deps.updateSession(sessionId, (session) => ({
-    ...session,
-    queue: removeDeliveredQueuedMessage(session.queue ?? [], text),
-    messages: [
-      ...session.messages,
-      { id: newId("user"), role: "user", text, timestamp: nowLabel() },
-    ],
-  }));
-  ensureNextAssistant(deps, sessionId);
+      queue,
+      messages: [
+        ...session.messages,
+        { id: newId("user"), role: "user", text, timestamp: nowLabel() },
+      ],
+    };
+  });
+  if (appended) ensureNextAssistant(deps, sessionId);
   return true;
 }
 
-function hasMatchingLastUserMessage(tabs: Session[], sessionId: SessionId, text: string): boolean {
-  const current = tabs.find((tab) => tab.id === sessionId);
-  const lastUser = [...(current?.messages ?? [])].reverse().find((entry) => entry.role === "user");
+function hasMatchingLastUserMessage(messages: ChatMessage[], text: string): boolean {
+  const lastUser = [...messages].reverse().find((entry) => entry.role === "user");
   return Boolean(lastUser && (lastUser.text === text || text.includes(lastUser.text)));
 }
 

--- a/frontend/src/lib/agent/sessions/pi-event-applier.ts
+++ b/frontend/src/lib/agent/sessions/pi-event-applier.ts
@@ -6,6 +6,7 @@ import {
   newId,
   nowLabel,
   reconcileQueueWithPiEvent,
+  removeDeliveredQueuedMessage,
   usageFromEvent,
   visibleUserTextFromPi,
 } from "@/lib/agent/session";
@@ -71,9 +72,17 @@ function appendUserMessageFromPiEvent(
   const msg = event.message as { role?: string; content?: string | Record<string, unknown>[] };
   if (msg?.role !== "user") return false;
   const text = visibleUserTextFromPi(messageText(msg.content));
-  if (!text || hasMatchingLastUserMessage(deps.tabsRef.current, sessionId, text)) return true;
+  if (!text) return true;
+  if (hasMatchingLastUserMessage(deps.tabsRef.current, sessionId, text)) {
+    deps.updateSession(sessionId, (session) => ({
+      ...session,
+      queue: removeDeliveredQueuedMessage(session.queue ?? [], text),
+    }));
+    return true;
+  }
   deps.updateSession(sessionId, (session) => ({
     ...session,
+    queue: removeDeliveredQueuedMessage(session.queue ?? [], text),
     messages: [
       ...session.messages,
       { id: newId("user"), role: "user", text, timestamp: nowLabel() },

--- a/frontend/src/lib/agent/sessions/queue-drain.test.ts
+++ b/frontend/src/lib/agent/sessions/queue-drain.test.ts
@@ -55,7 +55,12 @@ describe("session queue drain", () => {
 
   it("clears non-drainable queued work without scheduling a turn", () => {
     const deps = harness([
-      session({ queue: [{ id: "steer", mode: "steer", text: "interrupt", sent: true }] }),
+      session({
+        queue: [
+          { id: "steer", mode: "steer", text: "interrupt", sent: true },
+          { id: "accepted-follow", mode: "follow_up", text: "already accepted", sent: true },
+        ],
+      }),
     ]);
 
     drainQueuedTurnAfterAgentEnd(deps, "session-1");


### PR DESCRIPTION
## Summary
- Treat accepted chat steer/follow-up controls as Pi-owned queued messages.
- Reconcile local queue chips from Pi `queue_update` so accepted items disappear when Pi reports delivery/clearance.
- Preserve local fallback draining only for follow-ups Pi did not accept.

Closes #87.

## Verification
- `npm test -- src/app/agent/_components/chat-pane.test.ts src/lib/agent/sessions/queue-drain.test.ts src/app/api/agent/turn/route.test.ts src/lib/agent/sessions/pi-event-applier.test.ts src/lib/agent/sessions/runtime-resume.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- Pre-push `npm run check:quality` passed: lint, typecheck, desktop typecheck, cycle check, full unit suite, cleanup checks, and build.
- Subagent deployment verification: `npx next build`, `curl http://localhost:3001/agent` returned 200, `npm run desktop:dist`, installed /Applications/vLLM Studio.app updated and bundle id verified as `org.vllm.studio.desktop`.