### PR TITLE
Upgrade computer workspace

### DIFF
--- a/frontend/desktop/logic/window-manager.ts
+++ b/frontend/desktop/logic/window-manager.ts
@@ -1,7 +1,17 @@
-import { BrowserWindow } from "electron";
+import { app, BrowserWindow } from "electron";
 import path from "node:path";
 import { DESKTOP_CONFIG } from "../configs";
+import { log } from "../helpers/logger";
 import { hardenWebContents } from "./security";
+
+async function memorySummary(): Promise<string> {
+  try {
+    const memory = await process.getProcessMemoryInfo();
+    return `memory=${JSON.stringify(memory)}`;
+  } catch {
+    return "memory=unavailable";
+  }
+}
 
 export function createMainWindow(appUrl: string): BrowserWindow {
   const window = new BrowserWindow({
@@ -27,6 +37,21 @@ export function createMainWindow(appUrl: string): BrowserWindow {
   });
 
   hardenWebContents(window, new URL(appUrl).origin);
+
+  window.webContents.on("render-process-gone", (_event, details) => {
+    void memorySummary().then((memory) => {
+      log.error(
+        [
+          "Renderer process gone",
+          `reason=${details.reason}`,
+          `exitCode=${details.exitCode}`,
+          `url=${window.webContents.getURL() || appUrl}`,
+          `appVersion=${app.getVersion()}`,
+          memory,
+        ].join(" "),
+      );
+    });
+  });
 
   window.once("ready-to-show", () => window.show());
   void window.loadURL(appUrl);

--- a/frontend/desktop/main.ts
+++ b/frontend/desktop/main.ts
@@ -12,6 +12,14 @@ let appState: DesktopAppState = "starting";
 let mainWindow: BrowserWindow | null = null;
 let frontendServer: ServerHandle | undefined;
 
+async function processMemorySummary(): Promise<string> {
+  try {
+    return `memory=${JSON.stringify(await process.getProcessMemoryInfo())}`;
+  } catch {
+    return "memory=unavailable";
+  }
+}
+
 async function bootstrap(): Promise<void> {
   if (!frontendServer) {
     frontendServer = await startFrontendServer();
@@ -115,6 +123,21 @@ async function run(): Promise<void> {
 
   app.on("before-quit", () => {
     void shutdown();
+  });
+
+  app.on("render-process-gone", (_event, webContents, details) => {
+    void processMemorySummary().then((memory) => {
+      log.error(
+        [
+          "App render-process-gone",
+          `reason=${details.reason}`,
+          `exitCode=${details.exitCode}`,
+          `url=${webContents.getURL()}`,
+          `appVersion=${app.getVersion()}`,
+          memory,
+        ].join(" "),
+      );
+    });
   });
 
   process.on("uncaughtException", (error) => {

--- a/frontend/desktop/resources/pi-extensions/browser.ts
+++ b/frontend/desktop/resources/pi-extensions/browser.ts
@@ -17,6 +17,7 @@ type ToolResult = {
 };
 
 const FRONTEND_BASE = process.env.VLLM_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000";
+const BROWSER_SESSION_ID = process.env.VLLM_STUDIO_BROWSER_SESSION_ID ?? "";
 const DEFAULT_BROWSER_TOOL_TIMEOUT_MS = 60_000;
 
 function readTimeoutMs(name: string, fallback: number): number {
@@ -54,7 +55,9 @@ async function callBrowserAction(
   const response = await fetch(`${FRONTEND_BASE}/api/agent/browser/${verb}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(
+      BROWSER_SESSION_ID ? { ...payload, sessionId: BROWSER_SESSION_ID } : payload,
+    ),
     signal: controller.signal,
   }).finally(() => {
     clearTimeout(timeout);

--- a/frontend/desktop/resources/pi-extensions/canvas.ts
+++ b/frontend/desktop/resources/pi-extensions/canvas.ts
@@ -1,0 +1,105 @@
+// Canvas tool extension for vLLM Studio.
+//
+// Gives Pi a shared scratchboard it can read and update. The renderer also
+// edits this same document through /api/agent/canvas, so the human and model
+// see one source of truth.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+};
+
+const FRONTEND_BASE = process.env.VLLM_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000";
+const CANVAS_TOOL_TIMEOUT_MS = 20_000;
+
+function result(text: string, details: Record<string, unknown> = {}): ToolResult {
+  return { content: [{ type: "text", text }], details };
+}
+
+async function callCanvas(
+  method: "GET" | "POST",
+  body: Record<string, unknown> | null,
+  signal: AbortSignal,
+): Promise<{ enabled?: boolean; text?: string; updatedAt?: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CANVAS_TOOL_TIMEOUT_MS);
+  const abort = () => controller.abort();
+  signal.addEventListener("abort", abort, { once: true });
+  if (signal.aborted) controller.abort();
+  const response = await fetch(`${FRONTEND_BASE}/api/agent/canvas`, {
+    method,
+    headers: method === "POST" ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: controller.signal,
+  }).finally(() => {
+    clearTimeout(timeout);
+    signal.removeEventListener("abort", abort);
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  return (await response.json()) as { enabled?: boolean; text?: string; updatedAt?: string };
+}
+
+export default function registerCanvasExtension(pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "canvas_read",
+    label: "Canvas: Read",
+    description:
+      "Read the shared vLLM Studio canvas scratchboard. Use it to pick up notes left by the human or previous model steps.",
+    parameters: Type.Object({}),
+    async execute(_id, _params, signal) {
+      try {
+        const canvas = await callCanvas("GET", null, signal);
+        return result(canvas.text || "", canvas);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return result(`canvas_read failed: ${message}`, { failed: true, error: message });
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "canvas_write",
+    label: "Canvas: Write",
+    description:
+      "Replace the shared vLLM Studio canvas scratchboard with concise notes, plans, links, or state the human and model should both see.",
+    parameters: Type.Object({
+      text: Type.String({ description: "Full replacement canvas text" }),
+    }),
+    async execute(_id, params, signal) {
+      try {
+        const canvas = await callCanvas("POST", { enabled: true, text: params.text }, signal);
+        return result(canvas.text || "", canvas);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return result(`canvas_write failed: ${message}`, { failed: true, error: message });
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "canvas_append",
+    label: "Canvas: Append",
+    description: "Append a short note to the shared vLLM Studio canvas scratchboard.",
+    parameters: Type.Object({
+      text: Type.String({ description: "Text to append to the canvas" }),
+    }),
+    async execute(_id, params, signal) {
+      try {
+        const current = await callCanvas("GET", null, signal);
+        const prefix = current.text?.trimEnd() ? `${current.text.trimEnd()}\n\n` : "";
+        const canvas = await callCanvas(
+          "POST",
+          { enabled: true, text: `${prefix}${params.text}` },
+          signal,
+        );
+        return result(canvas.text || "", canvas);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return result(`canvas_append failed: ${message}`, { failed: true, error: message });
+      }
+    },
+  });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.2.1",
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.6.2",
         "highlight.js": "11.11.1",
         "lucide-react": "^0.561.0",
@@ -6775,6 +6777,21 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,8 @@
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.70.6",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.6.2",
     "highlight.js": "11.11.1",
     "lucide-react": "^0.561.0",

--- a/frontend/src/app/agent/_components/agent-browser-panel.tsx
+++ b/frontend/src/app/agent/_components/agent-browser-panel.tsx
@@ -33,7 +33,6 @@ type AgentBrowserPanelHandles = Pick<
 type AgentBrowserPanelProps = {
   handles: AgentBrowserPanelHandles;
   activeProject: Project | null;
-  focusedTitle: string;
   focusedSession: Session | null;
   sessions: Session[];
   activeModel: AgentModel | null;
@@ -49,7 +48,6 @@ type AgentBrowserPanelProps = {
 export function AgentBrowserPanel({
   handles,
   activeProject,
-  focusedTitle,
   focusedSession,
   sessions,
   activeModel,
@@ -84,8 +82,9 @@ export function AgentBrowserPanel({
       />
       <ComputerHeader
         tab={tools.computer.tab}
-        focusedTitle={focusedTitle}
+        openTabs={tools.computer.tabs}
         onSelectTab={tools.setComputerTab}
+        onCloseTab={tools.closeComputerTab}
       />
       <div className="absolute right-2 top-1.5 z-20 flex items-center gap-1">
         <button
@@ -109,6 +108,8 @@ export function AgentBrowserPanel({
           sessions={sessions}
           gitSummary={gitSummary}
         />
+      ) : tools.computer.tab === "canvas" ? (
+        <CanvasPanel />
       ) : tools.computer.tab === "browser" ? (
         <AgentBrowser
           ref={registerBrowserHandle}
@@ -136,6 +137,7 @@ export function AgentBrowserPanel({
 
 const TAB_LABELS: Record<ComputerTab, string> = {
   status: "Status",
+  canvas: "Canvas",
   browser: "Browser",
   files: "Filesystem",
   diff: "Git",
@@ -148,6 +150,12 @@ const TAB_OPTIONS: Array<{
   description: string;
   icon: typeof Activity;
 }> = [
+  {
+    tab: "canvas",
+    label: "Canvas",
+    description: "Shared scratchboard for human and model",
+    icon: Code2,
+  },
   {
     tab: "browser",
     label: "Browser",
@@ -166,35 +174,73 @@ const TAB_OPTIONS: Array<{
 
 function ComputerHeader({
   tab,
-  focusedTitle,
+  openTabs,
   onSelectTab,
+  onCloseTab,
 }: {
   tab: ComputerTab;
-  focusedTitle: string;
+  openTabs: ComputerTab[];
   onSelectTab: (tab: ComputerTab) => void;
+  onCloseTab: (tab: ComputerTab) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const activeIcon =
-    tab === "status"
-      ? PanelRight
-      : (TAB_OPTIONS.find((item) => item.tab === tab)?.icon ?? PanelRight);
-  const ActiveIcon = activeIcon;
+  const tabMeta = (candidate: ComputerTab) =>
+    candidate === "status"
+      ? { label: "Status", icon: PanelRight }
+      : {
+          label: TAB_LABELS[candidate],
+          icon: TAB_OPTIONS.find((item) => item.tab === candidate)?.icon ?? PanelRight,
+        };
+  const menuOptions = [
+    {
+      tab: "status" as const,
+      label: "Status",
+      description: "Session and workspace summary",
+      icon: PanelRight,
+    },
+    ...TAB_OPTIONS,
+  ].filter((item) => !openTabs.includes(item.tab));
   return (
-    <div className="relative flex h-10 shrink-0 items-center gap-2 border-b border-(--border) px-3 pr-12 text-xs">
-      <button
-        type="button"
-        onClick={() => onSelectTab("status")}
-        className={`inline-flex h-7 min-w-0 max-w-[52%] items-center gap-2 rounded-md px-2 ${
-          tab === "status" ? "bg-(--surface) text-(--fg)" : "text-(--dim) hover:text-(--fg)"
-        }`}
-        title={`Computer follows focused session: ${focusedTitle}`}
-      >
-        <ActiveIcon className="h-3.5 w-3.5 shrink-0" />
-        <span className="truncate">{TAB_LABELS[tab]}</span>
-      </button>
-      <span className="min-w-0 flex-1 truncate text-[10px] uppercase tracking-wide text-(--dim)">
-        {focusedTitle}
-      </span>
+    <div className="relative flex h-10 shrink-0 items-center gap-1 border-b border-(--border) px-2 pr-12 text-xs">
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        {openTabs.map((openTab) => {
+          const meta = tabMeta(openTab);
+          const Icon = meta.icon;
+          return (
+            <div
+              key={openTab}
+              className={`group inline-flex h-7 min-w-0 shrink-0 items-center gap-1.5 rounded-md px-2 ${
+                tab === openTab ? "bg-(--surface) text-(--fg)" : "text-(--dim) hover:text-(--fg)"
+              }`}
+              title={meta.label}
+            >
+              <button
+                type="button"
+                onClick={() => onSelectTab(openTab)}
+                className="inline-flex min-w-0 flex-1 items-center gap-1.5 text-left"
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span className="max-w-[9rem] truncate">{meta.label}</span>
+              </button>
+              {openTab !== "status" ? (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onCloseTab(openTab);
+                  }}
+                  className="ml-0.5 hidden h-4 w-4 items-center justify-center rounded text-(--dim) hover:bg-(--hover) hover:text-(--fg) group-hover:inline-flex"
+                  aria-label={`Close ${meta.label}`}
+                  title={`Close ${meta.label}`}
+                >
+                  <CloseIcon className="h-2.5 w-2.5" />
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      <span className="min-w-0 flex-1" />
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
@@ -207,19 +253,10 @@ function ComputerHeader({
       </button>
       {open ? (
         <div className="absolute right-10 top-9 z-40 w-64 rounded-md border border-(--border) bg-[#151515] p-1 shadow-[0_12px_36px_rgba(0,0,0,0.65)]">
-          <button
-            type="button"
-            onClick={() => {
-              onSelectTab("status");
-              setOpen(false);
-            }}
-            className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-xs text-(--fg) hover:bg-(--hover)"
-          >
-            <PanelRight className="h-3.5 w-3.5 text-(--accent)" />
-            <span className="min-w-0 flex-1">Status</span>
-          </button>
-          <div className="my-1 border-t border-(--border)" />
-          {TAB_OPTIONS.map((item) => {
+          {menuOptions.length === 0 ? (
+            <div className="px-2 py-2 text-[11px] text-(--dim)">All computer tabs are open.</div>
+          ) : null}
+          {menuOptions.map((item) => {
             const Icon = item.icon;
             return (
               <button
@@ -338,8 +375,15 @@ function ComputerStatusPanel({
           <span className="font-medium text-(--fg)">Canvas</span>
           <button
             type="button"
-            onClick={() => tools.toggleCanvas()}
-            className={`ml-auto h-6 rounded px-2 text-[11px] ${
+            onClick={() => tools.setComputerTab("canvas")}
+            className="ml-auto h-6 rounded px-2 text-[11px] text-(--dim) hover:bg-(--hover) hover:text-(--fg)"
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            onClick={tools.toggleCanvas}
+            className={`h-6 rounded px-2 text-[11px] ${
               tools.computer.canvasEnabled
                 ? "bg-(--accent)/15 text-(--accent)"
                 : "bg-(--bg) text-(--dim) hover:text-(--fg)"
@@ -348,20 +392,43 @@ function ComputerStatusPanel({
             {tools.computer.canvasEnabled ? "On" : "Off"}
           </button>
         </div>
-        {tools.computer.canvasEnabled ? (
-          <textarea
-            value={tools.computer.canvasText}
-            onChange={(event) => tools.setCanvasText(event.target.value)}
-            placeholder="Scratch notes for the human and model…"
-            className="min-h-44 w-full resize-y bg-transparent p-3 font-mono text-[11px] leading-5 text-(--fg) outline-none placeholder:text-(--dim)"
-            spellCheck={false}
-          />
-        ) : (
-          <div className="py-2 text-[11px] leading-5">
-            Shared scratch notes for the model and human. Toggle it here or from the composer.
-          </div>
-        )}
+        <div className="mt-2 max-h-28 overflow-hidden rounded-md bg-(--surface)/50 p-2 font-mono text-[11px] leading-5 text-(--dim)">
+          {tools.computer.canvasText.trim() || "No canvas notes yet."}
+        </div>
       </div>
+    </section>
+  );
+}
+
+function CanvasPanel() {
+  const tools = useTools();
+  return (
+    <section className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-(--border) px-3 text-xs">
+        <Code2 className="h-3.5 w-3.5 text-(--accent)" />
+        <span className="font-medium text-(--fg)">Canvas</span>
+        <span className="min-w-0 flex-1 truncate text-[11px] text-(--dim)">
+          Shared scratchboard for the human and model
+        </span>
+        <button
+          type="button"
+          onClick={tools.toggleCanvas}
+          className={`h-6 rounded px-2 text-[11px] ${
+            tools.computer.canvasEnabled
+              ? "bg-(--accent)/15 text-(--accent)"
+              : "bg-(--surface) text-(--dim) hover:text-(--fg)"
+          }`}
+        >
+          {tools.computer.canvasEnabled ? "On" : "Off"}
+        </button>
+      </div>
+      <textarea
+        value={tools.computer.canvasText}
+        onChange={(event) => tools.setCanvasText(event.target.value)}
+        placeholder="Scratch notes, live plan, links, state, or anything the model should keep in view..."
+        className="min-h-0 flex-1 resize-none bg-transparent p-4 font-mono text-[12px] leading-6 text-(--fg) outline-none placeholder:text-(--dim)"
+        spellCheck={false}
+      />
     </section>
   );
 }

--- a/frontend/src/app/agent/_components/agent-browser-panel.tsx
+++ b/frontend/src/app/agent/_components/agent-browser-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState, type FormEvent, type ReactNode } from "react";
 import {
   Activity,
   Code2,
@@ -284,34 +284,38 @@ function ComputerStatusPanel({
     [sessions],
   );
   const contextWindow = activeModel?.contextWindow ?? 0;
+  const sessionTokens = focusedSession?.tokenStats?.current ?? 0;
   return (
     <section className="min-h-0 flex-1 overflow-y-auto px-4 py-3 text-xs text-(--dim)">
-      <div className="grid grid-cols-3 gap-2">
-        <Metric
-          label="Session tokens"
-          value={formatTokenCount(focusedSession?.tokenStats?.current ?? 0)}
-        />
-        <Metric label="All tokens" value={formatTokenCount(totals.current)} />
-        <Metric label="Messages" value={String(totals.messages)} />
+      <div className="border-b border-(--border) pb-3">
+        <div className="truncate text-sm font-medium text-(--fg)">
+          {focusedSession?.title ?? "New session"}
+        </div>
+        <div className="mt-2 grid grid-cols-3 gap-3 font-mono">
+          <MiniStat label="session" value={formatTokenCount(sessionTokens)} />
+          <MiniStat label="all" value={formatTokenCount(totals.current)} />
+          <MiniStat label="msgs" value={String(totals.messages)} />
+        </div>
       </div>
-      <div className="mt-3 grid gap-1.5 rounded-md border border-(--border) bg-(--surface)/35 p-3">
-        <StatusRow label="Focused" value={focusedSession?.title ?? "No session"} />
-        <StatusRow label="Status" value={focusedSession?.status ?? "idle"} />
+
+      <StatusSection title="Session">
+        <StatusRow label="State" value={focusedSession?.status ?? "idle"} />
         <StatusRow
           label="Model"
           value={activeModel?.name ?? focusedSession?.modelId ?? "No model"}
         />
         <StatusRow
           label="Context"
-          value={`${formatTokenCount(focusedSession?.tokenStats?.current ?? 0)} / ${formatTokenCount(contextWindow)}`}
+          value={`${formatTokenCount(sessionTokens)} / ${formatTokenCount(contextWindow)}`}
         />
         <StatusRow
           label="Read / write"
           value={`${formatTokenCount(totals.read)} / ${formatTokenCount(totals.write)}`}
         />
         <StatusRow label="Queue" value={`${totals.queued} queued · ${totals.running} running`} />
-      </div>
-      <div className="mt-3 grid gap-1.5 rounded-md border border-(--border) bg-(--surface)/25 p-3">
+      </StatusSection>
+
+      <StatusSection title="Workspace">
         <StatusRow label="Project" value={activeProject?.name ?? "No project"} />
         <StatusRow
           label="Directory"
@@ -326,9 +330,10 @@ function ComputerStatusPanel({
           }
         />
         <StatusRow label="Browser" value={tools.browser.enabled ? tools.browser.url : "Tool off"} />
-      </div>
-      <div className="mt-3 rounded-md border border-(--border) bg-(--surface)/25">
-        <div className="flex h-9 items-center gap-2 border-b border-(--border) px-3">
+      </StatusSection>
+
+      <div className="mt-4 border-t border-(--border) pt-3">
+        <div className="flex h-8 items-center gap-2">
           <Code2 className="h-3.5 w-3.5 text-(--accent)" />
           <span className="font-medium text-(--fg)">Canvas</span>
           <button
@@ -352,9 +357,8 @@ function ComputerStatusPanel({
             spellCheck={false}
           />
         ) : (
-          <div className="p-3 text-[11px] leading-5">
-            Enable the canvas from here or the composer to keep shared scratch notes beside the
-            session.
+          <div className="py-2 text-[11px] leading-5">
+            Shared scratch notes for the model and human. Toggle it here or from the composer.
           </div>
         )}
       </div>
@@ -362,19 +366,28 @@ function ComputerStatusPanel({
   );
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
+function MiniStat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-md border border-(--border) bg-(--surface)/35 p-2">
-      <div className="truncate text-[10px] uppercase tracking-wide text-(--dim)">{label}</div>
-      <div className="mt-1 truncate font-mono text-sm text-(--fg)">{value}</div>
+    <div className="min-w-0">
+      <div className="truncate text-[9px] uppercase tracking-wide text-(--dim)">{label}</div>
+      <div className="mt-1 truncate text-[13px] text-(--fg)">{value}</div>
+    </div>
+  );
+}
+
+function StatusSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="mt-4 border-t border-(--border) pt-3">
+      <div className="mb-2 text-[10px] uppercase tracking-wide text-(--dim)">{title}</div>
+      <div className="grid gap-1">{children}</div>
     </div>
   );
 }
 
 function StatusRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="grid grid-cols-[5.5rem_1fr] gap-3">
-      <span className="text-[10px] uppercase tracking-wide text-(--dim)">{label}</span>
+    <div className="grid grid-cols-[5.5rem_1fr] gap-3 py-0.5">
+      <span className="text-[10px] text-(--dim)">{label}</span>
       <span className="min-w-0 truncate text-right font-mono text-[11px] text-(--fg)" title={value}>
         {value}
       </span>

--- a/frontend/src/app/agent/_components/agent-browser-panel.tsx
+++ b/frontend/src/app/agent/_components/agent-browser-panel.tsx
@@ -73,7 +73,7 @@ export function AgentBrowserPanel({
     <aside
       className="relative flex shrink-0 flex-col border-l border-(--border) bg-(--bg)"
       ref={registerComputerAside}
-      style={{ width: `min(${tools.computer.width}px, 48vw)` }}
+      style={{ width: `${tools.computer.width}px`, minWidth: "max(280px, 25%)", maxWidth: "65%" }}
     >
       <div
         role="separator"

--- a/frontend/src/app/agent/_components/agent-browser-panel.tsx
+++ b/frontend/src/app/agent/_components/agent-browser-panel.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import type { FormEvent, ReactNode } from "react";
+import { useMemo, useState, type FormEvent } from "react";
+import {
+  Activity,
+  Code2,
+  FolderTree,
+  GitBranch,
+  Globe2,
+  PanelRight,
+  Plus,
+  TerminalSquare,
+} from "lucide-react";
 import { CloseIcon } from "@/components/icons";
 import { normalizeBrowserInput } from "@/lib/agent/tools/browser-url";
-import { useTools, type ToolsContextValue } from "@/lib/agent/tools/context";
+import { useTools } from "@/lib/agent/tools/context";
+import type { ComputerTab } from "@/lib/agent/tools/types";
 import type { Project } from "@/lib/agent/projects/types";
+import type { Session } from "@/lib/agent/sessions/types";
+import type { AgentModel } from "@/lib/agent/workspace/types";
+import { formatTokenCount } from "@/lib/agent/session";
 import { AgentBrowser, type AgentBrowserHandle } from "./agent-browser";
 import { FilesystemPanel } from "./filesystem-panel";
 import { GitDiffPanel } from "./git-diff-panel";
@@ -20,12 +34,26 @@ type AgentBrowserPanelProps = {
   handles: AgentBrowserPanelHandles;
   activeProject: Project | null;
   focusedTitle: string;
+  focusedSession: Session | null;
+  sessions: Session[];
+  activeModel: AgentModel | null;
+  gitSummary?: {
+    isRepo: boolean;
+    branch?: string | null;
+    additions: number;
+    deletions: number;
+    statusCount: number;
+  } | null;
 };
 
 export function AgentBrowserPanel({
   handles,
   activeProject,
   focusedTitle,
+  focusedSession,
+  sessions,
+  activeModel,
+  gitSummary,
 }: AgentBrowserPanelProps) {
   const tools = useTools();
   if (!tools.computer.open) return null;
@@ -54,43 +82,18 @@ export function AgentBrowserPanel({
         onMouseDown={startComputerResize}
         className="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize hover:bg-(--accent)/20"
       />
-      <div className="flex h-9 shrink-0 items-center gap-3 px-3 text-xs text-(--dim)">
-        <span
-          className="min-w-0 flex-1 truncate px-1 text-[10px] uppercase tracking-wide"
-          title={`Computer follows focused session: ${focusedTitle}`}
-        >
-          {focusedTitle}
-        </span>
-        <ComputerTabButton
-          active={tools.computer.tab === "browser"}
-          onClick={() => tools.setComputerTab("browser")}
-        >
-          Browser
-        </ComputerTabButton>
-        <ComputerTabButton
-          active={tools.computer.tab === "files"}
-          onClick={() => tools.setComputerTab("files")}
-        >
-          Files
-        </ComputerTabButton>
-        <ComputerTabButton
-          active={tools.computer.tab === "diff"}
-          onClick={() => tools.setComputerTab("diff")}
-        >
-          Diff
-        </ComputerTabButton>
-        <ComputerTabButton
-          active={tools.computer.tab === "terminal"}
-          onClick={() => tools.setComputerTab("terminal")}
-        >
-          Term
-        </ComputerTabButton>
+      <ComputerHeader
+        tab={tools.computer.tab}
+        focusedTitle={focusedTitle}
+        onSelectTab={tools.setComputerTab}
+      />
+      <div className="absolute right-2 top-1.5 z-20 flex items-center gap-1">
         <button
           type="button"
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
           onClick={() => tools.setComputerOpen(false)}
-          className="ml-1 inline-flex h-7 w-7 items-center justify-center hover:text-(--fg)"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-(--dim) hover:bg-(--surface) hover:text-(--fg)"
           title="Close"
           aria-label="Close computer"
         >
@@ -98,7 +101,15 @@ export function AgentBrowserPanel({
         </button>
       </div>
 
-      {tools.computer.tab === "browser" ? (
+      {tools.computer.tab === "status" ? (
+        <ComputerStatusPanel
+          activeProject={activeProject}
+          activeModel={activeModel}
+          focusedSession={focusedSession}
+          sessions={sessions}
+          gitSummary={gitSummary}
+        />
+      ) : tools.computer.tab === "browser" ? (
         <AgentBrowser
           ref={registerBrowserHandle}
           url={tools.browser.url}
@@ -123,24 +134,250 @@ export function AgentBrowserPanel({
   );
 }
 
-function ComputerTabButton({
-  active,
-  onClick,
-  children,
+const TAB_LABELS: Record<ComputerTab, string> = {
+  status: "Status",
+  browser: "Browser",
+  files: "Filesystem",
+  diff: "Git",
+  terminal: "Terminal",
+};
+
+const TAB_OPTIONS: Array<{
+  tab: ComputerTab;
+  label: string;
+  description: string;
+  icon: typeof Activity;
+}> = [
+  {
+    tab: "browser",
+    label: "Browser",
+    description: "Web, localhost, and file previews",
+    icon: Globe2,
+  },
+  { tab: "diff", label: "Git", description: "Diffs, branch, commit, and push", icon: GitBranch },
+  {
+    tab: "files",
+    label: "Filesystem",
+    description: "Project files and rendered previews",
+    icon: FolderTree,
+  },
+  { tab: "terminal", label: "Terminal", description: "Project shell", icon: TerminalSquare },
+];
+
+function ComputerHeader({
+  tab,
+  focusedTitle,
+  onSelectTab,
 }: {
-  active: boolean;
-  onClick: () => void;
-  children: ReactNode;
+  tab: ComputerTab;
+  focusedTitle: string;
+  onSelectTab: (tab: ComputerTab) => void;
 }) {
+  const [open, setOpen] = useState(false);
+  const activeIcon =
+    tab === "status"
+      ? PanelRight
+      : (TAB_OPTIONS.find((item) => item.tab === tab)?.icon ?? PanelRight);
+  const ActiveIcon = activeIcon;
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`h-6 shrink-0 font-medium uppercase tracking-wide ${
-        active ? "text-(--fg)" : "hover:text-(--fg)"
-      }`}
-    >
-      {children}
-    </button>
+    <div className="relative flex h-10 shrink-0 items-center gap-2 border-b border-(--border) px-3 pr-12 text-xs">
+      <button
+        type="button"
+        onClick={() => onSelectTab("status")}
+        className={`inline-flex h-7 min-w-0 max-w-[52%] items-center gap-2 rounded-md px-2 ${
+          tab === "status" ? "bg-(--surface) text-(--fg)" : "text-(--dim) hover:text-(--fg)"
+        }`}
+        title={`Computer follows focused session: ${focusedTitle}`}
+      >
+        <ActiveIcon className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{TAB_LABELS[tab]}</span>
+      </button>
+      <span className="min-w-0 flex-1 truncate text-[10px] uppercase tracking-wide text-(--dim)">
+        {focusedTitle}
+      </span>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-(--surface) text-(--fg) hover:bg-(--hover)"
+        title="Open computer tab"
+        aria-label="Open computer tab"
+        aria-expanded={open}
+      >
+        <Plus className="h-4 w-4" />
+      </button>
+      {open ? (
+        <div className="absolute right-10 top-9 z-40 w-64 rounded-md border border-(--border) bg-[#151515] p-1 shadow-[0_12px_36px_rgba(0,0,0,0.65)]">
+          <button
+            type="button"
+            onClick={() => {
+              onSelectTab("status");
+              setOpen(false);
+            }}
+            className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-xs text-(--fg) hover:bg-(--hover)"
+          >
+            <PanelRight className="h-3.5 w-3.5 text-(--accent)" />
+            <span className="min-w-0 flex-1">Status</span>
+          </button>
+          <div className="my-1 border-t border-(--border)" />
+          {TAB_OPTIONS.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                type="button"
+                key={item.tab}
+                onClick={() => {
+                  onSelectTab(item.tab);
+                  setOpen(false);
+                }}
+                className="flex w-full items-start gap-2 rounded px-2 py-2 text-left hover:bg-(--hover)"
+              >
+                <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--accent)" />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-xs text-(--fg)">{item.label}</span>
+                  <span className="block text-[10px] leading-4 text-(--dim)">
+                    {item.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ComputerStatusPanel({
+  activeProject,
+  activeModel,
+  focusedSession,
+  sessions,
+  gitSummary,
+}: {
+  activeProject: Project | null;
+  activeModel: AgentModel | null;
+  focusedSession: Session | null;
+  sessions: Session[];
+  gitSummary?: {
+    isRepo: boolean;
+    branch?: string | null;
+    additions: number;
+    deletions: number;
+    statusCount: number;
+  } | null;
+}) {
+  const tools = useTools();
+  const totals = useMemo(
+    () =>
+      sessions.reduce(
+        (acc, session) => ({
+          read: acc.read + (session.tokenStats?.read ?? 0),
+          write: acc.write + (session.tokenStats?.write ?? 0),
+          current: acc.current + (session.tokenStats?.current ?? 0),
+          messages: acc.messages + session.messages.length,
+          queued: acc.queued + (session.queue?.length ?? 0),
+          running:
+            acc.running + (session.status === "running" || session.status === "starting" ? 1 : 0),
+        }),
+        { read: 0, write: 0, current: 0, messages: 0, queued: 0, running: 0 },
+      ),
+    [sessions],
+  );
+  const contextWindow = activeModel?.contextWindow ?? 0;
+  return (
+    <section className="min-h-0 flex-1 overflow-y-auto px-4 py-3 text-xs text-(--dim)">
+      <div className="grid grid-cols-3 gap-2">
+        <Metric
+          label="Session tokens"
+          value={formatTokenCount(focusedSession?.tokenStats?.current ?? 0)}
+        />
+        <Metric label="All tokens" value={formatTokenCount(totals.current)} />
+        <Metric label="Messages" value={String(totals.messages)} />
+      </div>
+      <div className="mt-3 grid gap-1.5 rounded-md border border-(--border) bg-(--surface)/35 p-3">
+        <StatusRow label="Focused" value={focusedSession?.title ?? "No session"} />
+        <StatusRow label="Status" value={focusedSession?.status ?? "idle"} />
+        <StatusRow
+          label="Model"
+          value={activeModel?.name ?? focusedSession?.modelId ?? "No model"}
+        />
+        <StatusRow
+          label="Context"
+          value={`${formatTokenCount(focusedSession?.tokenStats?.current ?? 0)} / ${formatTokenCount(contextWindow)}`}
+        />
+        <StatusRow
+          label="Read / write"
+          value={`${formatTokenCount(totals.read)} / ${formatTokenCount(totals.write)}`}
+        />
+        <StatusRow label="Queue" value={`${totals.queued} queued · ${totals.running} running`} />
+      </div>
+      <div className="mt-3 grid gap-1.5 rounded-md border border-(--border) bg-(--surface)/25 p-3">
+        <StatusRow label="Project" value={activeProject?.name ?? "No project"} />
+        <StatusRow
+          label="Directory"
+          value={activeProject?.path ?? focusedSession?.cwd ?? "No directory"}
+        />
+        <StatusRow
+          label="Git"
+          value={
+            gitSummary?.isRepo
+              ? `${gitSummary.branch ?? "detached"} · +${gitSummary.additions} -${gitSummary.deletions} · ${gitSummary.statusCount} files`
+              : "Not a repo"
+          }
+        />
+        <StatusRow label="Browser" value={tools.browser.enabled ? tools.browser.url : "Tool off"} />
+      </div>
+      <div className="mt-3 rounded-md border border-(--border) bg-(--surface)/25">
+        <div className="flex h-9 items-center gap-2 border-b border-(--border) px-3">
+          <Code2 className="h-3.5 w-3.5 text-(--accent)" />
+          <span className="font-medium text-(--fg)">Canvas</span>
+          <button
+            type="button"
+            onClick={() => tools.toggleCanvas()}
+            className={`ml-auto h-6 rounded px-2 text-[11px] ${
+              tools.computer.canvasEnabled
+                ? "bg-(--accent)/15 text-(--accent)"
+                : "bg-(--bg) text-(--dim) hover:text-(--fg)"
+            }`}
+          >
+            {tools.computer.canvasEnabled ? "On" : "Off"}
+          </button>
+        </div>
+        {tools.computer.canvasEnabled ? (
+          <textarea
+            value={tools.computer.canvasText}
+            onChange={(event) => tools.setCanvasText(event.target.value)}
+            placeholder="Scratch notes for the human and model…"
+            className="min-h-44 w-full resize-y bg-transparent p-3 font-mono text-[11px] leading-5 text-(--fg) outline-none placeholder:text-(--dim)"
+            spellCheck={false}
+          />
+        ) : (
+          <div className="p-3 text-[11px] leading-5">
+            Enable the canvas from here or the composer to keep shared scratch notes beside the
+            session.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-(--border) bg-(--surface)/35 p-2">
+      <div className="truncate text-[10px] uppercase tracking-wide text-(--dim)">{label}</div>
+      <div className="mt-1 truncate font-mono text-sm text-(--fg)">{value}</div>
+    </div>
+  );
+}
+
+function StatusRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[5.5rem_1fr] gap-3">
+      <span className="text-[10px] uppercase tracking-wide text-(--dim)">{label}</span>
+      <span className="min-w-0 truncate text-right font-mono text-[11px] text-(--fg)" title={value}>
+        {value}
+      </span>
+    </div>
   );
 }

--- a/frontend/src/app/agent/_components/agent-workspace-shell.tsx
+++ b/frontend/src/app/agent/_components/agent-workspace-shell.tsx
@@ -131,7 +131,6 @@ export function AgentWorkspaceShell({ state, dispatch, handles }: AgentWorkspace
         <AgentBrowserPanel
           handles={handles}
           activeProject={activeProject}
-          focusedTitle={focusedTab?.title ?? "Focused session"}
           focusedSession={focusedTab}
           sessions={[...state.sessions.values()]}
           activeModel={focusedModel}

--- a/frontend/src/app/agent/_components/agent-workspace-shell.tsx
+++ b/frontend/src/app/agent/_components/agent-workspace-shell.tsx
@@ -89,6 +89,9 @@ export function AgentWorkspaceShell({ state, dispatch, handles }: AgentWorkspace
 
   const activeProject = projects.selectedProject;
   const focusedTab = focusedSession(state);
+  const focusedModel =
+    state.models.find((model) => model.id === (focusedTab?.modelId ?? state.selectedModel)) ?? null;
+  const focusedGitSummary = projects.gitSummary(activeProject?.path);
   const focusedComputerUseLoaded = tools
     .selectionFor(focusedTab?.id)
     .plugins.some((plugin) =>
@@ -129,6 +132,10 @@ export function AgentWorkspaceShell({ state, dispatch, handles }: AgentWorkspace
           handles={handles}
           activeProject={activeProject}
           focusedTitle={focusedTab?.title ?? "Focused session"}
+          focusedSession={focusedTab}
+          sessions={[...state.sessions.values()]}
+          activeModel={focusedModel}
+          gitSummary={focusedGitSummary}
         />
       </div>
     </div>

--- a/frontend/src/app/agent/_components/assistant-markdown.test.tsx
+++ b/frontend/src/app/agent/_components/assistant-markdown.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AssistantMarkdown } from "./assistant-markdown";
+
+describe("AssistantMarkdown", () => {
+  it("renders fenced code with a dark highlighted shell and copy control", () => {
+    const html = renderToStaticMarkup(
+      <AssistantMarkdown
+        text={[
+          "Here is the snippet:",
+          "",
+          "```ts",
+          "const value = 1;",
+          "export function read() {",
+          "  return value;",
+          "}",
+          "```",
+        ].join("\n")}
+      />,
+    );
+
+    expect(html).toContain("chat-markdown");
+    expect(html).toContain("assistant-code-block");
+    expect(html).toContain("Copy code");
+    expect(html).toContain(">ts<");
+    expect(html).toContain("hljs-keyword");
+    expect(html).toContain("hljs-number");
+  });
+});

--- a/frontend/src/app/agent/_components/assistant-markdown.tsx
+++ b/frontend/src/app/agent/_components/assistant-markdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CheckIcon, CopyIcon } from "lucide-react";
 import React, { Children, isValidElement, useCallback, useState, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
@@ -45,13 +46,27 @@ function CodeBlockCopyButton({ code }: { code: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="absolute right-1.5 top-1.5 rounded px-1 text-[10px] text-(--dim) hover:text-(--fg)"
+      className="inline-flex h-6 items-center gap-1 rounded border border-white/10 bg-white/[0.035] px-2 text-[10px] font-medium text-(--dim) shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition hover:border-white/20 hover:bg-white/[0.07] hover:text-(--fg) focus-visible:outline focus-visible:outline-1 focus-visible:outline-(--accent)"
       aria-label={copied ? "Copied" : "Copy code"}
       title={copied ? "Copied" : "Copy code"}
     >
-      {copied ? "Copied" : "Copy"}
+      {copied ? <CheckIcon className="h-3 w-3" /> : <CopyIcon className="h-3 w-3" />}
+      <span>{copied ? "Copied" : "Copy"}</span>
     </button>
   );
+}
+
+function codeLanguage(children: ReactNode): string | null {
+  const codeElement = Children.toArray(children).find(
+    (child) =>
+      isValidElement<{ className?: string }>(child) &&
+      typeof child.props.className === "string" &&
+      /\blanguage-/.test(child.props.className),
+  );
+  if (!isValidElement<{ className?: string }>(codeElement)) return null;
+  const className = codeElement.props.className ?? "";
+  const match = /\blanguage-([^\s]+)/.exec(className);
+  return match ? match[1] : null;
 }
 
 const components: Components = {
@@ -74,10 +89,13 @@ const components: Components = {
   ol: ({ node: _n, ...props }) => <ol className="my-2 list-decimal pl-5" {...props} />,
   li: ({ node: _n, ...props }) => <li className="text-sm leading-6" {...props} />,
   code: ({ node: _n, className, children, ...props }) => {
-    const isBlock = typeof className === "string" && /\blanguage-/.test(className);
+    const isBlock = typeof className === "string" && /\b(language-|hljs)\b/.test(className);
     if (isBlock) {
       return (
-        <code className={`${className ?? ""} font-mono`} {...props}>
+        <code
+          className={`${className ?? ""} block min-w-full font-mono text-[12px] leading-5 text-[#d8dee9]`}
+          {...props}
+        >
           {children}
         </code>
       );
@@ -97,14 +115,22 @@ const components: Components = {
         (child) => isValidElement(child) && (child as { type?: string }).type === "code",
       ) ?? children,
     );
+    const language = codeLanguage(children);
     return (
-      <pre
-        className="relative my-2 overflow-x-auto rounded border border-(--border) bg-(--surface) p-2 text-[12px] leading-5"
-        {...props}
-      >
-        {code ? <CodeBlockCopyButton code={code} /> : null}
-        {children}
-      </pre>
+      <div className="assistant-code-block group my-3 overflow-hidden rounded-md border border-white/10 bg-[#07090d] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <div className="flex h-8 items-center justify-between border-b border-white/10 bg-white/[0.025] px-2.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-(--dim)">
+            {language ?? "code"}
+          </span>
+          {code ? <CodeBlockCopyButton code={code} /> : null}
+        </div>
+        <pre
+          className="m-0 max-w-full overflow-x-auto bg-transparent px-3 py-2.5 text-[12px] leading-5"
+          {...props}
+        >
+          {children}
+        </pre>
+      </div>
     );
   },
   a: ({ node: _n, href, ...props }) => (
@@ -140,7 +166,7 @@ const components: Components = {
 
 export function AssistantMarkdown({ text }: { text: string }) {
   return (
-    <div className="min-w-0 text-sm leading-6 text-(--fg)">
+    <div className="chat-markdown min-w-0 text-sm leading-6 text-(--fg)">
       <MarkdownErrorBoundary fallback={<pre className="whitespace-pre-wrap text-sm">{text}</pre>}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}

--- a/frontend/src/app/agent/_components/chat-attachments.test.ts
+++ b/frontend/src/app/agent/_components/chat-attachments.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { attachmentDedupKey, filesFromDataTransfer, isImageAttachment } from "./chat-attachments";
+import {
+  attachmentDedupKey,
+  attachmentPreviewKind,
+  filesFromDataTransfer,
+  isImageAttachment,
+} from "./chat-attachments";
 
 describe("chat attachments", () => {
   it("dedupes one pasted file exposed through files and items", () => {
@@ -33,7 +38,17 @@ describe("chat attachments", () => {
         type: "image/png",
         mode: "data-url",
         content: "data:image/png;base64,abc",
+        previewKind: "image",
+        previewUrl: "data:image/png;base64,abc",
       }),
     ).toBe(true);
+  });
+
+  it("classifies media attachments for rich previews", () => {
+    expect(attachmentPreviewKind("image/png", "image.png")).toBe("image");
+    expect(attachmentPreviewKind("video/mp4", "clip.mp4")).toBe("video");
+    expect(attachmentPreviewKind("application/pdf", "paper.pdf")).toBe("pdf");
+    expect(attachmentPreviewKind("", "paper.pdf")).toBe("pdf");
+    expect(attachmentPreviewKind("application/octet-stream", "archive.bin")).toBeUndefined();
   });
 });

--- a/frontend/src/app/agent/_components/chat-attachments.ts
+++ b/frontend/src/app/agent/_components/chat-attachments.ts
@@ -1,16 +1,9 @@
 "use client";
 
 import { newId, randomIdSegment } from "@/lib/agent/session/helpers";
+import type { ChatMessageAttachment } from "@/lib/agent/session";
 
-export type ChatAttachment = {
-  id: string;
-  name: string;
-  type: string;
-  size: number;
-  path?: string;
-  mode: "text" | "data-url" | "metadata";
-  content: string;
-};
+export type ChatAttachment = ChatMessageAttachment;
 
 export function attachmentDedupKey(file: Pick<ChatAttachment, "name" | "type" | "size" | "path">) {
   const path = file.path?.trim();
@@ -18,10 +11,38 @@ export function attachmentDedupKey(file: Pick<ChatAttachment, "name" | "type" | 
   return `file:${file.name.trim().toLowerCase()}:${file.type}:${file.size}`;
 }
 
-export function isImageAttachment(file: Pick<ChatAttachment, "type" | "mode" | "content">) {
+export function isImageAttachment(
+  file: Pick<ChatAttachment, "type" | "mode" | "content" | "previewKind" | "previewUrl">,
+) {
+  if (file.previewKind === "image" && Boolean(file.previewUrl)) return true;
   return (
     file.type.startsWith("image/") && file.mode === "data-url" && file.content.startsWith("data:")
   );
+}
+
+export function attachmentPreviewKind(type: string, name = ""): ChatAttachment["previewKind"] {
+  const normalized = type.toLowerCase().split(";")[0]?.trim() ?? "";
+  if (normalized.startsWith("image/")) return "image";
+  if (normalized.startsWith("video/")) return "video";
+  if (normalized === "application/pdf" || /\.pdf$/i.test(name)) return "pdf";
+  return undefined;
+}
+
+function objectUrlFor(file: File, previewKind: ChatAttachment["previewKind"]): string | undefined {
+  if (!previewKind || typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+    return undefined;
+  }
+  try {
+    return URL.createObjectURL(file);
+  } catch {
+    return undefined;
+  }
+}
+
+export function revokeAttachmentPreview(file: Pick<ChatAttachment, "previewUrl">) {
+  if (!file.previewUrl?.startsWith("blob:")) return;
+  if (typeof URL === "undefined" || typeof URL.revokeObjectURL !== "function") return;
+  URL.revokeObjectURL(file.previewUrl);
 }
 
 function newAttachmentId() {
@@ -132,6 +153,7 @@ export async function createAttachment(file: File): Promise<ChatAttachment> {
   const name = fileDisplayName(file);
   const type = file.type || "application/octet-stream";
   const path = getDesktopFilePath(file) ?? undefined;
+  const previewKind = attachmentPreviewKind(type, name);
   if (isTextLike(file, name) && file.size <= 350_000) {
     return {
       id,
@@ -144,6 +166,7 @@ export async function createAttachment(file: File): Promise<ChatAttachment> {
     };
   }
   if (file.size <= 1_500_000) {
+    const content = await readFileAsDataUrl(file);
     return {
       id,
       name,
@@ -151,7 +174,9 @@ export async function createAttachment(file: File): Promise<ChatAttachment> {
       size: file.size,
       path,
       mode: "data-url",
-      content: await readFileAsDataUrl(file),
+      content,
+      previewKind,
+      previewUrl: previewKind ? content : undefined,
     };
   }
   return {
@@ -164,6 +189,8 @@ export async function createAttachment(file: File): Promise<ChatAttachment> {
     content: path
       ? `File is too large to inline; it is available on disk at ${path}.`
       : "File is too large to inline; only metadata is attached.",
+    previewKind,
+    previewUrl: objectUrlFor(file, previewKind),
   };
 }
 

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -59,6 +59,7 @@ import {
   filesFromDataTransfer,
   formatFileSize,
   isImageAttachment,
+  revokeAttachmentPreview,
   type ChatAttachment,
 } from "./chat-attachments";
 import { Timeline } from "./timeline/timeline";
@@ -268,7 +269,7 @@ export function ChatPane({
           ? `Attached: ${attachments.map((file) => file.name).join(", ")}`
           : "";
       const userText = text || attachmentSummary;
-      const displayText = [text, attachmentSummary].filter(Boolean).join("\n\n");
+      const displayText = text;
       const selection = tools.selectionFor(sessionId);
       const contextText = selectedContextPrompt(
         text,
@@ -276,7 +277,13 @@ export function ChatPane({
         selection.skills,
       );
       const prompt = [contextText, attachedText].filter(Boolean).join("\n\n");
-      return { text, prompt, displayText, userText };
+      return {
+        text,
+        prompt,
+        displayText,
+        userText,
+        attachments: attachments.length > 0 ? attachments : undefined,
+      };
     },
     [attachments, tools],
   );
@@ -418,7 +425,10 @@ export function ChatPane({
           const uniqueNext: ChatAttachment[] = [];
           next.forEach((file) => {
             const key = attachmentDedupKey(file);
-            if (seen.has(key)) return;
+            if (seen.has(key)) {
+              revokeAttachmentPreview(file);
+              return;
+            }
             seen.add(key);
             uniqueNext.push(file);
           });
@@ -684,14 +694,27 @@ export function ChatPane({
               {attachments.map((file) => (
                 <span
                   key={file.id}
-                  className="inline-flex max-w-[220px] items-center gap-1 px-1 py-0.5 text-[11px] text-(--dim)"
+                  className="inline-flex max-w-[260px] items-center gap-1.5 rounded-md bg-white/[0.035] px-1.5 py-1 text-[11px] text-(--dim)"
                   title={`${file.name} · ${file.type} · ${formatFileSize(file.size)}${file.path ? ` · ${file.path}` : ""}`}
                 >
                   {isImageAttachment(file) ? (
                     <img
-                      src={file.content}
+                      src={file.previewUrl ?? file.content}
                       alt=""
-                      className="h-7 w-7 shrink-0 rounded object-cover"
+                      className="h-9 w-9 shrink-0 rounded object-cover"
+                    />
+                  ) : file.previewKind === "video" && file.previewUrl ? (
+                    <video
+                      src={file.previewUrl}
+                      muted
+                      playsInline
+                      className="h-9 w-12 shrink-0 rounded object-cover"
+                    />
+                  ) : file.previewKind === "pdf" && file.previewUrl ? (
+                    <iframe
+                      src={file.previewUrl}
+                      title={file.name}
+                      className="h-9 w-12 shrink-0 rounded border border-white/10 bg-(--bg)"
                     />
                   ) : (
                     <FileIcon className="h-3 w-3 shrink-0" />
@@ -700,9 +723,10 @@ export function ChatPane({
                   <span className="shrink-0 opacity-70">{formatFileSize(file.size)}</span>{" "}
                   <button
                     type="button"
-                    onClick={() =>
-                      setAttachments((current) => current.filter((item) => item.id !== file.id))
-                    }
+                    onClick={() => {
+                      revokeAttachmentPreview(file);
+                      setAttachments((current) => current.filter((item) => item.id !== file.id));
+                    }}
                     className="p-0.5 hover:text-(--fg)"
                     aria-label={`Remove ${file.name}`}
                     title={`Remove ${file.name}`}

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -256,6 +256,7 @@ export function ChatPane({
     modelId,
     cwd,
     browserToolEnabled,
+    canvasEnabled: tools.computer.canvasEnabled,
     onPiSessionIdChange,
     updateSession,
     selectionFor: tools.selectionFor,

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -608,7 +608,7 @@ export function ChatPane({
           onDragOver={handleComposerDragOver}
           onDragLeave={handleComposerDragLeave}
           onDrop={handleComposerDrop}
-          className={`mx-auto max-w-[var(--composer-w)] overflow-visible rounded-lg bg-(--composer) shadow-none transition-colors ${composerDragActive ? "outline outline-1 outline-(--accent)/50" : ""}`}
+          className={`agent-composer-shell mx-auto max-w-[var(--composer-w)] overflow-visible rounded-lg bg-(--composer) shadow-none transition-colors ${composerDragActive ? "outline outline-1 outline-(--accent)/50" : ""}`}
         >
           {" "}
           {composerDragActive ? (
@@ -802,7 +802,7 @@ export function ChatPane({
             }
             className="min-h-[42px] max-h-[132px] w-full resize-none overflow-y-auto bg-transparent px-4 py-2.5 text-sm leading-5 text-(--fg) outline-none placeholder:text-(--dim)"
           />
-          <div className="flex min-h-10 items-center gap-1.5 bg-transparent px-3 pb-2 pt-1 text-xs">
+          <div className="agent-composer-actions-row flex min-h-10 items-center gap-1.5 bg-transparent px-3 pb-2 pt-1 text-xs">
             {" "}
             <input
               ref={fileInputRef}
@@ -854,8 +854,8 @@ export function ChatPane({
             >
               <Code2 className="h-3.5 w-3.5" />
             </button>{" "}
-            <div className="ml-auto flex shrink-0 items-center gap-1">
-              {modelSelector}{" "}
+            <div className="ml-auto flex min-w-0 shrink items-center gap-1">
+              <div className="agent-model-slot min-w-0 shrink">{modelSelector}</div>{" "}
               {running ? (
                 <>
                   {" "}
@@ -923,9 +923,9 @@ export function ChatPane({
             </div>
           </div>{" "}
         </div>
-        <div className="relative z-20 mx-auto mt-0.5 flex max-w-[var(--composer-w)] items-center gap-2 overflow-visible font-mono text-[10px] text-(--dim)">
+        <div className="agent-composer-meta relative z-20 mx-auto mt-0.5 flex max-w-[var(--composer-w)] flex-wrap items-center gap-x-2 gap-y-0.5 overflow-hidden font-mono text-[10px] text-(--dim)">
           {" "}
-          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-visible">
+          <div className="agent-composer-meta-main flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             <button
               type="button"
               onClick={() => void compactSession()}
@@ -938,7 +938,7 @@ export function ChatPane({
               compact{" "}
             </button>
             <span className="shrink-0 text-(--border)">·</span>{" "}
-            <div className="min-w-0 max-w-[42%] shrink overflow-visible">
+            <div className="agent-composer-project min-w-0 max-w-[42%] shrink overflow-hidden">
               {projectSelector ? (
                 projectSelector
               ) : cwd ? (
@@ -948,7 +948,7 @@ export function ChatPane({
               ) : null}{" "}
             </div>
             {gitBranch ? (
-              <span className="inline-flex min-w-0 shrink items-center gap-1 text-(--dim)">
+              <span className="agent-composer-branch inline-flex min-w-0 shrink items-center gap-1 text-(--dim)">
                 <GitBranchIcon className="h-3 w-3 shrink-0" />{" "}
                 <span className="truncate">{gitBranch}</span>
               </span>
@@ -965,7 +965,7 @@ export function ChatPane({
               </button>
             ) : null}{" "}
             {gitSummary?.isRepo ? (
-              <span className="inline-flex shrink-0 items-center gap-1">
+              <span className="agent-composer-git-summary inline-flex min-w-0 shrink items-center gap-1 overflow-hidden">
                 {" "}
                 <span className="text-emerald-400">+{gitSummary.additions}</span>
                 <span className="text-red-400">-{gitSummary.deletions}</span>{" "}
@@ -975,7 +975,7 @@ export function ChatPane({
               </span>
             ) : null}
           </div>{" "}
-          <div className="flex shrink-0 items-center justify-end gap-2">
+          <div className="agent-composer-tokens flex shrink-0 items-center justify-end gap-2">
             <span>R {formatTokenCount(activeTab?.tokenStats?.read ?? 0)}</span>{" "}
             <span>W {formatTokenCount(activeTab?.tokenStats?.write ?? 0)}</span>
             <span>

--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -10,7 +10,7 @@ import {
   type DragEvent,
   type ReactNode,
 } from "react";
-import { Loader2 } from "lucide-react";
+import { Code2, Loader2 } from "lucide-react";
 import {
   AttachIcon,
   ChevronDownIcon,
@@ -814,6 +814,21 @@ export function ChatPane({
                 <GlobeIcon className="h-3.5 w-3.5" />
                 {computerUseLoaded ? <ComputerUseActivityDot /> : null}{" "}
               </span>
+            </button>{" "}
+            <button
+              type="button"
+              onClick={tools.toggleCanvas}
+              aria-pressed={tools.computer.canvasEnabled}
+              title={
+                tools.computer.canvasEnabled
+                  ? "Canvas: ON — shared scratchboard is visible in Computer"
+                  : "Canvas: OFF — click to open a shared scratchboard in Computer"
+              }
+              className={`inline-flex !h-7 !min-h-7 !w-7 !min-w-7 shrink-0 items-center justify-center rounded-md ${
+                tools.computer.canvasEnabled ? "text-(--accent)" : "text-(--dim) hover:text-(--fg)"
+              }`}
+            >
+              <Code2 className="h-3.5 w-3.5" />
             </button>{" "}
             <div className="ml-auto flex shrink-0 items-center gap-1">
               {modelSelector}{" "}

--- a/frontend/src/app/agent/_components/filesystem-panel.tsx
+++ b/frontend/src/app/agent/_components/filesystem-panel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FormEvent, useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import {
   ChevronRight,
@@ -8,10 +8,9 @@ import {
   File,
   Folder,
   Monitor,
-  MessageSquare,
   Minus,
+  PanelLeftOpen,
   Plus,
-  Trash2,
 } from "lucide-react";
 import hljs from "highlight.js";
 import { useAppStore } from "@/store";
@@ -187,7 +186,7 @@ function TreeFileList({
               )}
               <button
                 type="button"
-                onClick={() => onOpen(entry)}
+                onClick={() => (isDir ? onToggleDir(entry.rel) : onOpen(entry))}
                 title={entry.rel}
                 className="flex min-w-0 flex-1 items-center gap-1 text-left"
               >
@@ -297,9 +296,7 @@ export function FilesystemPanel({ cwd }: Props) {
   );
   const openEntry = useCallback(
     (entry: FsEntry) => {
-      if (entry.kind === "directory") {
-        setRelPath(entry.rel);
-      } else {
+      if (entry.kind !== "directory") {
         setOpenFile(entry.rel);
         if (cwd) setLastOpenFileByProject(cwd, entry.rel);
       }
@@ -323,49 +320,8 @@ export function FilesystemPanel({ cwd }: Props) {
     },
     [dirChildren, fetchDirChildren],
   );
-  const goUp = useCallback(() => {
-    if (!relPath) return;
-    const trimmed = relPath.replace(/\/$/, "");
-    const idx = trimmed.lastIndexOf("/");
-    setRelPath(idx === -1 ? "" : trimmed.slice(0, idx));
-  }, [relPath]);
   const lines = useMemo(() => fileContent.split("\n"), [fileContent]);
   const previewKind = useMemo(() => (openFile ? previewKindForPath(openFile) : null), [openFile]);
-  const commentsByLine = useMemo(() => {
-    const map = new Map<number, Comment[]>();
-    for (const c of comments) {
-      const list = map.get(c.line) ?? [];
-      list.push(c);
-      map.set(c.line, list);
-    }
-    return map;
-  }, [comments]);
-  const addComment = useCallback(
-    async (line: number, body: string) => {
-      if (!cwd || !openFile) return;
-      const response = await fetch("/api/agent/comments", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cwd, path: openFile, line, body }),
-      });
-      const payload = (await response.json()) as { comment?: Comment; error?: string };
-      if (response.ok && payload.comment) {
-        setComments((current) => [...current, payload.comment as Comment]);
-      }
-    },
-    [cwd, openFile],
-  );
-  const removeComment = useCallback(
-    async (id: string) => {
-      if (!cwd || !openFile) return;
-      await fetch(
-        `/api/agent/comments?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(openFile)}&id=${encodeURIComponent(id)}`,
-        { method: "DELETE" },
-      );
-      setComments((current) => current.filter((c) => c.id !== id));
-    },
-    [cwd, openFile],
-  );
   if (!cwd) {
     return (
       <div className="flex h-full items-center justify-center text-center text-[11px] text-(--dim)">
@@ -374,7 +330,7 @@ export function FilesystemPanel({ cwd }: Props) {
     );
   }
   return (
-    <div className="flex h-full min-h-0">
+    <div className="relative flex h-full min-h-0">
       {" "}
       {fileListOpen ? (
         <div className="flex w-[200px] shrink-0 flex-col border-r border-(--border)">
@@ -382,7 +338,7 @@ export function FilesystemPanel({ cwd }: Props) {
           <div className="flex h-7 shrink-0 items-center border-b border-(--border)">
             <div className="min-w-0 flex-1">
               {" "}
-              <Breadcrumb relPath={relPath} onUp={goUp} onRoot={() => setRelPath("")} />
+              <Breadcrumb relPath={relPath} onRoot={() => setRelPath("")} />
             </div>{" "}
             <button
               type="button"
@@ -433,20 +389,18 @@ export function FilesystemPanel({ cwd }: Props) {
             )}
           </div>{" "}
         </div>
-      ) : (
-        <div className="flex w-8 shrink-0 justify-center border-r border-(--border) pt-1">
-          <button
-            type="button"
-            onClick={() => setFileListOpen(true)}
-            className="h-6 rounded p-1 text-(--dim) hover:bg-(--surface) hover:text-(--fg)"
-            title="Show file list"
-            aria-label="Show file list"
-          >
-            {" "}
-            <Plus className="h-3.5 w-3.5" />
-          </button>{" "}
-        </div>
-      )}
+      ) : null}
+      {!fileListOpen ? (
+        <button
+          type="button"
+          onClick={() => setFileListOpen(true)}
+          className="absolute left-2 top-2 z-20 inline-flex h-7 w-7 items-center justify-center rounded-md border border-(--border) bg-(--surface) text-(--fg) shadow-[0_4px_16px_rgba(0,0,0,0.35)] hover:bg-(--hover)"
+          title="Show file list"
+          aria-label="Show file list"
+        >
+          <PanelLeftOpen className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
       <div className="flex min-w-0 flex-1 flex-col">
         {" "}
         {!openFile ? (
@@ -515,15 +469,7 @@ export function FilesystemPanel({ cwd }: Props) {
             {previewKind && viewMode === "preview" ? (
               <RenderedPreview content={fileContent} kind={previewKind} />
             ) : (
-              <FileViewer
-                key={openFile}
-                filePath={openFile}
-                lines={lines}
-                commentsByLine={commentsByLine}
-                onAddComment={addComment}
-                onRemoveComment={removeComment}
-                fontSize={fontSize}
-              />
+              <FileViewer key={openFile} filePath={openFile} lines={lines} fontSize={fontSize} />
             )}
           </>
         )}
@@ -532,15 +478,7 @@ export function FilesystemPanel({ cwd }: Props) {
   );
 }
 
-function Breadcrumb({
-  relPath,
-  onUp,
-  onRoot,
-}: {
-  relPath: string;
-  onUp: () => void;
-  onRoot: () => void;
-}) {
+function Breadcrumb({ relPath, onRoot }: { relPath: string; onRoot: () => void }) {
   const parts = relPath ? relPath.split("/").filter(Boolean) : [];
   return (
     <div className="flex h-7 shrink-0 items-center gap-0.5 overflow-x-auto px-2 text-[11px] text-(--dim)">
@@ -560,16 +498,6 @@ function Breadcrumb({
           {i < parts.length - 1 && <ChevronRight className="h-3 w-3 shrink-0 text-(--dim)" />}
         </span>
       ))}
-      <button
-        type="button"
-        onClick={onUp}
-        className="ml-auto shrink-0 rounded px-1 text-[10px] text-(--dim) hover:bg-(--surface) hover:text-(--fg)"
-        title="Go up"
-        aria-label="Go up"
-      >
-        {" "}
-        ⬆
-      </button>{" "}
     </div>
   );
 }
@@ -594,20 +522,12 @@ function RenderedPreview({ content, kind }: { content: string; kind: "html" | "j
 function FileViewer({
   filePath,
   lines,
-  commentsByLine,
-  onAddComment,
-  onRemoveComment,
   fontSize,
 }: {
   filePath: string;
   lines: string[];
-  commentsByLine: Map<number, Comment[]>;
-  onAddComment: (line: number, body: string) => Promise<void>;
-  onRemoveComment: (id: string) => Promise<void>;
   fontSize: number;
 }) {
-  const [composerLine, setComposerLine] = useState<number | null>(null);
-  const [composerValue, setComposerValue] = useState("");
   const highlightedLines = useMemo(() => {
     const lang = languageForPath(filePath);
     if (!lang) return null;
@@ -618,35 +538,15 @@ function FileViewer({
       return null;
     }
   }, [filePath, lines]);
-  const submit = useCallback(
-    async (event: FormEvent) => {
-      event.preventDefault();
-      if (composerLine === null) return;
-      const value = composerValue.trim();
-      if (!value) return;
-      await onAddComment(composerLine, value);
-      setComposerLine(null);
-      setComposerValue("");
-    },
-    [composerLine, composerValue, onAddComment],
-  );
   const lineHeight = Math.round(fontSize * 1.5);
   const renderLine = useCallback(
     (index: number) => {
       const lineNumber = index + 1;
       const text = lines[index] ?? "";
-      const lineComments = commentsByLine.get(lineNumber) ?? [];
-      const composerOpen = composerLine === lineNumber;
       const html = highlightedLines?.[index];
       return (
         <div className="group flex flex-col">
-          <div
-            onClick={() => {
-              setComposerLine(lineNumber);
-              setComposerValue("");
-            }}
-            className="flex cursor-text gap-1 px-1 hover:bg-(--surface)"
-          >
+          <div className="flex gap-1 px-1 hover:bg-(--surface)">
             {" "}
             <span
               className="w-8 shrink-0 select-none text-right font-mono text-(--dim)"
@@ -668,89 +568,11 @@ function FileViewer({
                 {text || "\u00a0"}
               </pre>
             )}{" "}
-            {lineComments.length > 0 ? (
-              <span className="ml-1 inline-flex shrink-0 items-center gap-0.5 rounded border border-(--border) px-1 font-mono text-[9px] text-(--dim)">
-                {" "}
-                <MessageSquare className="h-2 w-2" />
-                {lineComments.length}{" "}
-              </span>
-            ) : null}{" "}
           </div>
-          {lineComments.length > 0 ? (
-            <div className="ml-10 mr-2 mb-0.5 flex flex-col gap-1 border-l-2 border-(--border) pl-2">
-              {" "}
-              {lineComments.map((c) => (
-                <div key={c.id} className="flex items-start gap-1 text-[11px] text-(--fg)">
-                  {" "}
-                  <span className="flex-1 whitespace-pre-wrap">{c.body}</span>
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      void onRemoveComment(c.id);
-                    }}
-                    className="rounded p-0.5 text-(--dim) opacity-0 hover:bg-(--surface) hover:text-(--err) group-hover:opacity-100"
-                    title="Delete comment"
-                    aria-label="Delete comment"
-                  >
-                    <Trash2 className="h-2.5 w-2.5" />{" "}
-                  </button>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          {composerOpen ? (
-            <form
-              onSubmit={submit}
-              onClick={(event) => event.stopPropagation()}
-              className="ml-10 mr-2 mb-0.5 rounded border border-(--border) bg-(--surface) p-1.5"
-            >
-              {" "}
-              <textarea
-                value={composerValue}
-                onChange={(event) => setComposerValue(event.target.value)}
-                autoFocus
-                rows={2}
-                placeholder={`Comment on line ${lineNumber}…`}
-                className="w-full resize-none bg-transparent text-[11px] leading-5 text-(--fg) outline-none"
-              />
-              <div className="flex items-center justify-end gap-1">
-                {" "}
-                <button
-                  type="button"
-                  onClick={() => {
-                    setComposerLine(null);
-                    setComposerValue("");
-                  }}
-                  className="h-5 rounded px-1.5 text-[10px] text-(--dim) hover:bg-(--bg) hover:text-(--fg)"
-                >
-                  {" "}
-                  Cancel
-                </button>{" "}
-                <button
-                  type="submit"
-                  className="h-5 rounded bg-(--fg) px-1.5 text-[10px] font-medium text-(--bg) disabled:opacity-30"
-                  disabled={!composerValue.trim()}
-                >
-                  Add{" "}
-                </button>
-              </div>{" "}
-            </form>
-          ) : null}{" "}
         </div>
       );
     },
-    [
-      lines,
-      highlightedLines,
-      commentsByLine,
-      composerLine,
-      composerValue,
-      onRemoveComment,
-      submit,
-      fontSize,
-      lineHeight,
-    ],
+    [lines, highlightedLines, fontSize, lineHeight],
   );
   if (lines.length < 2000) {
     return (

--- a/frontend/src/app/agent/_components/git-diff-panel.tsx
+++ b/frontend/src/app/agent/_components/git-diff-panel.tsx
@@ -18,6 +18,7 @@ export function GitDiffPanel({ cwd }: { cwd: string | null }) {
   const [loading, setLoading] = useState(false);
   const [draftBranch, setDraftBranch] = useState("");
   const [commitMessage, setCommitMessage] = useState("");
+  const [viewMode, setViewMode] = useState<"unified" | "side-by-side" | "stacked">("unified");
 
   const load = useCallback(async () => {
     if (!cwd) return setPayload(null);
@@ -69,6 +70,8 @@ export function GitDiffPanel({ cwd }: { cwd: string | null }) {
       <GitDiffPanelBody
         cwd={cwd}
         files={files}
+        viewMode={viewMode}
+        onViewMode={setViewMode}
         initGit={() => run({ action: "init" })}
         loading={loading}
         payload={payload}
@@ -230,12 +233,16 @@ function RefSelect({
 function GitDiffPanelBody({
   cwd,
   files,
+  viewMode,
+  onViewMode,
   initGit,
   loading,
   payload,
 }: {
   cwd: string | null;
   files: DiffFile[];
+  viewMode: "unified" | "side-by-side" | "stacked";
+  onViewMode: (mode: "unified" | "side-by-side" | "stacked") => void;
   initGit: () => Promise<void>;
   loading: boolean;
   payload: (Partial<GitState> & { error?: string }) | null;
@@ -255,7 +262,7 @@ function GitDiffPanelBody({
   if (payload?.isRepo === false) return <InitializeGitPanel initGit={initGit} loading={loading} />;
   if (files.length === 0)
     return <EmptyDiffPanel loading={loading} status={payload?.status ?? []} />;
-  return <DiffFileList files={files} />;
+  return <DiffFileList files={files} viewMode={viewMode} onViewMode={onViewMode} />;
 }
 
 function InitializeGitPanel({
@@ -293,9 +300,31 @@ function EmptyDiffPanel({ loading, status }: { loading: boolean; status: string[
   );
 }
 
-function DiffFileList({ files }: { files: DiffFile[] }) {
+function DiffFileList({
+  files,
+  viewMode,
+  onViewMode,
+}: {
+  files: DiffFile[];
+  viewMode: "unified" | "side-by-side" | "stacked";
+  onViewMode: (mode: "unified" | "side-by-side" | "stacked") => void;
+}) {
   return (
     <div className="min-h-0 flex-1 overflow-auto p-2 font-mono text-[11px] leading-5">
+      <div className="sticky top-0 z-10 mb-2 flex items-center justify-end gap-1 bg-(--bg)/95 py-1">
+        <DiffModeButton active={viewMode === "unified"} onClick={() => onViewMode("unified")}>
+          Unified
+        </DiffModeButton>
+        <DiffModeButton
+          active={viewMode === "side-by-side"}
+          onClick={() => onViewMode("side-by-side")}
+        >
+          Side by side
+        </DiffModeButton>
+        <DiffModeButton active={viewMode === "stacked"} onClick={() => onViewMode("stacked")}>
+          Top / bottom
+        </DiffModeButton>
+      </div>
       <div className="flex flex-col gap-2">
         {files.map((file, fileIndex) => (
           <details
@@ -313,24 +342,154 @@ function DiffFileList({ files }: { files: DiffFile[] }) {
                 <span className="text-red-400">-{file.deletions}</span>
               </span>
             </summary>
-            <div className="min-w-max">
-              {file.lines.map((line, index) => (
-                <div
-                  key={`${file.path}-${index}`}
-                  className={`grid grid-cols-[3rem_3rem_1fr] gap-2 border-b border-(--border)/20 px-2 ${diffLineClassName(line.kind)}`}
-                >
-                  <span className="select-none text-right text-(--dim)">{line.oldLine ?? ""}</span>
-                  <span className="select-none text-right text-(--dim)">{line.newLine ?? ""}</span>
-                  <span className="whitespace-pre">
-                    {diffLinePrefix(line.kind)}
-                    {line.text}
-                  </span>
-                </div>
-              ))}
-            </div>
+            {viewMode === "side-by-side" ? (
+              <SideBySideDiff file={file} />
+            ) : viewMode === "stacked" ? (
+              <StackedDiff file={file} />
+            ) : (
+              <UnifiedDiff file={file} />
+            )}
           </details>
         ))}
       </div>
     </div>
   );
+}
+
+function DiffModeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-6 rounded px-2 text-[10px] ${
+        active ? "bg-(--surface) text-(--fg)" : "text-(--dim) hover:text-(--fg)"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function UnifiedDiff({ file }: { file: DiffFile }) {
+  return (
+    <div className="min-w-max">
+      {file.lines.map((line, index) => (
+        <div
+          key={`${file.path}-${index}`}
+          className={`grid grid-cols-[3rem_3rem_1fr] gap-2 border-b border-(--border)/20 px-2 ${diffLineClassName(line.kind)}`}
+        >
+          <span className="select-none text-right text-(--dim)">{line.oldLine ?? ""}</span>
+          <span className="select-none text-right text-(--dim)">{line.newLine ?? ""}</span>
+          <span className="whitespace-pre">
+            {diffLinePrefix(line.kind)}
+            {line.text}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SideBySideDiff({ file }: { file: DiffFile }) {
+  const rows = pairDiffLines(file);
+  return (
+    <div className="min-w-[52rem]">
+      {rows.map((row, index) => (
+        <div
+          key={`${file.path}-pair-${index}`}
+          className="grid grid-cols-2 border-b border-(--border)/20"
+        >
+          <DiffCell line={row.left} side="old" />
+          <DiffCell line={row.right} side="new" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StackedDiff({ file }: { file: DiffFile }) {
+  const oldLines = file.lines.filter((line) => line.kind !== "add");
+  const newLines = file.lines.filter((line) => line.kind !== "del");
+  return (
+    <div className="grid gap-2 p-2">
+      <div className="rounded border border-red-500/20">
+        <div className="border-b border-red-500/20 px-2 py-1 text-[10px] uppercase tracking-wide text-red-300">
+          Before
+        </div>
+        {oldLines.map((line, index) => (
+          <DiffStackLine key={`${file.path}-old-${index}`} line={line} />
+        ))}
+      </div>
+      <div className="rounded border border-emerald-500/20">
+        <div className="border-b border-emerald-500/20 px-2 py-1 text-[10px] uppercase tracking-wide text-emerald-300">
+          After
+        </div>
+        {newLines.map((line, index) => (
+          <DiffStackLine key={`${file.path}-new-${index}`} line={line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DiffCell({ line, side }: { line?: DiffFile["lines"][number]; side: "old" | "new" }) {
+  if (!line) {
+    return <div className="min-h-5 border-r border-(--border)/20 bg-(--surface)/20" />;
+  }
+  const lineNumber = side === "old" ? line.oldLine : line.newLine;
+  return (
+    <div
+      className={`grid grid-cols-[3rem_1fr] gap-2 border-r border-(--border)/20 px-2 ${diffLineClassName(line.kind)}`}
+    >
+      <span className="select-none text-right text-(--dim)">{lineNumber ?? ""}</span>
+      <span className="whitespace-pre">
+        {diffLinePrefix(line.kind)}
+        {line.text}
+      </span>
+    </div>
+  );
+}
+
+function DiffStackLine({ line }: { line: DiffFile["lines"][number] }) {
+  return (
+    <div className={`grid grid-cols-[3rem_1fr] gap-2 px-2 ${diffLineClassName(line.kind)}`}>
+      <span className="select-none text-right text-(--dim)">
+        {line.kind === "del" ? line.oldLine : (line.newLine ?? line.oldLine ?? "")}
+      </span>
+      <span className="whitespace-pre">
+        {diffLinePrefix(line.kind)}
+        {line.text}
+      </span>
+    </div>
+  );
+}
+
+function pairDiffLines(file: DiffFile): Array<{
+  left?: DiffFile["lines"][number];
+  right?: DiffFile["lines"][number];
+}> {
+  const rows: Array<{ left?: DiffFile["lines"][number]; right?: DiffFile["lines"][number] }> = [];
+  const pendingDeletes: DiffFile["lines"] = [];
+  for (const line of file.lines) {
+    if (line.kind === "del") {
+      pendingDeletes.push(line);
+      continue;
+    }
+    if (line.kind === "add") {
+      rows.push({ left: pendingDeletes.shift(), right: line });
+      continue;
+    }
+    while (pendingDeletes.length > 0) rows.push({ left: pendingDeletes.shift() });
+    rows.push({ left: line, right: line });
+  }
+  while (pendingDeletes.length > 0) rows.push({ left: pendingDeletes.shift() });
+  return rows;
 }

--- a/frontend/src/app/agent/_components/terminal-panel.tsx
+++ b/frontend/src/app/agent/_components/terminal-panel.tsx
@@ -1,17 +1,10 @@
 "use client";
 
 import { useRef } from "react";
-import type { Terminal as XTerm } from "@xterm/xterm";
-import type { FitAddon } from "@xterm/addon-fit";
-import { useTerminalPanelEffects } from "@/hooks/agent/use-terminal-panel-effects";
-
-type TerminalRefs = {
-  term: XTerm | null;
-  fit: FitAddon | null;
-  input: string;
-  running: boolean;
-  disposed: boolean;
-};
+import {
+  useTerminalPanelEffects,
+  type TerminalRefs,
+} from "@/hooks/agent/use-terminal-panel-effects";
 
 export function TerminalPanel({ cwd }: { cwd: string | null }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -29,6 +22,9 @@ export function TerminalPanel({ cwd }: { cwd: string | null }) {
     <section className="flex min-h-0 flex-1 flex-col bg-[#070707]">
       <div
         ref={containerRef}
+        tabIndex={0}
+        onMouseDown={() => stateRef.current.term?.focus()}
+        onClick={() => stateRef.current.term?.focus()}
         className="min-h-0 flex-1 overflow-hidden p-2 [--xterm-color-background:#070707]"
       />
     </section>

--- a/frontend/src/app/agent/_components/terminal-panel.tsx
+++ b/frontend/src/app/agent/_components/terminal-panel.tsx
@@ -1,90 +1,36 @@
 "use client";
 
-import { FormEvent, useState } from "react";
-import type { TerminalRunResult } from "@/lib/agent/contracts/terminal";
+import { useRef } from "react";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
+import { useTerminalPanelEffects } from "@/hooks/agent/use-terminal-panel-effects";
 
-type Entry = TerminalRunResult & { id: string };
+type TerminalRefs = {
+  term: XTerm | null;
+  fit: FitAddon | null;
+  input: string;
+  running: boolean;
+  disposed: boolean;
+};
 
 export function TerminalPanel({ cwd }: { cwd: string | null }) {
-  const [command, setCommand] = useState("pwd");
-  const [running, setRunning] = useState(false);
-  const [entries, setEntries] = useState<Entry[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stateRef = useRef<TerminalRefs>({
+    term: null,
+    fit: null,
+    input: "",
+    running: false,
+    disposed: false,
+  });
 
-  async function run(event: FormEvent) {
-    event.preventDefault();
-    if (!cwd || !command.trim() || running) return;
-    setRunning(true);
-    try {
-      const response = await fetch(`/api/agent/terminal?cwd=${encodeURIComponent(cwd)}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ command: command.trim() }),
-      });
-      const payload = (await response.json()) as TerminalRunResult;
-      setEntries((current) => [{ ...payload, id: crypto.randomUUID() }, ...current].slice(0, 20));
-    } catch (error) {
-      setEntries((current) => [
-        {
-          id: crypto.randomUUID(),
-          ok: false,
-          command,
-          stdout: "",
-          stderr: "",
-          exitCode: null,
-          error: error instanceof Error ? error.message : "Command failed",
-        },
-        ...current,
-      ]);
-    } finally {
-      setRunning(false);
-    }
-  }
+  useTerminalPanelEffects({ containerRef, cwd, stateRef });
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col">
-      <form onSubmit={run} className="flex shrink-0 gap-2 border-b border-(--border) p-2 text-xs">
-        <input
-          value={command}
-          onChange={(event) => setCommand(event.target.value)}
-          disabled={!cwd || running}
-          className="h-8 min-w-0 flex-1 rounded border border-(--border) bg-(--bg) px-2 font-mono text-(--fg) outline-none disabled:opacity-45"
-          placeholder={cwd ? "command" : "Choose a project first"}
-        />
-        <button
-          type="submit"
-          disabled={!cwd || running || !command.trim()}
-          className="h-8 rounded border border-(--border) px-3 text-(--fg) disabled:opacity-40"
-        >
-          {running ? "Running" : "Run"}
-        </button>
-      </form>
-      <div className="min-h-0 flex-1 overflow-auto p-2 font-mono text-[11px] leading-5">
-        {entries.length === 0 ? (
-          <div className="p-2 text-(--dim)">No terminal commands yet.</div>
-        ) : null}
-        {entries.map((entry) => (
-          <details
-            key={entry.id}
-            open
-            className="mb-2 rounded border border-(--border) bg-(--surface)/35"
-          >
-            <summary className="cursor-pointer px-2 py-1 text-(--fg)">
-              <span className={entry.ok ? "text-emerald-400" : "text-red-400"}>
-                {entry.ok ? "$" : `!${entry.exitCode ?? ""}`}
-              </span>{" "}
-              {entry.command}
-            </summary>
-            {entry.stdout ? (
-              <pre className="whitespace-pre-wrap px-2 pb-1 text-(--fg)">{entry.stdout}</pre>
-            ) : null}
-            {entry.stderr || entry.error ? (
-              <pre className="whitespace-pre-wrap px-2 pb-2 text-red-300">
-                {entry.stderr || entry.error}
-              </pre>
-            ) : null}
-          </details>
-        ))}
-      </div>
+    <section className="flex min-h-0 flex-1 flex-col bg-[#070707]">
+      <div
+        ref={containerRef}
+        className="min-h-0 flex-1 overflow-hidden p-2 [--xterm-color-background:#070707]"
+      />
     </section>
   );
 }

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
@@ -56,6 +56,56 @@ describe("groupAssistantBlocks", () => {
 });
 
 describe("SessionPaneBlockRouter", () => {
+  it("renders sent image, video, and PDF attachments inside the user bubble", () => {
+    const message: ChatMessage = {
+      id: "user",
+      role: "user",
+      text: "look at these",
+      attachments: [
+        {
+          id: "image",
+          name: "image.png",
+          type: "image/png",
+          size: 123,
+          mode: "metadata",
+          content: "",
+          previewKind: "image",
+          previewUrl: "blob:image",
+        },
+        {
+          id: "video",
+          name: "clip.mp4",
+          type: "video/mp4",
+          size: 456,
+          mode: "metadata",
+          content: "",
+          previewKind: "video",
+          previewUrl: "blob:video",
+        },
+        {
+          id: "pdf",
+          name: "paper.pdf",
+          type: "application/pdf",
+          size: 789,
+          mode: "metadata",
+          content: "",
+          previewKind: "pdf",
+          previewUrl: "blob:pdf",
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(<SessionPaneBlockRouter message={message} />);
+
+    expect(html).toContain("look at these");
+    expect(html).toContain("<img");
+    expect(html).toContain("<video");
+    expect(html).toContain("<iframe");
+    expect(html).toContain("image.png");
+    expect(html).toContain("clip.mp4");
+    expect(html).toContain("paper.pdf");
+  });
+
   it("keeps mixed reasoning and finished tools collapsed as a preview", () => {
     const message: ChatMessage = {
       id: "assistant",

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
@@ -81,6 +81,33 @@ describe("SessionPaneBlockRouter", () => {
     expect(html).not.toContain("private plan text");
   });
 
+  it("keeps running reasoning and tools collapsed behind a status preview", () => {
+    const message: ChatMessage = {
+      id: "assistant",
+      role: "assistant",
+      text: "",
+      blocks: [
+        { kind: "thinking", id: "think-1", text: "noisy live reasoning" },
+        {
+          kind: "tool",
+          id: "tool-1",
+          name: "bash",
+          status: "running",
+          text: "",
+          args: { cmd: "ssh -i ~/.ssh/linux-ai ser@100.90.62.80 'nvidia-smi'" },
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(<SessionPaneBlockRouter message={message} />);
+
+    expect(html).toContain("Reasoning + 1 tool");
+    expect(html).toContain("running");
+    expect(html).toContain("ssh -i");
+    expect(html).not.toContain("noisy live reasoning");
+    expect(html).not.toContain("Ran command");
+  });
+
   it("renders collapsed tool group previews without mounting completed tool details", () => {
     const message: ChatMessage = {
       id: "assistant",

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.test.tsx
@@ -56,6 +56,31 @@ describe("groupAssistantBlocks", () => {
 });
 
 describe("SessionPaneBlockRouter", () => {
+  it("keeps mixed reasoning and finished tools collapsed as a preview", () => {
+    const message: ChatMessage = {
+      id: "assistant",
+      role: "assistant",
+      text: "",
+      blocks: [
+        { kind: "thinking", id: "think-1", text: "private plan text" },
+        {
+          kind: "tool",
+          id: "tool-1",
+          name: "read_file",
+          status: "done",
+          text: "",
+          args: { path: "src/app.ts" },
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(<SessionPaneBlockRouter message={message} />);
+
+    expect(html).toContain("Reasoning + 1 tool");
+    expect(html).toContain("read app.ts");
+    expect(html).not.toContain("private plan text");
+  });
+
   it("renders collapsed tool group previews without mounting completed tool details", () => {
     const message: ChatMessage = {
       id: "assistant",

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { FileIcon } from "@/components/icons";
 import type {
   AssistantBlock,
+  ChatMessageAttachment,
   ChatMessage,
   EventBlock,
   TextBlock,
@@ -93,7 +95,14 @@ export function SessionPaneBlockRouter({ message }: { message: ChatMessage }) {
     return (
       <article className="flex justify-end">
         <div className="max-w-[72%] rounded-xl bg-(--surface) px-3.5 py-2 text-sm leading-6 text-(--fg)">
-          <div className="whitespace-pre-wrap break-words">{message.text}</div>
+          {message.text ? (
+            <div className="whitespace-pre-wrap break-words">{message.text}</div>
+          ) : null}
+          {message.attachments?.length ? (
+            <div className={message.text ? "mt-2" : ""}>
+              <UserMessageAttachments attachments={message.attachments} />
+            </div>
+          ) : null}
         </div>
       </article>
     );
@@ -118,6 +127,76 @@ export function SessionPaneBlockRouter({ message }: { message: ChatMessage }) {
         </div>
       )}
     </article>
+  );
+}
+
+function formatAttachmentSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function UserMessageAttachments({ attachments }: { attachments: ChatMessageAttachment[] }) {
+  return (
+    <div className={messageAttachmentsClassName(attachments.length)}>
+      {attachments.map((attachment) => (
+        <UserMessageAttachmentPreview key={attachment.id} attachment={attachment} />
+      ))}
+    </div>
+  );
+}
+
+function messageAttachmentsClassName(count: number) {
+  const base = "grid gap-2";
+  return count > 1 ? `${base} sm:grid-cols-2` : base;
+}
+
+function UserMessageAttachmentPreview({ attachment }: { attachment: ChatMessageAttachment }) {
+  const label = `${attachment.name} · ${attachment.type || "file"} · ${formatAttachmentSize(attachment.size)}`;
+  const previewUrl = attachment.previewUrl;
+  if (attachment.previewKind === "image" && previewUrl) {
+    return (
+      <figure className="min-w-0 overflow-hidden rounded-lg bg-black/20">
+        <img
+          src={previewUrl}
+          alt={attachment.name}
+          className="max-h-[360px] w-full object-contain"
+        />
+        <figcaption className="truncate px-2 py-1.5 text-[11px] leading-4 text-(--dim)">
+          {label}
+        </figcaption>
+      </figure>
+    );
+  }
+  if (attachment.previewKind === "video" && previewUrl) {
+    return (
+      <figure className="min-w-0 overflow-hidden rounded-lg bg-black/20">
+        <video src={previewUrl} controls playsInline className="max-h-[360px] w-full bg-black" />
+        <figcaption className="truncate px-2 py-1.5 text-[11px] leading-4 text-(--dim)">
+          {label}
+        </figcaption>
+      </figure>
+    );
+  }
+  if (attachment.previewKind === "pdf" && previewUrl) {
+    return (
+      <figure className="min-w-0 overflow-hidden rounded-lg bg-black/20">
+        <iframe
+          src={previewUrl}
+          title={attachment.name}
+          className="h-[360px] w-full border-0 bg-(--bg)"
+        />
+        <figcaption className="truncate px-2 py-1.5 text-[11px] leading-4 text-(--dim)">
+          {label}
+        </figcaption>
+      </figure>
+    );
+  }
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-lg bg-black/20 px-2.5 py-2 text-[12px] leading-5 text-(--dim)">
+      <FileIcon className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </div>
   );
 }
 

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -238,9 +238,9 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
         <div className="mt-1.5 flex min-w-0 flex-col gap-2">
           {segments.map((segment) =>
             segment.kind === "reasoning" ? (
-              <ReasoningGroup key={segment.id} blocks={segment.blocks} />
+              <ReasoningBlockContent key={segment.id} blocks={segment.blocks} />
             ) : (
-              <ToolCallGroup key={segment.id} blocks={segment.blocks} />
+              <ToolBlockStack key={segment.id} blocks={segment.blocks} />
             ),
           )}
         </div>
@@ -249,23 +249,17 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
   );
 }
 
-function ReasoningGroup({
-  blocks,
-  defaultOpen = false,
-}: {
-  blocks: ThinkingBlock[];
-  defaultOpen?: boolean;
-}) {
+function ReasoningBlockContent({ blocks }: { blocks: ThinkingBlock[] }) {
   const text = blocks.map((block) => block.text).join("\n\n");
   return (
-    <details className="text-xs" open={defaultOpen}>
-      <summary className="cursor-pointer list-none text-[11px] italic text-(--dim) hover:text-(--fg) [&::-webkit-details-marker]:hidden">
+    <div className="text-xs">
+      <div className="text-[11px] italic text-(--dim)">
         Reasoning{blocks.length > 1 ? ` · ${blocks.length}` : ""}
-      </summary>
+      </div>
       <pre className="mt-2 max-w-full whitespace-pre-wrap break-words border-l-2 border-(--border) pl-3 font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
         {text}
       </pre>
-    </details>
+    </div>
   );
 }
 
@@ -279,49 +273,17 @@ function EventBlockView({ block }: { block: EventBlock }) {
   );
 }
 
-function ToolCallGroup({ blocks }: { blocks: ToolBlock[] }) {
-  const hasActiveTool = blocks.some((block) => block.status === "running");
-  const hasError = blocks.some((block) => block.status === "error");
-  const [expanded, setExpanded] = useState(false);
-  const open = expanded;
-  const preview = toolGroupPreview(blocks);
-
+function ToolBlockStack({ blocks }: { blocks: ToolBlock[] }) {
   return (
-    <details className="group min-w-0" open={open}>
-      <summary
-        className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-1.5 py-1 text-[11px] text-(--fg) hover:bg-(--hover) [&::-webkit-details-marker]:hidden"
-        onClick={(event) => {
-          event.preventDefault();
-          setExpanded((value) => !value);
-        }}
-      >
-        <ChevronDown
-          className={`h-3 w-3 shrink-0 text-(--fg)/70 transition-transform ${open ? "rotate-180" : ""}`}
-        />
-        <span className="shrink-0 font-medium text-(--fg)/90">
-          {blocks.length === 1 ? "1 tool" : `${blocks.length} tools`}
-        </span>
-        <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-(--fg)/75">
-          {preview}
-        </span>
-        {hasActiveTool ? (
-          <span className="shrink-0 text-[10px] text-(--accent)">running</span>
-        ) : hasError ? (
-          <span className="shrink-0 text-[10px] text-(--err)">error</span>
-        ) : null}
-      </summary>
-      {open ? (
-        <div className="mt-2 border-l-2 border-(--border) pl-3">
-          {blocks.map((block, index) => (
-            <div key={block.id} className="pb-1.5 last:pb-0">
-              <div className={index === 0 ? "" : "pt-0.5"}>
-                <ToolBlockView block={block} />
-              </div>
-            </div>
-          ))}
+    <div className="border-l-2 border-(--border) pl-3">
+      {blocks.map((block, index) => (
+        <div key={block.id} className="pb-1.5 last:pb-0">
+          <div className={index === 0 ? "" : "pt-0.5"}>
+            <ToolBlockView block={block} />
+          </div>
         </div>
-      ) : null}
-    </details>
+      ))}
+    </div>
   );
 }
 

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -235,7 +235,7 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
         ) : null}
       </summary>
       {open ? (
-        <div className="mt-1.5 flex min-w-0 flex-col gap-2">
+        <div className="ml-[11px] mt-1.5 flex min-w-0 flex-col gap-2 border-l border-(--border) pl-3">
           {segments.map((segment) =>
             segment.kind === "reasoning" ? (
               <ReasoningBlockContent key={segment.id} blocks={segment.blocks} />
@@ -252,11 +252,11 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
 function ReasoningBlockContent({ blocks }: { blocks: ThinkingBlock[] }) {
   const text = blocks.map((block) => block.text).join("\n\n");
   return (
-    <div className="text-xs">
-      <div className="text-[11px] italic text-(--dim)">
+    <div className="text-xs" data-activity-tree-child="reasoning">
+      <div className="text-[11px] italic leading-5 text-(--dim)">
         Reasoning{blocks.length > 1 ? ` · ${blocks.length}` : ""}
       </div>
-      <pre className="mt-2 max-w-full whitespace-pre-wrap break-words border-l-2 border-(--border) pl-3 font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
+      <pre className="mt-1 max-w-full whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-(--dim) [overflow-wrap:anywhere]">
         {text}
       </pre>
     </div>
@@ -275,7 +275,7 @@ function EventBlockView({ block }: { block: EventBlock }) {
 
 function ToolBlockStack({ blocks }: { blocks: ToolBlock[] }) {
   return (
-    <div className="border-l-2 border-(--border) pl-3">
+    <div data-activity-tree-child="tools">
       {blocks.map((block, index) => (
         <div key={block.id} className="pb-1.5 last:pb-0">
           <div className={index === 0 ? "" : "pt-0.5"}>

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -126,14 +126,12 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
     (segment) =>
       segment.kind === "tools" && segment.blocks.some((block) => block.status === "running"),
   );
-  const [expanded, setExpanded] = useState(hasActiveTool);
-  const open = hasActiveTool || expanded;
-
-  if (segments.length === 1) {
-    const [segment] = segments;
-    if (segment.kind === "reasoning") return <ReasoningGroup blocks={segment.blocks} />;
-    return <ToolCallGroup blocks={segment.blocks} />;
-  }
+  const hasError = segments.some(
+    (segment) =>
+      segment.kind === "tools" && segment.blocks.some((block) => block.status === "error"),
+  );
+  const [expanded, setExpanded] = useState(false);
+  const open = expanded;
 
   return (
     <details className="group min-w-0" open={open}>
@@ -153,6 +151,8 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
         </span>
         {hasActiveTool ? (
           <span className="shrink-0 text-[10px] text-(--accent)">running</span>
+        ) : hasError ? (
+          <span className="shrink-0 text-[10px] text-(--err)">error</span>
         ) : null}
       </summary>
       {open ? (
@@ -203,8 +203,8 @@ function EventBlockView({ block }: { block: EventBlock }) {
 function ToolCallGroup({ blocks }: { blocks: ToolBlock[] }) {
   const hasActiveTool = blocks.some((block) => block.status === "running");
   const hasError = blocks.some((block) => block.status === "error");
-  const [expanded, setExpanded] = useState(hasActiveTool);
-  const open = hasActiveTool || expanded;
+  const [expanded, setExpanded] = useState(false);
+  const open = expanded;
   const preview = toolGroupPreview(blocks);
 
   return (

--- a/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
+++ b/frontend/src/app/agent/_components/timeline/session-pane-block-router.tsx
@@ -126,10 +126,7 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
     (segment) =>
       segment.kind === "tools" && segment.blocks.some((block) => block.status === "running"),
   );
-  const isMixed =
-    segments.some((segment) => segment.kind === "reasoning") &&
-    segments.some((segment) => segment.kind === "tools");
-  const [expanded, setExpanded] = useState(isMixed || hasActiveTool);
+  const [expanded, setExpanded] = useState(hasActiveTool);
   const open = hasActiveTool || expanded;
 
   if (segments.length === 1) {
@@ -173,10 +170,16 @@ function AssistantActivityGroup({ segments }: { segments: ActivitySegment[] }) {
   );
 }
 
-function ReasoningGroup({ blocks }: { blocks: ThinkingBlock[] }) {
+function ReasoningGroup({
+  blocks,
+  defaultOpen = false,
+}: {
+  blocks: ThinkingBlock[];
+  defaultOpen?: boolean;
+}) {
   const text = blocks.map((block) => block.text).join("\n\n");
   return (
-    <details className="text-xs" open>
+    <details className="text-xs" open={defaultOpen}>
       <summary className="cursor-pointer list-none text-[11px] italic text-(--dim) hover:text-(--fg) [&::-webkit-details-marker]:hidden">
         Reasoning{blocks.length > 1 ? ` · ${blocks.length}` : ""}
       </summary>
@@ -229,10 +232,9 @@ function ToolCallGroup({ blocks }: { blocks: ToolBlock[] }) {
         ) : null}
       </summary>
       {open ? (
-        <div className="ml-3 mt-1.5 border-l border-(--border)/70 pl-2">
+        <div className="mt-2 border-l-2 border-(--border) pl-3">
           {blocks.map((block, index) => (
-            <div key={block.id} className="relative pb-1.5 last:pb-0">
-              <span className="absolute -left-2 top-4 h-px w-2 bg-(--border)/80" />
+            <div key={block.id} className="pb-1.5 last:pb-0">
               <div className={index === 0 ? "" : "pt-0.5"}>
                 <ToolBlockView block={block} />
               </div>

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.test.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.test.tsx
@@ -42,4 +42,23 @@ describe("ToolBlockView", () => {
     expect(html).toContain("hljs-addition");
     expect(html).toContain("hljs-deletion");
   });
+
+  it("renders git diff output with the same highlighted source treatment", () => {
+    const block: ToolBlock = {
+      kind: "tool",
+      id: "diff-1",
+      name: "git_diff",
+      status: "done",
+      text: "",
+      resultText:
+        "diff --git a/app.ts b/app.ts\n@@ -1 +1 @@\n-const oldValue = 0;\n+const newValue = 1;\n",
+    };
+
+    const html = renderToStaticMarkup(<ToolBlockView block={block} />);
+
+    expect(html).toContain("Git Diff");
+    expect(html).toContain("language-diff");
+    expect(html).toContain("hljs-addition");
+    expect(html).toContain("hljs-deletion");
+  });
 });

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
@@ -248,7 +248,8 @@ function FileWritePreview({
       </div>
       {isHtml && showPreview ? (
         <iframe
-          sandbox=""
+          sandbox="allow-scripts"
+          referrerPolicy="no-referrer"
           srcDoc={body}
           className="h-72 w-full rounded-md border border-(--border) bg-white"
           title={filePath ?? "preview"}

--- a/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
+++ b/frontend/src/app/agent/_components/timeline/tool-block-view.tsx
@@ -233,7 +233,7 @@ function FileWritePreview({
   const sourceLang = fileContent === null && patchContent !== null ? "diff" : lang;
 
   return (
-    <ToolSummary block={block} filePath={filePath} open={block.status === "running"}>
+    <ToolSummary block={block} filePath={filePath} open>
       <div className="mb-1 flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.08em] text-(--dim)">
         <span>{sourceLang || "source"}</span>
         {isHtml ? (
@@ -265,12 +265,35 @@ function FileWritePreview({
   );
 }
 
+function diffPreviewData(block: ToolBlock): string | null {
+  const diffText =
+    extractFromArgs(block.args, block.argsText, ["patch", "diff", "edits"]) ?? block.resultText;
+  if (!diffText) return null;
+  if (block.name.toLowerCase().includes("diff")) return diffText;
+  if (/^(diff --git|@@\s+-|\+\+\+ |--- )/m.test(diffText)) return diffText;
+  return null;
+}
+
+function DiffPreview({ block, diffText }: { block: ToolBlock; diffText: string }) {
+  const filePath = toolArg(block, ["path", "file_path", "filePath", "file", "filename"]);
+  return (
+    <ToolSummary block={block} filePath={filePath} open>
+      <div className="mb-1 text-[10px] uppercase tracking-[0.08em] text-(--dim)">diff</div>
+      <HighlightedToolSource body={diffText} lang="diff" />
+    </ToolSummary>
+  );
+}
+
 export function ToolBlockView({ block }: { block: ToolBlock }) {
   const fileWritePreview = FILE_WRITE_TOOL_NAMES.has(block.name.toLowerCase())
     ? fileWritePreviewData(block)
     : null;
   if (fileWritePreview) {
     return <FileWritePreview block={block} {...fileWritePreview} />;
+  }
+  const diffPreview = diffPreviewData(block);
+  if (diffPreview) {
+    return <DiffPreview block={block} diffText={diffPreview} />;
   }
 
   // Generic fallback (shells, reads, searches, browser tools, etc.).

--- a/frontend/src/app/agent/_components/use-workspace.ts
+++ b/frontend/src/app/agent/_components/use-workspace.ts
@@ -33,7 +33,12 @@ import type { ChatPaneHandle, SessionTab } from "./chat-pane";
 import type { AgentBrowserHandle } from "./agent-browser";
 import type { SessionDropPayload } from "./pane-grid";
 
-type BrowserCommand = { id: string; verb: string; payload: Record<string, unknown> };
+type BrowserCommand = {
+  id: string;
+  verb: string;
+  sessionId?: string;
+  payload: Record<string, unknown>;
+};
 
 export type WorkspaceHandles = {
   registerBrowserHandle: (handle: AgentBrowserHandle | null) => void;
@@ -88,11 +93,32 @@ function parseBrowserCommand(raw: string): BrowserCommand | null {
     const id = parsed.id;
     const verb = parsed.verb;
     const payload = parsed.payload;
+    const sessionId = parsed.sessionId;
     if (typeof id !== "string" || typeof verb !== "string" || !isRecord(payload)) return null;
-    return { id, verb, payload };
+    return {
+      id,
+      verb,
+      payload,
+      ...(typeof sessionId === "string" && sessionId.trim() ? { sessionId: sessionId.trim() } : {}),
+    };
   } catch {
     return null;
   }
+}
+
+function focusedBrowserSessionId(state: WorkspaceState): string | null {
+  const pane = state.panesById.get(state.focusedPaneId);
+  if (!pane) return null;
+  const activeSession = state.sessions.get(pane.activeSessionId);
+  return activeSession?.runtimeSessionId || pane.runtimeSessionId || null;
+}
+
+function postBrowserResult(id: string, result: BrowserCommandResult) {
+  return fetch("/api/agent/browser/result", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...result }),
+  });
 }
 
 function createWorkspaceWindow(source: Window): WorkspaceWindow {
@@ -111,6 +137,7 @@ function createBrowserEvents(
     verb: string,
     payload: Record<string, unknown>,
   ) => Promise<BrowserCommandResult>,
+  focusedSessionId: () => string | null,
 ): BrowserEventsSubscription {
   let source: EventSource | null = null;
   let enabled = false;
@@ -131,14 +158,18 @@ function createBrowserEvents(
         if (typeof event.data !== "string") return;
         const command = parseBrowserCommand(event.data);
         if (!command || typeof fetch !== "function") return;
+        const focused = focusedSessionId();
+        if (command.sessionId && command.sessionId !== focused) {
+          void postBrowserResult(command.id, {
+            ok: false,
+            error: focused
+              ? `Browser is connected to the focused session (${focused}); focus the requesting session to run browser_${command.verb}.`
+              : `Browser is not connected to the requesting session (${command.sessionId}).`,
+          });
+          return;
+        }
         void runBrowserCommand(command.verb, command.payload)
-          .then((result) =>
-            fetch("/api/agent/browser/result", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ id: command.id, ...result }),
-            }),
-          )
+          .then((result) => postBrowserResult(command.id, result))
           .catch((error) => {
             console.warn("[agent] browser bridge dispatch failed", error);
           });
@@ -197,7 +228,9 @@ export function useWorkspace(): UseWorkspaceResult {
   const controller = useMemo(() => {
     let browserEvents: BrowserEventsSubscription | null = null;
     const getBrowserEvents = () => {
-      browserEvents ??= createBrowserEvents(runBrowserCommand);
+      browserEvents ??= createBrowserEvents(runBrowserCommand, () =>
+        focusedBrowserSessionId(stateRef.current),
+      );
       return browserEvents;
     };
     const makeDeps = (workspaceDispatch: WorkspaceDispatch): WorkspaceEffectDeps | null => {

--- a/frontend/src/app/agent/_components/use-workspace.ts
+++ b/frontend/src/app/agent/_components/use-workspace.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { safeJson } from "@/lib/agent/safe-json";
-import { clampComputerWidth } from "@/lib/agent/tools/persistence";
+import { clampComputerWidth, gentlySnapComputerWidth } from "@/lib/agent/tools/persistence";
 import { loadInitialFromStorage } from "@/lib/agent/workspace/persistence";
 import {
   createInitialState,
@@ -340,10 +340,16 @@ export function useWorkspace(): UseWorkspaceResult {
         if (typeof window === "undefined") return;
         event.preventDefault();
         const startX = event.clientX;
-        const startWidth = toolsRef.current.computer.width;
+        const startWidth =
+          computerAsideRef.current?.getBoundingClientRect().width ??
+          toolsRef.current.computer.width;
+        const containerWidth =
+          computerAsideRef.current?.parentElement?.getBoundingClientRect().width ??
+          window.innerWidth;
         let frame = 0;
+        if (computerAsideRef.current) computerAsideRef.current.style.transition = "none";
         const onMove = (moveEvent: MouseEvent) => {
-          const next = clampComputerWidth(startWidth + startX - moveEvent.clientX);
+          const next = clampComputerWidth(startWidth + startX - moveEvent.clientX, containerWidth);
           if (frame) cancelAnimationFrame(frame);
           frame = requestAnimationFrame(() => {
             if (computerAsideRef.current) computerAsideRef.current.style.width = `${next}px`;
@@ -351,8 +357,16 @@ export function useWorkspace(): UseWorkspaceResult {
         };
         const onUp = (upEvent: MouseEvent) => {
           if (frame) cancelAnimationFrame(frame);
-          const next = clampComputerWidth(startWidth + startX - upEvent.clientX);
-          if (computerAsideRef.current) computerAsideRef.current.style.width = `${next}px`;
+          const raw = startWidth + startX - upEvent.clientX;
+          const next = gentlySnapComputerWidth(raw, containerWidth);
+          if (computerAsideRef.current) {
+            computerAsideRef.current.style.transition =
+              "width 150ms cubic-bezier(0.22, 1, 0.36, 1)";
+            computerAsideRef.current.style.width = `${next}px`;
+            window.setTimeout(() => {
+              if (computerAsideRef.current) computerAsideRef.current.style.transition = "";
+            }, 170);
+          }
           toolsRef.current.setComputerWidth(next);
           window.removeEventListener("mousemove", onMove);
           window.removeEventListener("mouseup", onUp);

--- a/frontend/src/app/api/agent/browser/[verb]/route.ts
+++ b/frontend/src/app/api/agent/browser/[verb]/route.ts
@@ -15,10 +15,7 @@ const ALLOWED_VERBS = new Set([
   "fill",
 ]);
 
-export async function POST(
-  request: NextRequest,
-  context: { params: Promise<{ verb: string }> },
-) {
+export async function POST(request: NextRequest, context: { params: Promise<{ verb: string }> }) {
   const { verb } = await context.params;
   if (!ALLOWED_VERBS.has(verb)) {
     return Response.json({ ok: false, error: `Unknown browser verb: ${verb}` }, { status: 400 });
@@ -30,8 +27,14 @@ export async function POST(
   } catch {
     // empty body is fine
   }
+  const sessionId = typeof payload.sessionId === "string" ? payload.sessionId.trim() : "";
+  if (sessionId) {
+    const browserPayload = { ...payload };
+    delete browserPayload.sessionId;
+    payload = browserPayload;
+  }
   try {
-    const result = await browserBridge.enqueue(verb, payload);
+    const result = await browserBridge.enqueue(verb, payload, sessionId || undefined);
     if (!result.ok) {
       return Response.json({ ok: false, error: result.error || "Browser command failed" });
     }

--- a/frontend/src/app/api/agent/canvas/route.ts
+++ b/frontend/src/app/api/agent/canvas/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from "next/server";
+import { readAgentCanvas, writeAgentCanvas } from "@/lib/agent/canvas-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json(await readAgentCanvas());
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as {
+    enabled?: unknown;
+    text?: unknown;
+  } | null;
+  if (!body || typeof body !== "object") {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const patch: { enabled?: boolean; text?: string } = {};
+  if (typeof body.enabled === "boolean") patch.enabled = body.enabled;
+  if (typeof body.text === "string") patch.text = body.text;
+  return Response.json(await writeAgentCanvas(patch));
+}

--- a/frontend/src/app/api/agent/compact/route.ts
+++ b/frontend/src/app/api/agent/compact/route.ts
@@ -18,6 +18,8 @@ type CompactRequest = {
   piSessionId?: string | null;
   customInstructions?: string;
   browserToolEnabled?: boolean;
+  browserSessionId?: string;
+  canvasEnabled?: boolean;
   plugins?: ComposerPluginRef[];
   skills?: ComposerSkillRef[];
 };
@@ -53,6 +55,9 @@ export async function POST(request: NextRequest) {
     const skills = sanitizeComposerSkills(body.skills);
     await session.ensureStarted(modelId, cwd, piSessionId, {
       browserToolEnabled: body.browserToolEnabled === true,
+      browserSessionId:
+        typeof body.browserSessionId === "string" ? body.browserSessionId.trim() : undefined,
+      canvasEnabled: body.canvasEnabled === true,
       plugins,
       skills,
     });

--- a/frontend/src/app/api/agent/turn/route.ts
+++ b/frontend/src/app/api/agent/turn/route.ts
@@ -53,6 +53,8 @@ export async function POST(request: NextRequest) {
     cwd,
     piSessionId,
     browserToolEnabled,
+    browserSessionId,
+    canvasEnabled,
     plugins,
     skills,
     mode,
@@ -92,6 +94,8 @@ export async function POST(request: NextRequest) {
         if (ownsPromptStream) {
           await session.ensureStarted(modelId, cwd, effectivePiSessionId, {
             browserToolEnabled,
+            browserSessionId,
+            canvasEnabled,
             plugins,
             skills,
           });

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,5 +1,6 @@
 /* CRITICAL */
 @import "../../node_modules/tailwindcss" source("../");
+@import "@xterm/xterm/css/xterm.css";
 @import "./styles/globals/tokens.css";
 @import "./styles/globals/base.css";
 @import "./styles/globals/mobile.css";

--- a/frontend/src/app/styles/globals/chat.css
+++ b/frontend/src/app/styles/globals/chat.css
@@ -160,14 +160,16 @@
 .chat-markdown table {
   width: 100%;
   border-collapse: collapse;
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 0.45rem;
   overflow: hidden;
-  margin: 0.75rem 0;
+  margin: 0.65rem 0;
+  font-size: 0.82rem;
+  background: color-mix(in srgb, var(--surface) 18%, transparent);
 }
 
 .chat-markdown thead {
-  background: var(--surface);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
 }
 
 .chat-markdown tbody {
@@ -183,21 +185,21 @@
 }
 
 .chat-markdown tbody tr:nth-child(even) {
-  background: color-mix(in srgb, var(--surface) 30%, transparent);
+  background: color-mix(in srgb, var(--fg) 2.5%, transparent);
 }
 
 .chat-markdown th {
   text-align: left;
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.625rem 1rem;
-  color: var(--dim);
+  letter-spacing: 0.08em;
+  padding: 0.45rem 0.8rem;
+  color: color-mix(in srgb, var(--fg) 48%, var(--dim));
   font-weight: 600;
 }
 
 .chat-markdown td {
-  padding: 0.625rem 1rem;
+  padding: 0.45rem 0.8rem;
   color: var(--fg);
   vertical-align: top;
 }
@@ -210,16 +212,18 @@
 }
 
 .chat-markdown :not(pre) > code {
-  padding: 0.15rem 0.4rem;
-  border-radius: 0.3rem;
-  background: color-mix(in srgb, var(--fg) 7%, var(--surface));
-  border: 1px solid color-mix(in srgb, var(--fg) 12%, var(--border));
-  color: var(--fg);
+  padding: 0.03rem 0.24rem 0.06rem;
+  border-radius: 0.22rem;
+  background: #0b0b0b;
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  color: color-mix(in srgb, var(--fg) 76%, var(--dim));
   font-family:
     var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
+  line-height: 1.35;
   word-break: break-word;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.025);
 }
 
 .chat-markdown .assistant-code-block pre {

--- a/frontend/src/app/styles/globals/chat.css
+++ b/frontend/src/app/styles/globals/chat.css
@@ -34,7 +34,11 @@
 }
 
 .message-content code {
-  word-break: break-all;
+  word-break: break-word;
+}
+
+.message-content pre code {
+  word-break: normal;
 }
 
 /* Chat markdown */
@@ -205,17 +209,80 @@
   margin: 0.75rem 0;
 }
 
-.chat-markdown code {
+.chat-markdown :not(pre) > code {
   padding: 0.15rem 0.4rem;
   border-radius: 0.3rem;
-  background: color-mix(in srgb, var(--hl3) 10%, var(--surface));
-  border: 1px solid color-mix(in srgb, var(--hl3) 18%, var(--border));
-  color: var(--hl3);
+  background: color-mix(in srgb, var(--fg) 7%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--fg) 12%, var(--border));
+  color: var(--fg);
   font-family:
     var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.82rem;
   word-break: break-word;
+}
+
+.chat-markdown .assistant-code-block pre {
+  scrollbar-color: color-mix(in srgb, var(--fg) 18%, transparent) transparent;
+}
+
+.chat-markdown .assistant-code-block code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: #d8dee9;
+  white-space: pre;
+  word-break: normal;
+}
+
+.chat-markdown .assistant-code-block .hljs {
+  background: transparent;
+  color: #d8dee9;
+}
+
+.chat-markdown .assistant-code-block .hljs-keyword,
+.chat-markdown .assistant-code-block .hljs-selector-tag,
+.chat-markdown .assistant-code-block .hljs-literal,
+.chat-markdown .assistant-code-block .hljs-section,
+.chat-markdown .assistant-code-block .hljs-link {
+  color: #c792ea;
+}
+
+.chat-markdown .assistant-code-block .hljs-string,
+.chat-markdown .assistant-code-block .hljs-title,
+.chat-markdown .assistant-code-block .hljs-name,
+.chat-markdown .assistant-code-block .hljs-type,
+.chat-markdown .assistant-code-block .hljs-attribute,
+.chat-markdown .assistant-code-block .hljs-symbol,
+.chat-markdown .assistant-code-block .hljs-bullet,
+.chat-markdown .assistant-code-block .hljs-addition {
+  color: #9ccc65;
+}
+
+.chat-markdown .assistant-code-block .hljs-number,
+.chat-markdown .assistant-code-block .hljs-built_in,
+.chat-markdown .assistant-code-block .hljs-builtin-name,
+.chat-markdown .assistant-code-block .hljs-variable,
+.chat-markdown .assistant-code-block .hljs-template-variable {
+  color: #f78c6c;
+}
+
+.chat-markdown .assistant-code-block .hljs-comment,
+.chat-markdown .assistant-code-block .hljs-quote,
+.chat-markdown .assistant-code-block .hljs-meta {
+  color: #717784;
+}
+
+.chat-markdown .assistant-code-block .hljs-deletion {
+  color: #ff7373;
+}
+
+.chat-markdown .assistant-code-block .hljs-emphasis {
+  font-style: italic;
+}
+
+.chat-markdown .assistant-code-block .hljs-strong {
+  font-weight: 600;
 }
 
 .chat-markdown blockquote {

--- a/frontend/src/app/styles/globals/chat.css
+++ b/frontend/src/app/styles/globals/chat.css
@@ -285,6 +285,73 @@
   font-weight: 600;
 }
 
+.agent-composer-shell {
+  container-type: inline-size;
+  width: min(100%, var(--composer-w));
+}
+
+.agent-composer-meta {
+  container-type: inline-size;
+  width: min(100%, var(--composer-w));
+}
+
+.agent-model-slot {
+  max-width: clamp(7rem, 34cqw, 150px);
+}
+
+.agent-model-slot > * {
+  max-width: 100%;
+}
+
+.agent-composer-project {
+  max-width: min(42%, 18rem);
+}
+
+.agent-composer-branch {
+  max-width: 12rem;
+}
+
+.agent-composer-git-summary {
+  max-width: 13rem;
+}
+
+.agent-composer-tokens {
+  white-space: nowrap;
+}
+
+@container (max-width: 560px) {
+  .agent-composer-actions-row {
+    flex-wrap: wrap;
+  }
+
+  .agent-model-slot {
+    max-width: min(13rem, 58cqw);
+  }
+}
+
+@container (max-width: 520px) {
+  .agent-composer-meta-main {
+    flex-basis: 100%;
+  }
+
+  .agent-composer-project {
+    max-width: 38%;
+  }
+
+  .agent-composer-branch {
+    max-width: 9rem;
+  }
+
+  .agent-composer-git-summary {
+    max-width: 9rem;
+  }
+
+  .agent-composer-tokens {
+    margin-left: auto;
+    max-width: 100%;
+  }
+}
+
 .chat-markdown blockquote {
   border-left: 2px solid var(--accent);
   padding-left: 1rem;

--- a/frontend/src/components/projects-nav-section.test.ts
+++ b/frontend/src/components/projects-nav-section.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { mergeActiveSessionPref } from "./projects-nav-section";
+
+describe("mergeActiveSessionPref", () => {
+  it("keeps a session-id pin when a tab-scoped pref exists", () => {
+    expect(
+      mergeActiveSessionPref(
+        { piSessionId: "pi-1", paneId: "pane-1", tabId: "tab-1" },
+        {
+          "pi-1": { pinned: true },
+          "tab:pane-1:tab-1": { title: "Renamed active tab", pinned: false },
+        },
+      ),
+    ).toEqual({ title: "Renamed active tab", pinned: true });
+  });
+});

--- a/frontend/src/components/projects-nav-section.tsx
+++ b/frontend/src/components/projects-nav-section.tsx
@@ -94,17 +94,31 @@ function setAgentSessionDragData(
   event.dataTransfer.setData("application/x-vllm-agent-session", JSON.stringify(session));
   event.dataTransfer.effectAllowed = "copy";
 }
-function activeSessionPrefKeys(session: ActiveAgentSession): string[] {
+function activeSessionPrefKeys(
+  session: Pick<ActiveAgentSession, "piSessionId" | "paneId" | "tabId">,
+): string[] {
   return [
     session.piSessionId,
     session.paneId && session.tabId ? `tab:${session.paneId}:${session.tabId}` : null,
   ].filter((value): value is string => Boolean(value));
 }
+
+export function mergeActiveSessionPref(
+  session: Pick<ActiveAgentSession, "piSessionId" | "paneId" | "tabId">,
+  prefs: SessionPrefs,
+): SessionPref {
+  const merged: SessionPref = {};
+  for (const key of activeSessionPrefKeys(session)) {
+    const pref = prefs[key];
+    if (!pref) continue;
+    if (pref.title) merged.title = pref.title;
+    if (pref.pinned) merged.pinned = true;
+    if (pref.hidden) merged.hidden = true;
+  }
+  return merged;
+}
 function activeSessionPref(session: ActiveAgentSession, prefs: SessionPrefs): SessionPref {
-  return activeSessionPrefKeys(session).reduce<SessionPref>(
-    (merged, key) => ({ ...merged, ...(prefs[key] ?? {}) }),
-    {},
-  );
+  return mergeActiveSessionPref(session, prefs);
 }
 function patchActiveSessionPref(session: ActiveAgentSession, patch: SessionPref) {
   for (const key of activeSessionPrefKeys(session)) patchSessionPref(key, patch);
@@ -535,42 +549,6 @@ function ProjectDirectoryPickerModal({
           ))}{" "}
         </div>
       ) : null}{" "}
-      {chatProject ? (
-        <>
-          <SidebarSectionHeader
-            label="Chats"
-            open={chatsExpanded}
-            onToggle={() => setChatsExpanded((value) => !value)}
-            action={
-              <Link
-                href={`/agent?project=${encodeURIComponent(chatProject.id)}&new=1`}
-                onClick={(event) => {
-                  if (window.location.pathname !== "/agent") return;
-                  event.preventDefault();
-                  window.dispatchEvent(
-                    new CustomEvent(NEW_AGENT_SESSION_EVENT, {
-                      detail: { projectId: chatProject.id },
-                    }),
-                  );
-                }}
-                className="rounded p-0.5 text-(--dim) transition-colors hover:text-(--fg)"
-                title="New chat"
-                aria-label="New chat"
-              >
-                <PlusIcon className="h-3.5 w-3.5" />{" "}
-              </Link>
-            }
-          />
-          {chatsExpanded ? (
-            <ProjectSessions
-              project={chatProject}
-              activeSessions={activeSessions}
-              prefs={prefs}
-              excludedIds={pinnedRenderedIds}
-            />
-          ) : null}
-        </>
-      ) : null}
       <SidebarSectionHeader
         label="Projects"
         open={projectsExpanded}
@@ -616,6 +594,42 @@ function ProjectDirectoryPickerModal({
             />
           ))
         )
+      ) : null}
+      {chatProject ? (
+        <>
+          <SidebarSectionHeader
+            label="Chats"
+            open={chatsExpanded}
+            onToggle={() => setChatsExpanded((value) => !value)}
+            action={
+              <Link
+                href={`/agent?project=${encodeURIComponent(chatProject.id)}&new=1`}
+                onClick={(event) => {
+                  if (window.location.pathname !== "/agent") return;
+                  event.preventDefault();
+                  window.dispatchEvent(
+                    new CustomEvent(NEW_AGENT_SESSION_EVENT, {
+                      detail: { projectId: chatProject.id },
+                    }),
+                  );
+                }}
+                className="rounded p-0.5 text-(--dim) transition-colors hover:text-(--fg)"
+                title="New chat"
+                aria-label="New chat"
+              >
+                <PlusIcon className="h-3.5 w-3.5" />{" "}
+              </Link>
+            }
+          />
+          {chatsExpanded ? (
+            <ProjectSessions
+              project={chatProject}
+              activeSessions={activeSessions}
+              prefs={prefs}
+              excludedIds={pinnedRenderedIds}
+            />
+          ) : null}
+        </>
       ) : null}
       {addError ? <div className="px-3 py-1 text-[11px] text-red-400">{addError}</div> : null}{" "}
     </div>

--- a/frontend/src/hooks/agent/use-terminal-panel-effects.ts
+++ b/frontend/src/hooks/agent/use-terminal-panel-effects.ts
@@ -3,12 +3,17 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { TerminalRunResult } from "@/lib/agent/contracts/terminal";
 
-type TerminalRefs = {
+export type TerminalRefs = {
   term: XTerm | null;
   fit: FitAddon | null;
   input: string;
   running: boolean;
   disposed: boolean;
+};
+
+type TerminalSessionState = {
+  input: string;
+  running: boolean;
 };
 
 export function useTerminalPanelEffects({
@@ -26,6 +31,7 @@ export function useTerminalPanelEffects({
     refs.input = "";
     refs.running = false;
     let cleanupResize: (() => void) | null = null;
+    let cleanupKeyboard: (() => void) | null = null;
 
     async function boot() {
       const element = containerRef.current;
@@ -64,11 +70,20 @@ export function useTerminalPanelEffects({
       fit.fit();
       refs.term = term;
       refs.fit = fit;
+      const session: TerminalSessionState = { input: "", running: false };
       writeIntro(term, cwd);
-      term.onData((data) => handleTerminalData(data, cwd, refs));
+      term.onData((data) => handleTerminalData(data, cwd, refs, term, session));
+      term.focus();
+      window.setTimeout(() => {
+        if (!refs.disposed) term.focus();
+      }, 0);
       const observer = new ResizeObserver(() => refs.fit?.fit());
       observer.observe(element);
       cleanupResize = () => observer.disconnect();
+      const onKeyDown = (event: KeyboardEvent) =>
+        handleTerminalDomKeyDown(event, cwd, refs, term, session);
+      element.addEventListener("keydown", onKeyDown, true);
+      cleanupKeyboard = () => element.removeEventListener("keydown", onKeyDown, true);
     }
 
     void boot();
@@ -76,6 +91,7 @@ export function useTerminalPanelEffects({
     return () => {
       refs.disposed = true;
       cleanupResize?.();
+      cleanupKeyboard?.();
       refs.term?.dispose();
       refs.term = null;
       refs.fit = null;
@@ -83,27 +99,56 @@ export function useTerminalPanelEffects({
   }, [containerRef, cwd, stateRef]);
 }
 
-function handleTerminalData(data: string, cwd: string | null, refs: TerminalRefs) {
-  const term = refs.term;
-  if (!term || refs.running) return;
-  if (data === "\r") {
-    const command = refs.input.trim();
-    term.write("\r\n");
-    refs.input = "";
-    if (command) void runCommand(command, cwd, refs);
-    else writePrompt(term, cwd);
+function handleTerminalDomKeyDown(
+  event: KeyboardEvent,
+  cwd: string | null,
+  refs: TerminalRefs,
+  term: XTerm,
+  session: TerminalSessionState,
+) {
+  if (event.metaKey || event.ctrlKey || event.altKey) return;
+  const key = event.key;
+  if (key === "Enter") {
+    if (handleTerminalData("\r", cwd, refs, term, session)) event.preventDefault();
     return;
+  }
+  if (key === "Backspace") {
+    if (handleTerminalData("\u007f", cwd, refs, term, session)) event.preventDefault();
+    return;
+  }
+  if (key.length === 1) {
+    if (handleTerminalData(key, cwd, refs, term, session)) event.preventDefault();
+  }
+}
+
+function handleTerminalData(
+  data: string,
+  cwd: string | null,
+  refs: TerminalRefs,
+  term = refs.term,
+  session: TerminalSessionState = refs,
+): boolean {
+  if (!term || session.running || term.element?.isConnected === false) return false;
+  if (data === "\r") {
+    const command = session.input.trim();
+    term.write("\r\n");
+    session.input = "";
+    if (command) void runCommand(command, cwd, refs, session, term);
+    else writePrompt(term, cwd);
+    return true;
   }
   if (data === "\u007f") {
-    if (refs.input.length === 0) return;
-    refs.input = refs.input.slice(0, -1);
+    if (session.input.length === 0) return true;
+    session.input = session.input.slice(0, -1);
     term.write("\b \b");
-    return;
+    return true;
   }
   if (data >= " " && data !== "\u007f") {
-    refs.input += data;
+    session.input += data;
     term.write(data);
+    return true;
   }
+  return false;
 }
 
 function writeIntro(term: XTerm, cwd: string | null) {
@@ -119,15 +164,20 @@ function writePrompt(term: XTerm, cwd: string | null) {
   term.write(`\x1b[90m${label}\x1b[0m \x1b[32m$\x1b[0m `);
 }
 
-async function runCommand(command: string, cwd: string | null, refs: TerminalRefs) {
-  const term = refs.term;
+async function runCommand(
+  command: string,
+  cwd: string | null,
+  refs: TerminalRefs,
+  session: TerminalSessionState = refs,
+  term = refs.term,
+) {
   if (!term) return;
   if (!cwd) {
     term.writeln("\x1b[31mNo project directory selected.\x1b[0m");
     writePrompt(term, cwd);
     return;
   }
-  refs.running = true;
+  session.running = true;
   try {
     const response = await fetch(`/api/agent/terminal?cwd=${encodeURIComponent(cwd)}`, {
       method: "POST",
@@ -139,7 +189,7 @@ async function runCommand(command: string, cwd: string | null, refs: TerminalRef
   } catch (error) {
     term.writeln(`\x1b[31m${error instanceof Error ? error.message : "Command failed"}\x1b[0m`);
   } finally {
-    refs.running = false;
+    session.running = false;
     if (!refs.disposed) writePrompt(term, cwd);
   }
 }

--- a/frontend/src/hooks/agent/use-terminal-panel-effects.ts
+++ b/frontend/src/hooks/agent/use-terminal-panel-effects.ts
@@ -31,7 +31,6 @@ export function useTerminalPanelEffects({
     refs.input = "";
     refs.running = false;
     let cleanupResize: (() => void) | null = null;
-    let cleanupKeyboard: (() => void) | null = null;
 
     async function boot() {
       const element = containerRef.current;
@@ -80,10 +79,6 @@ export function useTerminalPanelEffects({
       const observer = new ResizeObserver(() => refs.fit?.fit());
       observer.observe(element);
       cleanupResize = () => observer.disconnect();
-      const onKeyDown = (event: KeyboardEvent) =>
-        handleTerminalDomKeyDown(event, cwd, refs, term, session);
-      element.addEventListener("keydown", onKeyDown, true);
-      cleanupKeyboard = () => element.removeEventListener("keydown", onKeyDown, true);
     }
 
     void boot();
@@ -91,34 +86,11 @@ export function useTerminalPanelEffects({
     return () => {
       refs.disposed = true;
       cleanupResize?.();
-      cleanupKeyboard?.();
       refs.term?.dispose();
       refs.term = null;
       refs.fit = null;
     };
   }, [containerRef, cwd, stateRef]);
-}
-
-function handleTerminalDomKeyDown(
-  event: KeyboardEvent,
-  cwd: string | null,
-  refs: TerminalRefs,
-  term: XTerm,
-  session: TerminalSessionState,
-) {
-  if (event.metaKey || event.ctrlKey || event.altKey) return;
-  const key = event.key;
-  if (key === "Enter") {
-    if (handleTerminalData("\r", cwd, refs, term, session)) event.preventDefault();
-    return;
-  }
-  if (key === "Backspace") {
-    if (handleTerminalData("\u007f", cwd, refs, term, session)) event.preventDefault();
-    return;
-  }
-  if (key.length === 1) {
-    if (handleTerminalData(key, cwd, refs, term, session)) event.preventDefault();
-  }
 }
 
 function handleTerminalData(

--- a/frontend/src/hooks/agent/use-terminal-panel-effects.ts
+++ b/frontend/src/hooks/agent/use-terminal-panel-effects.ts
@@ -1,0 +1,153 @@
+import { useEffect, type RefObject } from "react";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { TerminalRunResult } from "@/lib/agent/contracts/terminal";
+
+type TerminalRefs = {
+  term: XTerm | null;
+  fit: FitAddon | null;
+  input: string;
+  running: boolean;
+  disposed: boolean;
+};
+
+export function useTerminalPanelEffects({
+  containerRef,
+  cwd,
+  stateRef,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>;
+  cwd: string | null;
+  stateRef: RefObject<TerminalRefs>;
+}): void {
+  useEffect(() => {
+    const refs = stateRef.current;
+    refs.disposed = false;
+    refs.input = "";
+    refs.running = false;
+    let cleanupResize: (() => void) | null = null;
+
+    async function boot() {
+      const element = containerRef.current;
+      if (!element) return;
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+      ]);
+      if (refs.disposed) return;
+      const term = new Terminal({
+        cursorBlink: true,
+        convertEol: true,
+        fontFamily:
+          'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+        fontSize: 12,
+        lineHeight: 1.35,
+        theme: {
+          background: "#070707",
+          foreground: "#f2f2f2",
+          cursor: "#f2f2f2",
+          selectionBackground: "#3a3a3a",
+          black: "#0a0a0a",
+          blue: "#74a7ff",
+          brightBlue: "#9fc2ff",
+          cyan: "#69d2e7",
+          green: "#7ee787",
+          magenta: "#d2a8ff",
+          red: "#ff7b72",
+          white: "#f0f0f0",
+          yellow: "#f2cc60",
+        },
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(element);
+      fit.fit();
+      refs.term = term;
+      refs.fit = fit;
+      writeIntro(term, cwd);
+      term.onData((data) => handleTerminalData(data, cwd, refs));
+      const observer = new ResizeObserver(() => refs.fit?.fit());
+      observer.observe(element);
+      cleanupResize = () => observer.disconnect();
+    }
+
+    void boot();
+
+    return () => {
+      refs.disposed = true;
+      cleanupResize?.();
+      refs.term?.dispose();
+      refs.term = null;
+      refs.fit = null;
+    };
+  }, [containerRef, cwd, stateRef]);
+}
+
+function handleTerminalData(data: string, cwd: string | null, refs: TerminalRefs) {
+  const term = refs.term;
+  if (!term || refs.running) return;
+  if (data === "\r") {
+    const command = refs.input.trim();
+    term.write("\r\n");
+    refs.input = "";
+    if (command) void runCommand(command, cwd, refs);
+    else writePrompt(term, cwd);
+    return;
+  }
+  if (data === "\u007f") {
+    if (refs.input.length === 0) return;
+    refs.input = refs.input.slice(0, -1);
+    term.write("\b \b");
+    return;
+  }
+  if (data >= " " && data !== "\u007f") {
+    refs.input += data;
+    term.write(data);
+  }
+}
+
+function writeIntro(term: XTerm, cwd: string | null) {
+  term.writeln("\x1b[90mvLLM Studio terminal\x1b[0m");
+  if (!cwd) {
+    term.writeln("\x1b[31mChoose a project directory before running commands.\x1b[0m");
+  }
+  writePrompt(term, cwd);
+}
+
+function writePrompt(term: XTerm, cwd: string | null) {
+  const label = cwd ? cwd.split("/").filter(Boolean).pop() || cwd : "no-project";
+  term.write(`\x1b[90m${label}\x1b[0m \x1b[32m$\x1b[0m `);
+}
+
+async function runCommand(command: string, cwd: string | null, refs: TerminalRefs) {
+  const term = refs.term;
+  if (!term) return;
+  if (!cwd) {
+    term.writeln("\x1b[31mNo project directory selected.\x1b[0m");
+    writePrompt(term, cwd);
+    return;
+  }
+  refs.running = true;
+  try {
+    const response = await fetch(`/api/agent/terminal?cwd=${encodeURIComponent(cwd)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command }),
+    });
+    const payload = (await response.json()) as TerminalRunResult;
+    writeResult(term, payload);
+  } catch (error) {
+    term.writeln(`\x1b[31m${error instanceof Error ? error.message : "Command failed"}\x1b[0m`);
+  } finally {
+    refs.running = false;
+    if (!refs.disposed) writePrompt(term, cwd);
+  }
+}
+
+function writeResult(term: XTerm, payload: TerminalRunResult) {
+  if (payload.stdout) term.write(payload.stdout.replace(/\n/g, "\r\n"));
+  if (payload.stderr) term.write(`\x1b[31m${payload.stderr.replace(/\n/g, "\r\n")}\x1b[0m`);
+  if (payload.error) term.writeln(`\x1b[31m${payload.error}\x1b[0m`);
+  if (!payload.ok) term.writeln(`\x1b[31mexit ${payload.exitCode ?? 1}\x1b[0m`);
+  if (payload.ok && !payload.stdout && !payload.stderr) term.writeln("");
+}

--- a/frontend/src/lib/agent/browser-bridge.ts
+++ b/frontend/src/lib/agent/browser-bridge.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "node:events";
 export type BrowserCommand = {
   id: string;
   verb: string;
+  sessionId?: string;
   payload: Record<string, unknown>;
 };
 
@@ -27,7 +28,11 @@ class BrowserBridge extends EventEmitter {
   private pending = new Map<string, PendingCommand>();
   private seq = 0;
 
-  enqueue(verb: string, payload: Record<string, unknown>): Promise<BrowserResult> {
+  enqueue(
+    verb: string,
+    payload: Record<string, unknown>,
+    sessionId?: string,
+  ): Promise<BrowserResult> {
     if (this.listenerCount("command") === 0) {
       return Promise.reject(
         new Error(`Browser command '${verb}' could not run because no browser panel is connected.`),
@@ -35,7 +40,7 @@ class BrowserBridge extends EventEmitter {
     }
 
     const id = `browser-${Date.now().toString(36)}-${(++this.seq).toString(36)}`;
-    const command: BrowserCommand = { id, verb, payload };
+    const command: BrowserCommand = { id, verb, ...(sessionId ? { sessionId } : {}), payload };
     return new Promise<BrowserResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       this.emit("command", command);

--- a/frontend/src/lib/agent/canvas-store.ts
+++ b/frontend/src/lib/agent/canvas-store.ts
@@ -1,0 +1,52 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { resolveDataDir } from "@/lib/data-dir";
+
+export type AgentCanvasDocument = {
+  enabled: boolean;
+  text: string;
+  updatedAt: string;
+};
+
+const DEFAULT_CANVAS: AgentCanvasDocument = {
+  enabled: false,
+  text: "",
+  updatedAt: "",
+};
+
+function canvasFilePath(): string {
+  return path.join(resolveDataDir(), "agent-canvas.json");
+}
+
+function normalizeCanvas(input: unknown): AgentCanvasDocument {
+  const value = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  return {
+    enabled: value.enabled === true,
+    text: typeof value.text === "string" ? value.text : "",
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : "",
+  };
+}
+
+export async function readAgentCanvas(): Promise<AgentCanvasDocument> {
+  try {
+    return normalizeCanvas(JSON.parse(await readFile(canvasFilePath(), "utf8")));
+  } catch {
+    return DEFAULT_CANVAS;
+  }
+}
+
+export async function writeAgentCanvas(
+  patch: Partial<Pick<AgentCanvasDocument, "enabled" | "text">>,
+): Promise<AgentCanvasDocument> {
+  const current = await readAgentCanvas();
+  const next: AgentCanvasDocument = {
+    ...current,
+    ...(typeof patch.enabled === "boolean" ? { enabled: patch.enabled } : {}),
+    ...(typeof patch.text === "string" ? { text: patch.text } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+  const filePath = canvasFilePath();
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  return next;
+}

--- a/frontend/src/lib/agent/contracts/turn.ts
+++ b/frontend/src/lib/agent/contracts/turn.ts
@@ -11,6 +11,8 @@ export type AgentTurnRequest = {
   cwd?: string;
   piSessionId: string | null;
   browserToolEnabled: boolean;
+  browserSessionId?: string;
+  canvasEnabled: boolean;
   plugins: ReturnType<typeof sanitizeComposerPlugins>;
   skills: ReturnType<typeof sanitizeComposerSkills>;
   mode: AgentTurnMode;
@@ -35,6 +37,8 @@ export function parseAgentTurnRequest(input: unknown): ParseResult<AgentTurnRequ
   if (!cwd.ok) return cwd;
   const piSessionId = stringField(body, "piSessionId");
   if (!piSessionId.ok) return piSessionId;
+  const browserSessionId = stringField(body, "browserSessionId");
+  if (!browserSessionId.ok) return browserSessionId;
   const mode = body.mode === "steer" || body.mode === "follow_up" ? body.mode : "prompt";
   const streamingBehavior =
     body.streamingBehavior === "steer" || body.streamingBehavior === "followUp"
@@ -49,6 +53,8 @@ export function parseAgentTurnRequest(input: unknown): ParseResult<AgentTurnRequ
       cwd: cwd.value,
       piSessionId: piSessionId.value ?? null,
       browserToolEnabled: boolField(body, "browserToolEnabled"),
+      browserSessionId: browserSessionId.value,
+      canvasEnabled: boolField(body, "canvasEnabled"),
       plugins: sanitizeComposerPlugins(body.plugins),
       skills: sanitizeComposerSkills(body.skills),
       mode,

--- a/frontend/src/lib/agent/pi-runtime-helpers.test.ts
+++ b/frontend/src/lib/agent/pi-runtime-helpers.test.ts
@@ -124,21 +124,30 @@ describe("pi runtime helper seams", () => {
     const timeoutExtension = path.join(root, "vllm-studio-timeouts.ts");
     const mcpExtension = path.join(root, "mcp-plugin.ts");
     const browserExtension = path.join(root, "browser.ts");
+    const canvasExtension = path.join(root, "canvas.ts");
     const mcpConfigPath = path.join(root, "plugin", ".mcp.json");
     mkdirSync(pluginSkills, { recursive: true });
     mkdirSync(selectedSkills, { recursive: true });
-    for (const file of [timeoutExtension, mcpExtension, browserExtension, mcpConfigPath]) {
+    for (const file of [
+      timeoutExtension,
+      mcpExtension,
+      browserExtension,
+      canvasExtension,
+      mcpConfigPath,
+    ]) {
       mkdirSync(path.dirname(file), { recursive: true });
       writeFileSync(file, file.endsWith(".json") ? JSON.stringify({ mcpServers: {} }) : "");
     }
     process.env.VLLM_STUDIO_TIMEOUT_EXTENSION_PATH = timeoutExtension;
     process.env.VLLM_STUDIO_MCP_EXTENSION_PATH = mcpExtension;
     process.env.VLLM_STUDIO_BROWSER_EXTENSION_PATH = browserExtension;
+    process.env.VLLM_STUDIO_CANVAS_EXTENSION_PATH = canvasExtension;
 
     const plan = buildPiLaunchPlan({
       agentDir: path.join(root, "agent"),
       modelId: "qwen",
       options: {
+        canvasEnabled: true,
         plugins: [{ name: "browser-use", path: path.join(root, "plugin") }],
         skills: [{ name: "selected", path: selectedSkills }],
       },
@@ -170,6 +179,8 @@ describe("pi runtime helper seams", () => {
       mcpExtension,
       "--extension",
       browserExtension,
+      "--extension",
+      canvasExtension,
     ]);
     expect(plan.env).toMatchObject({
       PATH: "/tmp/pi-bin",

--- a/frontend/src/lib/agent/pi-runtime-helpers.ts
+++ b/frontend/src/lib/agent/pi-runtime-helpers.ts
@@ -24,6 +24,8 @@ export type RuntimeSkillRef = {
 
 export type RuntimeStartOptions = {
   browserToolEnabled?: boolean;
+  browserSessionId?: string;
+  canvasEnabled?: boolean;
   plugins?: RuntimePluginRef[];
   skills?: RuntimeSkillRef[];
 };
@@ -134,6 +136,10 @@ export function resolveBrowserExtensionPath(): string | null {
   );
 }
 
+export function resolveCanvasExtensionPath(): string | null {
+  return resolveBundledPiExtensionPath("canvas.ts", process.env.VLLM_STUDIO_CANVAS_EXTENSION_PATH);
+}
+
 export function resolveTimeoutExtensionPath(): string | null {
   return resolveBundledPiExtensionPath(
     "vllm-studio-timeouts.ts",
@@ -171,6 +177,8 @@ export function pluginFingerprint(options: RuntimeStartOptions): string {
     .sort();
   return JSON.stringify({
     browser: options.browserToolEnabled === true,
+    browserSessionId: options.browserSessionId ?? "",
+    canvas: options.canvasEnabled === true,
     plugins: names,
     skills,
   });
@@ -313,6 +321,10 @@ function extensionArgs(
     const browserExtensionPath = resolveBrowserExtensionPath();
     if (browserExtensionPath) args.push("--extension", browserExtensionPath);
   }
+  if (options.canvasEnabled === true) {
+    const canvasExtensionPath = resolveCanvasExtensionPath();
+    if (canvasExtensionPath) args.push("--extension", canvasExtensionPath);
+  }
   return args;
 }
 
@@ -342,6 +354,7 @@ export function buildPiLaunchPlan(input: RuntimeLaunchPlanInput): RuntimeLaunchP
       PATH: input.pathEnv,
       PI_CODING_AGENT_DIR: input.agentDir,
       PI_SKIP_VERSION_CHECK: "1",
+      VLLM_STUDIO_BROWSER_SESSION_ID: input.options.browserSessionId ?? "",
       VLLM_STUDIO_FRONTEND_BASE: input.processEnv.VLLM_STUDIO_FRONTEND_BASE ?? deriveFrontendBase(),
       VLLM_STUDIO_MCP_PLUGIN_CONFIGS: JSON.stringify(mcpConfigs),
     },

--- a/frontend/src/lib/agent/session/types.ts
+++ b/frontend/src/lib/agent/session/types.ts
@@ -30,10 +30,23 @@ export type ThinkingBlock = { kind: "thinking"; id: string; text: string };
 export type EventBlock = { kind: "event"; id: string; text: string };
 export type AssistantBlock = TextBlock | ThinkingBlock | ToolBlock | EventBlock;
 
+export type ChatMessageAttachment = {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  path?: string;
+  mode: "text" | "data-url" | "metadata";
+  content: string;
+  previewKind?: "image" | "video" | "pdf";
+  previewUrl?: string;
+};
+
 export type ChatMessage = {
   id: string;
   role: "user" | "assistant" | "system";
   text: string;
+  attachments?: ChatMessageAttachment[];
   blocks?: AssistantBlock[];
   timestamp?: string;
 };

--- a/frontend/src/lib/agent/sessions/api.ts
+++ b/frontend/src/lib/agent/sessions/api.ts
@@ -69,6 +69,8 @@ export type CompactSessionArgs = {
   cwd?: string;
   piSessionId?: string | null;
   browserToolEnabled: boolean;
+  browserSessionId?: string;
+  canvasEnabled?: boolean;
   plugins: ComposerPluginRef[];
   skills: ComposerSkillRef[];
 };
@@ -100,6 +102,8 @@ export type SubmitTurnArgs = {
   /** Control mode for steer/follow-up; omitted for a normal prompt. */
   mode?: "steer" | "follow_up";
   browserToolEnabled: boolean;
+  browserSessionId?: string;
+  canvasEnabled?: boolean;
   plugins: ComposerPluginRef[];
   skills: ComposerSkillRef[];
 };

--- a/frontend/src/lib/agent/sessions/engine.ts
+++ b/frontend/src/lib/agent/sessions/engine.ts
@@ -58,6 +58,7 @@ export type UseSessionEngineDeps = {
   modelId: string;
   cwd: string;
   browserToolEnabled: boolean;
+  canvasEnabled: boolean;
   onPiSessionIdChange?: (piSessionId: string) => void;
   /** Mutate a single session record. */
   updateSession: UpdateSession;
@@ -92,6 +93,7 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
     modelId,
     cwd,
     browserToolEnabled,
+    canvasEnabled,
     onPiSessionIdChange,
     updateSession,
     selectionFor,
@@ -109,6 +111,16 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
   // Pi can split a single user turn across multiple assistant messages (after
   // a queue_update / message_start), and we need a stable id to patch.
   const liveAssistantIdsRef = useRef<Map<SessionId, string>>(new Map());
+  const piEventBatchesRef = useRef<
+    Map<
+      SessionId,
+      {
+        assistantId: string;
+        events: Record<string, unknown>[];
+        timer: ReturnType<typeof setTimeout> | null;
+      }
+    >
+  >(new Map());
 
   const patchAssistant = useCallback(
     (sessionId: SessionId, assistantId: string, patch: (msg: ChatMessage) => ChatMessage) => {
@@ -132,6 +144,56 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
       );
     },
     [patchAssistant, updateSession],
+  );
+
+  const flushPiEventBatch = useCallback(
+    (sessionId: SessionId) => {
+      const batch = piEventBatchesRef.current.get(sessionId);
+      if (!batch) return;
+      if (batch.timer) clearTimeout(batch.timer);
+      piEventBatchesRef.current.delete(sessionId);
+      for (const event of batch.events) {
+        applyPiEvent(sessionId, batch.assistantId, event);
+      }
+    },
+    [applyPiEvent],
+  );
+
+  const enqueuePiEvent = useCallback(
+    (
+      sessionId: SessionId,
+      assistantId: string,
+      event: Record<string, unknown>,
+      options: { flushNow?: boolean } = {},
+    ) => {
+      const existing = piEventBatchesRef.current.get(sessionId);
+      const batch = existing ?? {
+        assistantId,
+        events: [] as Record<string, unknown>[],
+        timer: null,
+      };
+      batch.assistantId = batch.assistantId || assistantId;
+      batch.events.push(event);
+      if (!existing) piEventBatchesRef.current.set(sessionId, batch);
+      if (options.flushNow) {
+        flushPiEventBatch(sessionId);
+        return;
+      }
+      if (!batch.timer) {
+        batch.timer = setTimeout(() => flushPiEventBatch(sessionId), 100);
+      }
+    },
+    [flushPiEventBatch],
+  );
+
+  useEffect(
+    () => () => {
+      for (const batch of piEventBatchesRef.current.values()) {
+        if (batch.timer) clearTimeout(batch.timer);
+      }
+      piEventBatchesRef.current.clear();
+    },
+    [],
   );
 
   const loadRuntimeStatusCb = useCallback(api.loadRuntimeStatus, []);
@@ -179,6 +241,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
             piSessionId,
             mode,
             browserToolEnabled,
+            browserSessionId: runtime,
+            canvasEnabled,
             plugins: plugins as ComposerPluginRef[],
             skills,
           },
@@ -203,17 +267,27 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
                 activeAssistantId: agentEnded ? undefined : assistantId,
               }));
               if (eventId) onPiSessionIdChange?.(eventId);
-              applyPiEvent(sessionId, assistantId, payload.event);
+              enqueuePiEvent(sessionId, assistantId, payload.event, { flushNow: agentEnded });
             }
           },
         );
         if (controlError) throw new Error(controlError);
         return { ok: true };
       } catch (error) {
+        flushPiEventBatch(sessionId);
         return { ok: false, error: error instanceof Error ? error.message : "Message failed" };
       }
     },
-    [applyPiEvent, browserToolEnabled, cwd, modelId, onPiSessionIdChange, updateSession],
+    [
+      browserToolEnabled,
+      canvasEnabled,
+      cwd,
+      enqueuePiEvent,
+      flushPiEventBatch,
+      modelId,
+      onPiSessionIdChange,
+      updateSession,
+    ],
   );
 
   // Stable ref for the queue-drain self-call from inside submitPrompt and the
@@ -273,6 +347,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
               tabsRef.current.find((tab) => tab.id === sessionId)?.piSessionId ??
               selected.piSessionId,
             browserToolEnabled,
+            browserSessionId: runtime,
+            canvasEnabled,
             plugins: activeComposerPlugins(
               selectionForRef.current(sessionId).plugins ?? EMPTY_PLUGINS,
             ) as ComposerPluginRef[],
@@ -290,6 +366,7 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
               if (payload.piSessionId) onPiSessionIdChange?.(payload.piSessionId);
             } else if (payload.type === "error") {
               streamError = payload.error;
+              flushPiEventBatch(sessionId);
               updateSession(sessionId, (session) => ({
                 ...session,
                 error: payload.error,
@@ -317,13 +394,14 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
                   "";
                 onPiSessionIdChange?.(latestPiSessionId);
               }
-              applyPiEvent(sessionId, assistantId, piEvent);
+              enqueuePiEvent(sessionId, assistantId, piEvent, { flushNow: agentEnded });
             }
           },
         );
       } catch (err) {
         streamError = err instanceof Error ? err.message : "Agent request failed";
       } finally {
+        flushPiEventBatch(sessionId);
         localStreamRef.current.delete(sessionId);
         liveAssistantIdsRef.current.delete(sessionId);
         const runtimeStatus = agentEnded ? null : await api.loadRuntimeStatus(runtime);
@@ -355,8 +433,10 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
       runtimeSessionId,
       cwd,
       browserToolEnabled,
+      canvasEnabled,
       onPiSessionIdChange,
-      applyPiEvent,
+      enqueuePiEvent,
+      flushPiEventBatch,
       updateSession,
     ],
   );
@@ -368,9 +448,10 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
       const session = tabsRef.current.find((tab) => tab.id === sessionId);
       const runtime = resolveRuntimeSessionId(session, runtimeSessionId);
       await api.abortSession(runtime);
+      flushPiEventBatch(sessionId);
       updateSession(sessionId, (s) => ({ ...s, status: "idle" }));
     },
-    [runtimeSessionId, updateSession],
+    [flushPiEventBatch, runtimeSessionId, updateSession],
   );
 
   const loadAndReplay = useCallback(
@@ -432,6 +513,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
           cwd: cwd.trim() || undefined,
           piSessionId: session.piSessionId,
           browserToolEnabled,
+          browserSessionId: session.runtimeSessionId || runtimeSessionId,
+          canvasEnabled,
           plugins: activeComposerPlugins(
             selectionForRef.current(sessionId).plugins ?? EMPTY_PLUGINS,
           ) as ComposerPluginRef[],
@@ -446,7 +529,15 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
         }));
       }
     },
-    [browserToolEnabled, cwd, loadAndReplay, modelId, runtimeSessionId, updateSession],
+    [
+      browserToolEnabled,
+      canvasEnabled,
+      cwd,
+      loadAndReplay,
+      modelId,
+      runtimeSessionId,
+      updateSession,
+    ],
   );
 
   // Resume an in-flight runtime session via SSE — fires when the active
@@ -469,7 +560,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
     const sub = subscribeResumeRuntimeSession({
       after: resumeAfter,
       api,
-      applyPiEvent,
+      applyPiEvent: enqueuePiEvent,
+      flushPiEvents: flushPiEventBatch,
       onPiSessionIdChange,
       runtime: resumeRuntimeSessionId,
       sessionId: resumeRuntimeId,
@@ -479,7 +571,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
     });
     return sub.close;
   }, [
-    applyPiEvent,
+    enqueuePiEvent,
+    flushPiEventBatch,
     onPiSessionIdChange,
     resumeAfter,
     resumeRuntimeId,

--- a/frontend/src/lib/agent/sessions/engine.ts
+++ b/frontend/src/lib/agent/sessions/engine.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { isAgentEndEvent } from "@/lib/agent/pi-events";
 import {
   type ChatMessage,
+  type ChatMessageAttachment,
   mergeCanonicalAndRuntimeEvents,
   newId,
   nowLabel,
@@ -44,6 +45,7 @@ type SubmitArgs = {
   prompt: string;
   displayText: string;
   userText: string;
+  attachments?: ChatMessageAttachment[];
   targetSessionId?: SessionId;
 };
 
@@ -245,7 +247,13 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
             : session.title,
         messages: [
           ...session.messages,
-          { id: userId, role: "user", text: args.displayText, timestamp: nowLabel() },
+          {
+            id: userId,
+            role: "user",
+            text: args.displayText,
+            attachments: args.attachments,
+            timestamp: nowLabel(),
+          },
           { id: assistantId, role: "assistant", text: "", blocks: [], timestamp: nowLabel() },
         ],
       }));

--- a/frontend/src/lib/agent/sessions/runtime-resume.ts
+++ b/frontend/src/lib/agent/sessions/runtime-resume.ts
@@ -21,7 +21,13 @@ type RuntimeResumeApi = {
 export type RuntimeResumeDeps = {
   after: number;
   api: RuntimeResumeApi;
-  applyPiEvent: (sessionId: SessionId, assistantId: string, event: Record<string, unknown>) => void;
+  applyPiEvent: (
+    sessionId: SessionId,
+    assistantId: string,
+    event: Record<string, unknown>,
+    options?: { flushNow?: boolean },
+  ) => void;
+  flushPiEvents?: (sessionId: SessionId) => void;
   onPiSessionIdChange?: (piSessionId: string) => void;
   runtime: string;
   schedule?: (callback: () => void) => void;
@@ -47,6 +53,7 @@ export function subscribeResumeRuntimeSession(deps: RuntimeResumeDeps): RuntimeE
   return {
     close: () => {
       closed = true;
+      deps.flushPiEvents?.(deps.sessionId);
       sub.close();
     },
   };
@@ -88,7 +95,11 @@ function applyRuntimePiPayload(
     activeAssistantId: agentEnded ? undefined : assistantId,
   }));
   if (eventId) deps.onPiSessionIdChange?.(eventId);
-  deps.applyPiEvent(deps.sessionId, assistantId, payload.event);
+  if (agentEnded) {
+    deps.applyPiEvent(deps.sessionId, assistantId, payload.event, { flushNow: true });
+  } else {
+    deps.applyPiEvent(deps.sessionId, assistantId, payload.event);
+  }
   if (agentEnded) drainQueuedTurnAfterAgentEnd(deps, deps.sessionId);
 }
 
@@ -132,6 +143,7 @@ async function reconcileRuntimeLiveness(
     return;
   }
   sub.close();
+  deps.flushPiEvents?.(deps.sessionId);
   deps.updateSession(deps.sessionId, (session) =>
     session.status === "running" || session.status === "starting"
       ? { ...session, status: "idle", activeAssistantId: undefined }

--- a/frontend/src/lib/agent/tools/context.tsx
+++ b/frontend/src/lib/agent/tools/context.tsx
@@ -29,7 +29,9 @@ import {
   writeComputerCanvasEnabled,
   writeComputerCanvasText,
   writeComputerTab,
+  writeComputerTabs,
   writeComputerWidth,
+  uniqueComputerTabs,
 } from "./persistence";
 
 export type ToolsContextValue = {
@@ -48,6 +50,7 @@ export type ToolsContextValue = {
   setComputerOpen: (open: boolean) => void;
   toggleComputerOpen: () => void;
   setComputerTab: (tab: ComputerTab) => void;
+  closeComputerTab: (tab: ComputerTab) => void;
   setComputerWidth: (width: number) => void;
   setCanvasEnabled: (enabled: boolean) => void;
   toggleCanvas: () => void;
@@ -73,7 +76,14 @@ function buildInitialBrowser(): BrowserState {
 
 function buildInitialComputer(): ComputerState {
   if (typeof window === "undefined") {
-    return { open: false, tab: "status", width: 0, canvasEnabled: false, canvasText: "" };
+    return {
+      open: false,
+      tab: "status",
+      tabs: ["status"],
+      width: 0,
+      canvasEnabled: false,
+      canvasText: "",
+    };
   }
   return loadComputerState();
 }
@@ -111,6 +121,28 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/agent/canvas", { cache: "no-store" })
+      .then((res) =>
+        res.ok
+          ? (res.json() as Promise<{ enabled?: boolean; text?: string }>)
+          : Promise.reject(new Error("Canvas fetch failed")),
+      )
+      .then((payload) => {
+        if (cancelled) return;
+        setComputer((current) => ({
+          ...current,
+          canvasEnabled: payload.enabled ?? current.canvasEnabled,
+          canvasText: typeof payload.text === "string" ? payload.text : current.canvasText,
+        }));
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const setBrowserEnabled = useCallback((enabled: boolean) => {
     setBrowser((current) => (current.enabled === enabled ? current : { ...current, enabled }));
     writeBrowserEnabled(enabled);
@@ -142,7 +174,12 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
     setComputer((current) =>
       current.open === open
         ? current
-        : { ...current, open, tab: open ? current.tab || "status" : current.tab },
+        : {
+            ...current,
+            open,
+            tab: open ? current.tab || "status" : current.tab,
+            tabs: uniqueComputerTabs(current.tabs.length ? current.tabs : ["status"]),
+          },
     );
   }, []);
 
@@ -151,12 +188,30 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       ...current,
       open: !current.open,
       tab: !current.open ? current.tab || "status" : current.tab,
+      tabs: uniqueComputerTabs(current.tabs.length ? current.tabs : ["status"]),
     }));
   }, []);
 
   const setComputerTab = useCallback((tab: ComputerTab) => {
-    setComputer((current) => (current.tab === tab ? current : { ...current, tab }));
+    setComputer((current) => {
+      const tabs = uniqueComputerTabs([...current.tabs, tab]);
+      writeComputerTabs(tabs);
+      return current.tab === tab && current.tabs === tabs
+        ? current
+        : { ...current, open: true, tab, tabs };
+    });
     writeComputerTab(tab);
+  }, []);
+
+  const closeComputerTab = useCallback((tab: ComputerTab) => {
+    if (tab === "status") return;
+    setComputer((current) => {
+      const tabs = uniqueComputerTabs(current.tabs.filter((item) => item !== tab));
+      const activeTab = current.tab === tab ? (tabs[tabs.length - 1] ?? "status") : current.tab;
+      writeComputerTabs(tabs);
+      writeComputerTab(activeTab);
+      return { ...current, tab: activeTab, tabs };
+    });
   }, []);
 
   const setComputerWidth = useCallback((width: number) => {
@@ -173,17 +228,30 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       current.canvasEnabled === enabled ? current : { ...current, canvasEnabled: enabled },
     );
     writeComputerCanvasEnabled(enabled);
+    void fetch("/api/agent/canvas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    }).catch(() => undefined);
   }, []);
 
   const toggleCanvas = useCallback(() => {
     setComputer((current) => {
       const next = !current.canvasEnabled;
+      const tabs = next ? uniqueComputerTabs([...current.tabs, "canvas"]) : current.tabs;
       writeComputerCanvasEnabled(next);
+      if (next) writeComputerTabs(tabs);
+      void fetch("/api/agent/canvas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      }).catch(() => undefined);
       return {
         ...current,
         canvasEnabled: next,
         open: next ? true : current.open,
-        tab: next ? "status" : current.tab,
+        tab: next ? "canvas" : current.tab,
+        tabs,
       };
     });
   }, []);
@@ -194,6 +262,11 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       current.canvasText === text ? current : { ...current, canvasText: text },
     );
     writeComputerCanvasText(text);
+    void fetch("/api/agent/canvas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    }).catch(() => undefined);
   }, []);
 
   const selectionFor = useCallback(
@@ -253,6 +326,7 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       setComputerOpen,
       toggleComputerOpen,
       setComputerTab,
+      closeComputerTab,
       setComputerWidth,
       setCanvasEnabled,
       toggleCanvas,
@@ -273,6 +347,7 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       setComputerOpen,
       toggleComputerOpen,
       setComputerTab,
+      closeComputerTab,
       setComputerWidth,
       setCanvasEnabled,
       toggleCanvas,

--- a/frontend/src/lib/agent/tools/context.tsx
+++ b/frontend/src/lib/agent/tools/context.tsx
@@ -26,6 +26,8 @@ import {
   loadComputerState,
   migrateToolStorage,
   writeBrowserEnabled,
+  writeComputerCanvasEnabled,
+  writeComputerCanvasText,
   writeComputerTab,
   writeComputerWidth,
 } from "./persistence";
@@ -47,6 +49,9 @@ export type ToolsContextValue = {
   toggleComputerOpen: () => void;
   setComputerTab: (tab: ComputerTab) => void;
   setComputerWidth: (width: number) => void;
+  setCanvasEnabled: (enabled: boolean) => void;
+  toggleCanvas: () => void;
+  setCanvasText: (text: string) => void;
   /**
    * Replace the entire selection for a session. Pass `null` to clear it (used
    * when a session is closed / pruned).
@@ -68,7 +73,7 @@ function buildInitialBrowser(): BrowserState {
 
 function buildInitialComputer(): ComputerState {
   if (typeof window === "undefined") {
-    return { open: false, tab: "browser", width: 0 };
+    return { open: false, tab: "status", width: 0, canvasEnabled: false, canvasText: "" };
   }
   return loadComputerState();
 }
@@ -134,11 +139,19 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const setComputerOpen = useCallback((open: boolean) => {
-    setComputer((current) => (current.open === open ? current : { ...current, open }));
+    setComputer((current) =>
+      current.open === open
+        ? current
+        : { ...current, open, tab: open ? current.tab || "status" : current.tab },
+    );
   }, []);
 
   const toggleComputerOpen = useCallback(() => {
-    setComputer((current) => ({ ...current, open: !current.open }));
+    setComputer((current) => ({
+      ...current,
+      open: !current.open,
+      tab: !current.open ? current.tab || "status" : current.tab,
+    }));
   }, []);
 
   const setComputerTab = useCallback((tab: ComputerTab) => {
@@ -153,6 +166,34 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       current.width === clamped ? current : { ...current, width: clamped },
     );
     writeComputerWidth(clamped);
+  }, []);
+
+  const setCanvasEnabled = useCallback((enabled: boolean) => {
+    setComputer((current) =>
+      current.canvasEnabled === enabled ? current : { ...current, canvasEnabled: enabled },
+    );
+    writeComputerCanvasEnabled(enabled);
+  }, []);
+
+  const toggleCanvas = useCallback(() => {
+    setComputer((current) => {
+      const next = !current.canvasEnabled;
+      writeComputerCanvasEnabled(next);
+      return {
+        ...current,
+        canvasEnabled: next,
+        open: next ? true : current.open,
+        tab: next ? "status" : current.tab,
+      };
+    });
+  }, []);
+
+  const setCanvasText = useCallback((text: string) => {
+    if (typeof text !== "string") return;
+    setComputer((current) =>
+      current.canvasText === text ? current : { ...current, canvasText: text },
+    );
+    writeComputerCanvasText(text);
   }, []);
 
   const selectionFor = useCallback(
@@ -213,6 +254,9 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       toggleComputerOpen,
       setComputerTab,
       setComputerWidth,
+      setCanvasEnabled,
+      toggleCanvas,
+      setCanvasText,
       setSelection,
       hydrateSelections,
     }),
@@ -230,6 +274,9 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       toggleComputerOpen,
       setComputerTab,
       setComputerWidth,
+      setCanvasEnabled,
+      toggleCanvas,
+      setCanvasText,
       setSelection,
       hydrateSelections,
     ],

--- a/frontend/src/lib/agent/tools/persistence.test.ts
+++ b/frontend/src/lib/agent/tools/persistence.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { clampComputerWidth, computerSnapWidths, gentlySnapComputerWidth } from "./persistence";
+import {
+  clampComputerWidth,
+  computerSnapWidths,
+  gentlySnapComputerWidth,
+  uniqueComputerTabs,
+} from "./persistence";
 
 describe("computer panel width helpers", () => {
   it("uses the requested percentage snap widths inside the available bounds", () => {
@@ -13,5 +18,13 @@ describe("computer panel width helpers", () => {
 
   it("keeps the chat side usable when clamping wide computer widths", () => {
     expect(clampComputerWidth(900, 1200)).toBe(780);
+  });
+
+  it("keeps status as the anchor while allowing multiple open computer tabs", () => {
+    expect(uniqueComputerTabs(["browser", "files", "browser"])).toEqual([
+      "status",
+      "browser",
+      "files",
+    ]);
   });
 });

--- a/frontend/src/lib/agent/tools/persistence.test.ts
+++ b/frontend/src/lib/agent/tools/persistence.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { clampComputerWidth, computerSnapWidths, gentlySnapComputerWidth } from "./persistence";
+
+describe("computer panel width helpers", () => {
+  it("uses the requested percentage snap widths inside the available bounds", () => {
+    expect(computerSnapWidths(1200)).toEqual([300, 420, 600, 780]);
+  });
+
+  it("only snaps when the dropped width is close to a snap point", () => {
+    expect(gentlySnapComputerWidth(424, 1200)).toBe(420);
+    expect(gentlySnapComputerWidth(470, 1200)).toBe(470);
+  });
+
+  it("keeps the chat side usable when clamping wide computer widths", () => {
+    expect(clampComputerWidth(900, 1200)).toBe(780);
+  });
+});

--- a/frontend/src/lib/agent/tools/persistence.ts
+++ b/frontend/src/lib/agent/tools/persistence.ts
@@ -11,6 +11,7 @@ export const COMPUTER_FILES_OPEN_KEY = "vllm-studio.agent.computer.filesOpen";
 export const COMPUTER_DEFAULT_CLOSED_STORAGE_ID = "vllm-studio.agent.computer.defaultCollapsedV2";
 export const COMPUTER_WIDTH_KEY = "vllm-studio.agent.computer.width";
 export const COMPUTER_TAB_KEY = "vllm-studio.agent.computer.tab";
+export const COMPUTER_TABS_KEY = "vllm-studio.agent.computer.tabs";
 export const COMPUTER_CANVAS_ENABLED_KEY = "vllm-studio.agent.computer.canvasEnabled";
 export const COMPUTER_CANVAS_TEXT_KEY = "vllm-studio.agent.computer.canvasText";
 
@@ -20,6 +21,8 @@ export const MIN_COMPUTER_WIDTH = 280;
 export const MAX_COMPUTER_WIDTH = 1800;
 export const MIN_CHAT_WIDTH_WHEN_COMPUTER_OPEN = 340;
 export const COMPUTER_SNAP_RATIOS = [0.25, 0.35, 0.5, 0.65] as const;
+
+const COMPUTER_TABS: ComputerTab[] = ["status", "canvas", "browser", "files", "diff", "terminal"];
 
 function viewportWidth(): number | undefined {
   return typeof window === "undefined" ? undefined : window.innerWidth;
@@ -126,20 +129,51 @@ export function loadBrowserState(): BrowserState {
 export function loadComputerState(): ComputerState {
   const storedWidth = Number(read(COMPUTER_WIDTH_KEY));
   const storedTab = read(COMPUTER_TAB_KEY);
-  const tab: ComputerTab =
-    storedTab === "browser" ||
-    storedTab === "files" ||
-    storedTab === "diff" ||
-    storedTab === "terminal"
-      ? storedTab
-      : "status";
+  const tab: ComputerTab = isComputerTab(storedTab) ? storedTab : "status";
+  const storedTabs = readComputerTabs();
+  const canvasEnabled = read(COMPUTER_CANVAS_ENABLED_KEY) === "1";
+  const persistedTabs = uniqueComputerTabs([
+    "status",
+    ...(storedTabs.length ? storedTabs : [tab]),
+    ...(canvasEnabled ? (["canvas"] as const) : []),
+  ]);
+  const tabs = persistedTabs.includes(tab)
+    ? persistedTabs
+    : uniqueComputerTabs([...persistedTabs, tab]);
   return {
     open: false,
     tab,
+    tabs,
     width: Number.isFinite(storedWidth) ? clampComputerWidth(storedWidth) : DEFAULT_COMPUTER_WIDTH,
-    canvasEnabled: read(COMPUTER_CANVAS_ENABLED_KEY) === "1",
+    canvasEnabled,
     canvasText: read(COMPUTER_CANVAS_TEXT_KEY) ?? "",
   };
+}
+
+function isComputerTab(value: unknown): value is ComputerTab {
+  return typeof value === "string" && COMPUTER_TABS.includes(value as ComputerTab);
+}
+
+function readComputerTabs(): ComputerTab[] {
+  const raw = read(COMPUTER_TABS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? uniqueComputerTabs(parsed.filter(isComputerTab)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function uniqueComputerTabs(tabs: ComputerTab[]): ComputerTab[] {
+  const seen = new Set<ComputerTab>();
+  const out: ComputerTab[] = [];
+  for (const tab of tabs) {
+    if (seen.has(tab)) continue;
+    seen.add(tab);
+    out.push(tab);
+  }
+  return out.includes("status") ? out : ["status", ...out];
 }
 
 export function writeBrowserEnabled(enabled: boolean): void {
@@ -149,6 +183,10 @@ export function writeBrowserEnabled(enabled: boolean): void {
 export function writeComputerTab(tab: ComputerTab): void {
   write(COMPUTER_FILES_OPEN_KEY, tab === "files" ? "1" : "0");
   write(COMPUTER_TAB_KEY, tab);
+}
+
+export function writeComputerTabs(tabs: ComputerTab[]): void {
+  write(COMPUTER_TABS_KEY, JSON.stringify(uniqueComputerTabs(tabs)));
 }
 
 export function writeComputerWidth(width: number): void {

--- a/frontend/src/lib/agent/tools/persistence.ts
+++ b/frontend/src/lib/agent/tools/persistence.ts
@@ -16,12 +16,58 @@ export const COMPUTER_CANVAS_TEXT_KEY = "vllm-studio.agent.computer.canvasText";
 
 export const DEFAULT_BROWSER_URL = "https://www.google.com";
 export const DEFAULT_COMPUTER_WIDTH = 440;
-export const MIN_COMPUTER_WIDTH = 320;
-export const MAX_COMPUTER_WIDTH = 960;
+export const MIN_COMPUTER_WIDTH = 280;
+export const MAX_COMPUTER_WIDTH = 1800;
+export const MIN_CHAT_WIDTH_WHEN_COMPUTER_OPEN = 340;
+export const COMPUTER_SNAP_RATIOS = [0.25, 0.35, 0.5, 0.65] as const;
 
-export function clampComputerWidth(width: number): number {
+function viewportWidth(): number | undefined {
+  return typeof window === "undefined" ? undefined : window.innerWidth;
+}
+
+export function computerWidthBounds(containerWidth = viewportWidth()): {
+  min: number;
+  max: number;
+} {
+  if (!containerWidth || !Number.isFinite(containerWidth)) {
+    return { min: MIN_COMPUTER_WIDTH, max: MAX_COMPUTER_WIDTH };
+  }
+  const minimum = Math.max(
+    MIN_COMPUTER_WIDTH,
+    Math.round(containerWidth * COMPUTER_SNAP_RATIOS[0]),
+  );
+  const roomyMaximum = Math.round(
+    containerWidth * COMPUTER_SNAP_RATIOS[COMPUTER_SNAP_RATIOS.length - 1],
+  );
+  const chatSafeMaximum = Math.max(minimum, containerWidth - MIN_CHAT_WIDTH_WHEN_COMPUTER_OPEN);
+  return {
+    min: minimum,
+    max: Math.min(MAX_COMPUTER_WIDTH, roomyMaximum, chatSafeMaximum),
+  };
+}
+
+export function clampComputerWidth(width: number, containerWidth?: number): number {
   if (!Number.isFinite(width)) return DEFAULT_COMPUTER_WIDTH;
-  return Math.min(MAX_COMPUTER_WIDTH, Math.max(MIN_COMPUTER_WIDTH, Math.round(width)));
+  const { min, max } = computerWidthBounds(containerWidth);
+  return Math.min(max, Math.max(min, Math.round(width)));
+}
+
+export function computerSnapWidths(containerWidth: number): number[] {
+  const { min, max } = computerWidthBounds(containerWidth);
+  return COMPUTER_SNAP_RATIOS.map((ratio) => Math.round(containerWidth * ratio)).filter(
+    (width) => width >= min && width <= max,
+  );
+}
+
+export function gentlySnapComputerWidth(width: number, containerWidth: number): number {
+  const clamped = clampComputerWidth(width, containerWidth);
+  const snapThreshold = Math.max(14, Math.min(30, Math.round(containerWidth * 0.015)));
+  const nearest = computerSnapWidths(containerWidth).reduce<number | null>((best, candidate) => {
+    if (best === null) return candidate;
+    return Math.abs(candidate - clamped) < Math.abs(best - clamped) ? candidate : best;
+  }, null);
+  if (nearest === null || Math.abs(nearest - clamped) > snapThreshold) return clamped;
+  return nearest;
 }
 
 function read(key: string): string | null {

--- a/frontend/src/lib/agent/tools/persistence.ts
+++ b/frontend/src/lib/agent/tools/persistence.ts
@@ -8,9 +8,11 @@ export const BROWSER_TOOL_DEFAULT_OFF_MIGRATION_KEY =
   "***************************************************";
 export const COMPUTER_BROWSER_OPEN_KEY = "vllm-studio.agent.computer.browserOpen";
 export const COMPUTER_FILES_OPEN_KEY = "vllm-studio.agent.computer.filesOpen";
-export const COMPUTER_DEFAULT_CLOSED_STORAGE_ID =
-  "vllm-studio.agent.computer.defaultCollapsedV2";
+export const COMPUTER_DEFAULT_CLOSED_STORAGE_ID = "vllm-studio.agent.computer.defaultCollapsedV2";
 export const COMPUTER_WIDTH_KEY = "vllm-studio.agent.computer.width";
+export const COMPUTER_TAB_KEY = "vllm-studio.agent.computer.tab";
+export const COMPUTER_CANVAS_ENABLED_KEY = "vllm-studio.agent.computer.canvasEnabled";
+export const COMPUTER_CANVAS_TEXT_KEY = "vllm-studio.agent.computer.canvasText";
 
 export const DEFAULT_BROWSER_URL = "https://www.google.com";
 export const DEFAULT_COMPUTER_WIDTH = 440;
@@ -77,11 +79,20 @@ export function loadBrowserState(): BrowserState {
 
 export function loadComputerState(): ComputerState {
   const storedWidth = Number(read(COMPUTER_WIDTH_KEY));
-  const tab: ComputerTab = read(COMPUTER_FILES_OPEN_KEY) === "1" ? "files" : "browser";
+  const storedTab = read(COMPUTER_TAB_KEY);
+  const tab: ComputerTab =
+    storedTab === "browser" ||
+    storedTab === "files" ||
+    storedTab === "diff" ||
+    storedTab === "terminal"
+      ? storedTab
+      : "status";
   return {
     open: false,
     tab,
     width: Number.isFinite(storedWidth) ? clampComputerWidth(storedWidth) : DEFAULT_COMPUTER_WIDTH,
+    canvasEnabled: read(COMPUTER_CANVAS_ENABLED_KEY) === "1",
+    canvasText: read(COMPUTER_CANVAS_TEXT_KEY) ?? "",
   };
 }
 
@@ -91,8 +102,17 @@ export function writeBrowserEnabled(enabled: boolean): void {
 
 export function writeComputerTab(tab: ComputerTab): void {
   write(COMPUTER_FILES_OPEN_KEY, tab === "files" ? "1" : "0");
+  write(COMPUTER_TAB_KEY, tab);
 }
 
 export function writeComputerWidth(width: number): void {
   write(COMPUTER_WIDTH_KEY, String(clampComputerWidth(width)));
+}
+
+export function writeComputerCanvasEnabled(enabled: boolean): void {
+  write(COMPUTER_CANVAS_ENABLED_KEY, enabled ? "1" : "0");
+}
+
+export function writeComputerCanvasText(text: string): void {
+  write(COMPUTER_CANVAS_TEXT_KEY, text);
 }

--- a/frontend/src/lib/agent/tools/types.ts
+++ b/frontend/src/lib/agent/tools/types.ts
@@ -9,7 +9,7 @@
 import type { ComposerPluginRef, ComposerSkillRef } from "@/lib/agent/composer-context";
 import type { SessionId } from "@/lib/agent/sessions/types";
 
-export type ComputerTab = "status" | "browser" | "files" | "diff" | "terminal";
+export type ComputerTab = "status" | "canvas" | "browser" | "files" | "diff" | "terminal";
 
 export type BrowserState = {
   enabled: boolean;
@@ -20,6 +20,7 @@ export type BrowserState = {
 export type ComputerState = {
   open: boolean;
   tab: ComputerTab;
+  tabs: ComputerTab[];
   width: number;
   canvasEnabled: boolean;
   canvasText: string;

--- a/frontend/src/lib/agent/tools/types.ts
+++ b/frontend/src/lib/agent/tools/types.ts
@@ -9,7 +9,7 @@
 import type { ComposerPluginRef, ComposerSkillRef } from "@/lib/agent/composer-context";
 import type { SessionId } from "@/lib/agent/sessions/types";
 
-export type ComputerTab = "browser" | "files" | "diff" | "terminal";
+export type ComputerTab = "status" | "browser" | "files" | "diff" | "terminal";
 
 export type BrowserState = {
   enabled: boolean;
@@ -21,6 +21,8 @@ export type ComputerState = {
   open: boolean;
   tab: ComputerTab;
   width: number;
+  canvasEnabled: boolean;
+  canvasText: string;
 };
 
 export type ToolSelection = {

--- a/frontend/src/lib/agent/workspace/effects.test.ts
+++ b/frontend/src/lib/agent/workspace/effects.test.ts
@@ -103,6 +103,92 @@ describe("runWorkspaceEffect", () => {
     expect(events.map((event) => event.type)).not.toContain(SESSIONS_CHANGED_EVENT);
   });
 
+  it("persists pane metadata without transcript payloads", () => {
+    const storage = memoryStorage();
+    const { deps } = makeDeps(storage);
+    const state = createInitialState();
+    const action: WorkspaceAction = {
+      type: "replaySession",
+      piSessionId: "pi-1",
+      tab: tab({
+        id: "tab-pi-1",
+        runtimeSessionId: "rt-tab-pi-1",
+        piSessionId: "pi-1",
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            text: "",
+            blocks: [{ kind: "thinking", id: "think-1", text: "x".repeat(50_000) }],
+          },
+        ],
+      }),
+    };
+    const next = reducer(state, action);
+
+    runWorkspaceEffect(action, state, next, deps);
+
+    const raw = storage.value(PANE_STATE_KEY) ?? "";
+    expect(raw).toContain("pi-1");
+    expect(raw).not.toContain("messages");
+    expect(raw).not.toContain("think-1");
+  });
+
+  it("does not write pane state for streaming setPaneTabs mutations", () => {
+    const storage = memoryStorage();
+    const { deps } = makeDeps(storage);
+    const state = createInitialState();
+    const paneId = state.focusedPaneId;
+    const session = state.sessions.get(state.panesById.get(paneId)!.activeSessionId)!;
+    const action: WorkspaceAction = {
+      type: "setPaneTabs",
+      paneId,
+      tabs: [
+        {
+          ...session,
+          messages: [
+            {
+              id: "assistant-1",
+              role: "assistant",
+              text: "",
+              blocks: [{ kind: "thinking", id: "think-1", text: "x".repeat(50_000) }],
+            },
+          ],
+        },
+      ],
+    };
+    const next = reducer(state, action);
+
+    runWorkspaceEffect(action, state, next, deps);
+
+    expect(storage.value(PANE_STATE_KEY)).toBeUndefined();
+    expect(storage.setItem).not.toHaveBeenCalledWith(
+      PANE_STATE_KEY,
+      expect.stringContaining("think-1"),
+    );
+  });
+
+  it("writes pane metadata when setPaneTabs changes recoverable session identity", () => {
+    const storage = memoryStorage();
+    const { deps } = makeDeps(storage);
+    const state = createInitialState();
+    const paneId = state.focusedPaneId;
+    const session = state.sessions.get(state.panesById.get(paneId)!.activeSessionId)!;
+    const action: WorkspaceAction = {
+      type: "setPaneTabs",
+      paneId,
+      tabs: [{ ...session, piSessionId: "pi-1", status: "running" }],
+    };
+    const next = reducer(state, action);
+
+    runWorkspaceEffect(action, state, next, deps);
+
+    const raw = storage.value(PANE_STATE_KEY) ?? "";
+    expect(raw).toContain("pi-1");
+    expect(raw).toContain("running");
+    expect(raw).not.toContain("messages");
+  });
+
   it("dispatches a sessions refresh when a tab gains a pi session id", () => {
     const { deps, events } = makeDeps();
     const state = hydratedProjectState(createInitialState());

--- a/frontend/src/lib/agent/workspace/effects.ts
+++ b/frontend/src/lib/agent/workspace/effects.ts
@@ -7,6 +7,7 @@ import type { ToolSelection } from "@/lib/agent/tools/types";
 import type { AgentModel, PaneId, WorkspaceAction, WorkspaceState } from "./types";
 import {
   loadPersistedActiveAgentSessions,
+  sessionMetaForPersistence,
   setupWarningFromPiCheck,
   type WorkspaceStorage,
 } from "./store";
@@ -73,8 +74,6 @@ const PANE_STATE_ACTIONS = new Set<WorkspaceAction["type"]>([
   "renameTab",
   "splitTab",
   "closePane",
-  "setPaneTabs",
-  "patchActiveTab",
   "hydrateActiveSessions",
   "urlNavRequested",
 ]);
@@ -94,6 +93,8 @@ const SESSIONS_CHANGED_ACTIONS = new Set<WorkspaceAction["type"]>([
   "notifySessionsChanged",
   "urlNavRequested",
 ]);
+
+const METADATA_PATCH_ACTIONS = new Set<WorkspaceAction["type"]>(["setPaneTabs", "patchActiveTab"]);
 
 function dispatchEvent(deps: WorkspaceEffectDeps, type: string): void {
   deps.window.dispatchEvent(new deps.window.Event(type));
@@ -402,15 +403,48 @@ function queueReplayEffects(
 
 function persistActionEffects(
   action: WorkspaceAction,
-  _prevState: WorkspaceState,
+  prevState: WorkspaceState,
   nextState: WorkspaceState,
   deps: WorkspaceEffectDeps,
 ): void {
   if (PANE_STATE_ACTIONS.has(action.type)) {
     writePaneState(deps.storage, nextState, deps.selectionFor);
+    return;
+  }
+  if (
+    METADATA_PATCH_ACTIONS.has(action.type) &&
+    paneMetadataKey(prevState, deps.selectionFor) !== paneMetadataKey(nextState, deps.selectionFor)
+  ) {
+    writePaneState(deps.storage, nextState, deps.selectionFor);
   }
   // Browser/computer tool state persistence now lives in
   // lib/agent/tools/persistence.ts and is driven by ToolsProvider directly.
+}
+
+function paneMetadataKey(
+  state: WorkspaceState,
+  selectionFor: ((sessionId: SessionId) => ToolSelection | null) | undefined,
+): string {
+  const panes: Record<string, unknown> = {};
+  for (const [paneId, pane] of state.panesById.entries()) {
+    panes[paneId] = {
+      activeSessionId: pane.activeSessionId,
+      runtimeSessionId: pane.runtimeSessionId,
+      sessionIds: pane.sessionIds,
+      tabs: pane.sessionIds
+        .map((id) => {
+          const session = state.sessions.get(id);
+          if (!session) return null;
+          return sessionMetaForPersistence(session, selectionFor?.(id) ?? undefined);
+        })
+        .filter(Boolean),
+    };
+  }
+  return JSON.stringify({
+    layout: state.layout,
+    focusedPaneId: state.focusedPaneId,
+    panes,
+  });
 }
 
 export function runWorkspaceEffect(

--- a/frontend/src/lib/agent/workspace/persistence.ts
+++ b/frontend/src/lib/agent/workspace/persistence.ts
@@ -9,7 +9,7 @@ import {
   PANE_STATE_KEY,
   persistActiveAgentSessions,
   restorePersistedPaneState,
-  tabForPersistence,
+  sessionMetaForPersistence,
   type WorkspaceStorage,
 } from "./store";
 import { makeFreshTab, newRuntimeId } from "@/lib/agent/session/helpers";
@@ -113,14 +113,14 @@ export function writePaneState(
     {
       activeTabId: string;
       runtimeSessionId: string;
-      tabs: ReturnType<typeof tabForPersistence>[];
+      tabs: ReturnType<typeof sessionMetaForPersistence>[];
     }
   > = {};
   for (const [paneId, pane] of state.panesById.entries()) {
-    const tabs: ReturnType<typeof tabForPersistence>[] = [];
+    const tabs: ReturnType<typeof sessionMetaForPersistence>[] = [];
     for (const id of pane.sessionIds) {
       const session = state.sessions.get(id);
-      if (session) tabs.push(tabForPersistence(session, selectionFor(id) ?? undefined));
+      if (session) tabs.push(sessionMetaForPersistence(session, selectionFor(id) ?? undefined));
     }
     panes[paneId] = {
       activeTabId: pane.activeSessionId,

--- a/frontend/src/lib/agent/workspace/store.test.ts
+++ b/frontend/src/lib/agent/workspace/store.test.ts
@@ -7,6 +7,7 @@ import {
   createInitialState,
   normalizePersistedTab,
   reducer,
+  sessionMetaForPersistence,
   setupWarningFromPiCheck,
 } from "./store";
 
@@ -44,6 +45,31 @@ function pane(state: WorkspaceState, paneId = state.focusedPaneId) {
 }
 
 describe("normalizePersistedTab", () => {
+  it("drops legacy persisted transcript payloads during pane-state restore", () => {
+    const restored = normalizePersistedTab({
+      id: "tab-1",
+      runtimeSessionId: "rt-1",
+      piSessionId: "pi-1",
+      title: "Legacy payload",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          text: "answer",
+          blocks: [
+            { kind: "thinking", id: "think-1", text: "x".repeat(50_000) },
+            { kind: "tool", id: "tool-1", name: "write", status: "done", text: "payload" },
+          ],
+        },
+      ],
+      status: "idle",
+      input: "",
+    });
+
+    expect(restored?.messages).toEqual([]);
+    expect(restored?.piSessionId).toBe("pi-1");
+  });
+
   it("preserves selected plugin and skill tabs across pane-state restore", () => {
     const restored = normalizePersistedTab({
       id: "tab-1",
@@ -62,6 +88,66 @@ describe("normalizePersistedTab", () => {
       runtimeSessionId: "rt-1",
       plugins: [{ id: "browser", name: "browser-use", enabled: true }],
       skills: [{ id: "agent-browser", name: "agent-browser", path: "/skills/agent-browser" }],
+    });
+  });
+});
+
+describe("sessionMetaForPersistence", () => {
+  it("strips transcript, tool, reasoning, and attachment bodies from persisted pane state", () => {
+    const persisted = sessionMetaForPersistence(
+      tab({
+        piSessionId: "pi-1",
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            text: "look",
+            attachments: [
+              {
+                id: "att-1",
+                name: "image.png",
+                type: "image/png",
+                size: 123,
+                mode: "data-url",
+                content: "data:image/png;base64,huge",
+                previewKind: "image",
+                previewUrl: "blob:http://local/1",
+              },
+            ],
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            text: "",
+            blocks: [
+              { kind: "thinking", id: "think-1", text: "private reasoning" },
+              {
+                kind: "tool",
+                id: "tool-1",
+                name: "write",
+                status: "done",
+                argsText: "large args",
+                resultText: "large result",
+                text: "large args",
+              },
+            ],
+          },
+        ],
+        queue: [{ id: "queue-1", mode: "follow_up", text: "next", sent: true }],
+      }),
+      { plugins: [{ id: "browser", name: "browser-use", enabled: true }], skills: [] },
+    );
+
+    expect("messages" in persisted).toBe(false);
+    expect("error" in persisted).toBe(false);
+    expect(JSON.stringify(persisted)).not.toContain("private reasoning");
+    expect(JSON.stringify(persisted)).not.toContain("data:image/png");
+    expect(persisted).toMatchObject({
+      id: "tab-1",
+      runtimeSessionId: "rt-tab-1",
+      piSessionId: "pi-1",
+      queue: [{ id: "queue-1", mode: "follow_up", text: "next", sent: true }],
+      plugins: [{ id: "browser", name: "browser-use", enabled: true }],
     });
   });
 });

--- a/frontend/src/lib/agent/workspace/store.ts
+++ b/frontend/src/lib/agent/workspace/store.ts
@@ -74,6 +74,11 @@ type PersistedTabShape = Partial<Session> & {
   skills?: ComposerSkillRef[];
 };
 
+export type PersistedSessionMeta = Omit<Session, "messages" | "error"> & {
+  plugins?: ComposerPluginRef[];
+  skills?: ComposerSkillRef[];
+};
+
 export function normalizePersistedTab(value: unknown): Session | null {
   if (!value || typeof value !== "object") return null;
   const tab = value as PersistedTabShape;
@@ -86,7 +91,10 @@ export function normalizePersistedTab(value: unknown): Session | null {
     runtimeSessionId: tab.runtimeSessionId,
     piSessionId: typeof tab.piSessionId === "string" ? tab.piSessionId : null,
     title: typeof tab.title === "string" && tab.title.trim() ? tab.title : fallback.title,
-    messages: Array.isArray(tab.messages) ? tab.messages.slice(-80) : [],
+    // The canonical session log is the transcript source of truth. Legacy
+    // pane-state entries may still contain messages, but restoring them here
+    // would put large reasoning/tool payloads back onto the renderer hot path.
+    messages: [],
     status: typeof tab.status === "string" ? tab.status : "idle",
     error: "",
     startedAt: typeof tab.startedAt === "string" ? tab.startedAt : undefined,
@@ -210,22 +218,29 @@ export function restorePersistedPaneState(raw: string): RestoredPaneState | null
 }
 
 /**
- * Serialize a session for persistence. Tool selection (plugins/skills) is
- * embedded back into the persisted tab so older clients keep loading; the
- * runtime model keeps them in the tools subsystem.
+ * Serialize only durable session metadata. Transcripts, reasoning, tool
+ * payloads, attachment bodies, and preview data belong to canonical session
+ * storage or runtime memory, never pane-state localStorage.
  */
-export function tabForPersistence(
+export function sessionMetaForPersistence(
   tab: Session,
   selection?: ToolSelection,
-): Session & {
-  plugins?: ComposerPluginRef[];
-  skills?: ComposerSkillRef[];
-} {
-  const base: Session = {
-    ...tab,
-    messages: tab.messages.slice(-80),
+): PersistedSessionMeta {
+  const base: PersistedSessionMeta = {
+    id: tab.id,
+    runtimeSessionId: tab.runtimeSessionId,
+    piSessionId: tab.piSessionId,
+    projectId: tab.projectId,
+    cwd: tab.cwd,
+    modelId: tab.modelId,
+    title: tab.title,
     status: tab.status,
-    error: "",
+    startedAt: tab.startedAt,
+    input: tab.input,
+    tokenStats: tab.tokenStats,
+    activeAssistantId: tab.activeAssistantId,
+    lastEventSeq: tab.lastEventSeq,
+    queue: tab.queue,
   };
   if (selection) {
     return {


### PR DESCRIPTION
## Summary\n- Rework Computer into a status-first workspace with a compact active tab and + menu for Browser, Git, Filesystem, and Terminal surfaces.\n- Add a persisted Canvas scratchboard toggle in the composer and status pane.\n- Clean up filesystem browsing, add diff layout modes, and replace the terminal command-card UI with an xterm-based surface.\n\n## Verification\n- npm run lint\n- npx tsc --noEmit\n- npm test -- --run src/app/agent/_components/git-diff-panel-model.test.ts src/app/agent/_components/agent-workspace.test.ts src/app/agent/_components/use-workspace.test.tsx\n- npm test\n- npx next build\n- npm run desktop:dist\n- Playwright screenshots: computer-status.png, computer-tab-menu.png, computer-terminal.png\n- Installed /Applications/vLLM Studio.app and verified bundle id org.vllm.studio.desktop\n