### PR TITLE
micro: extract composer mention selection

### DIFF
--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -5,7 +5,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type ClipboardEvent,
   type DragEvent,
   type ReactNode,
@@ -22,22 +21,19 @@ import {
 } from "@/ui/agent-composer-context";
 import { AgentQueuePanel } from "@/ui/agent-queue-panel";
 import {
+  useChatPaneContextAttachEffect,
   useChatPaneMentionEffects,
   useChatPaneRegisterHandleEffect,
   useChatPaneStickToBottomEffect,
 } from "@/hooks/agent/use-chat-pane-effects";
 import { useProjectsNavSessionPrefs } from "@/hooks/agent/use-projects-nav-section-effects";
 import {
-  activateComposerPlugin,
   activeComposerPlugins,
   byQuery,
   detectComposerMention,
-  consumeComposerMention,
   selectedContextPrompt,
   type ComposerMention,
   type ComposerPluginRef,
-  type ComposerPromptTemplateRef,
-  type ComposerSkillRef,
 } from "@/lib/agent/composer-context";
 import {
   AgentTurnSsePayload,
@@ -70,7 +66,6 @@ import {
   attachmentDedupKey,
   attachmentPrompt,
   createAttachment,
-  createProjectFileAttachment,
   dataTransferHasFiles,
   filesFromDataTransfer,
   imageFileFromDataUrlText,
@@ -78,6 +73,7 @@ import {
   type ChatAttachment,
 } from "./chat-attachments";
 import { Timeline } from "./timeline/timeline";
+import { useComposerMentionSelection } from "./use-composer-mention-selection";
 export type {
   AgentTurnSsePayload,
   AssistantBlock,
@@ -200,42 +196,11 @@ export function ChatPane({
     activeTabId: activeTab?.id,
     setStickToBottom,
   });
-  // Consume "attach as context" requests (e.g. file comments from the
-  // filesystem panel) into this pane's composer attachments. Only the focused
-  // pane consumes a given request; a handled-id guard prevents re-adding.
-  // Uses useSyncExternalStore (not useEffect) per this repo's workspace rule.
-  const contextAttachRequest = tools.contextAttachRequest;
-  const handledContextAttachRef = useRef(0);
-  const subscribeContextAttach = useCallback(() => {
-    if (
-      contextAttachRequest &&
-      isFocused &&
-      handledContextAttachRef.current !== contextAttachRequest.id
-    ) {
-      handledContextAttachRef.current = contextAttachRequest.id;
-      const attachment: ChatAttachment = {
-        id: newId("ctx"),
-        name: contextAttachRequest.label,
-        type: "text/plain",
-        size: contextAttachRequest.content.length,
-        ...(contextAttachRequest.path ? { path: contextAttachRequest.path } : {}),
-        mode: "text",
-        content: contextAttachRequest.content,
-        previewKind: "file",
-      };
-      setAttachments((current) => {
-        const nextKey = attachmentDedupKey(attachment);
-        if (current.some((file) => attachmentDedupKey(file) === nextKey)) return current;
-        return [...current, attachment];
-      });
-    }
-    return () => undefined;
-  }, [contextAttachRequest, isFocused]);
-  useSyncExternalStore(
-    subscribeContextAttach,
-    getChatPaneEffectSnapshot,
-    getChatPaneEffectSnapshot,
-  );
+  useChatPaneContextAttachEffect({
+    contextAttachRequest: tools.contextAttachRequest,
+    isFocused,
+    setAttachments,
+  });
   const mentionRows = useMemo<MentionRow[]>(() => {
     if (!mention) return [];
     if (mention.kind === "skill") {
@@ -328,103 +293,16 @@ export function ChatPane({
     },
     [activeTab, displayedSessionTitle, onRenameSession, patchActiveSessionPrefs],
   );
-  const selectMentionRow = useCallback(
-    async (entry: MentionRow) => {
-      if (!activeTab || !mention) return;
-      const selectedMention = mention;
-      if (entry.kind === "file") {
-        const input = consumeComposerMention(activeTab.input, selectedMention);
-        updateTab(activeTab.id, (tab) => ({ ...tab, input }));
-        const loaded = await fetch(
-          `/api/agent/fs/file?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(entry.row.rel)}`,
-          { cache: "no-store" },
-        )
-          .then((response) =>
-            response.ok
-              ? (response.json() as Promise<{
-                  content: string;
-                  truncated: boolean;
-                  size: number;
-                }>)
-              : null,
-          )
-          .catch(() => null);
-        const attachment = createProjectFileAttachment({
-          id: entry.row.id,
-          name: entry.row.name,
-          path: entry.row.path,
-          content: loaded?.content ?? "",
-          truncated: loaded?.truncated ?? true,
-          size: loaded?.size ?? 0,
-        });
-        setAttachments((current) => {
-          const nextKey = attachmentDedupKey(attachment);
-          if (current.some((file) => attachmentDedupKey(file) === nextKey)) return current;
-          return [...current, attachment];
-        });
-        setMention(null);
-        requestAnimationFrame(() => textareaRef.current?.focus());
-        return;
-      }
-      const row = entry.row;
-      const input = consumeComposerMention(activeTab.input, selectedMention);
-      let selectedRow = row;
-      if ("path" in row && row.path) {
-        const endpoint =
-          selectedMention.kind === "skill"
-            ? `/api/agent/skills/load?path=${encodeURIComponent(row.path)}`
-            : selectedMention.kind === "promptTemplate"
-              ? `/api/agent/prompt-templates/load?path=${encodeURIComponent(row.path)}`
-              : `/api/agent/plugins/load?path=${encodeURIComponent(row.path)}`;
-        const loaded = await fetch(endpoint, { cache: "no-store" })
-          .then((res) =>
-            res.ok
-              ? (res.json() as Promise<{
-                  skill?: ComposerSkillRef;
-                  plugin?: ComposerPluginRef;
-                  template?: ComposerPromptTemplateRef;
-                }>)
-              : null,
-          )
-          .catch(() => null);
-        selectedRow = loaded?.skill
-          ? { ...row, ...loaded.skill, id: row.id }
-          : loaded?.plugin
-            ? { ...row, ...loaded.plugin, id: row.id }
-            : loaded?.template
-              ? { ...row, ...loaded.template, id: row.id }
-              : row;
-      }
-      updateTab(activeTab.id, (tab) => ({ ...tab, input }));
-      const current = tools.selectionFor(activeTab.id);
-      if (selectedMention.kind === "plugin") {
-        if (!current.plugins.some((plugin) => plugin.id === selectedRow.id)) {
-          tools.setSelection(activeTab.id, {
-            ...current,
-            plugins: [...current.plugins, activateComposerPlugin(selectedRow as ComposerPluginRef)],
-          });
-        }
-      } else if (selectedMention.kind === "skill") {
-        if (!current.skills.some((skill) => skill.id === selectedRow.id)) {
-          tools.setSelection(activeTab.id, {
-            ...current,
-            skills: [...current.skills, selectedRow as ComposerSkillRef],
-          });
-        }
-      } else if (
-        selectedMention.kind === "promptTemplate" &&
-        !current.promptTemplates.some((template) => template.id === selectedRow.id)
-      ) {
-        tools.setSelection(activeTab.id, {
-          ...current,
-          promptTemplates: [...current.promptTemplates, selectedRow as ComposerPromptTemplateRef],
-        });
-      }
-      setMention(null);
-      requestAnimationFrame(() => textareaRef.current?.focus());
-    },
-    [activeTab, cwd, mention, tools, updateTab],
-  );
+  const selectMentionRow = useComposerMentionSelection({
+    activeTab,
+    mention,
+    cwd,
+    tools,
+    updateTab,
+    setAttachments,
+    setMention,
+    textareaRef,
+  });
   const removeLoadedContext = useCallback(
     (kind: "plugin" | "skill" | "promptTemplate", id: string) => {
       if (!activeTab) return;
@@ -1070,5 +948,3 @@ export function ChatPane({
     </section>
   );
 }
-
-const getChatPaneEffectSnapshot = (): number => 0;

--- a/frontend/src/app/agent/_components/use-composer-mention-selection.ts
+++ b/frontend/src/app/agent/_components/use-composer-mention-selection.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, type Dispatch, type RefObject, type SetStateAction } from "react";
+import {
+  activateComposerPlugin,
+  consumeComposerMention,
+  type ComposerMention,
+  type ComposerPluginRef,
+  type ComposerPromptTemplateRef,
+  type ComposerSkillRef,
+} from "@/lib/agent/composer-context";
+import type { SessionTab } from "@/lib/agent/session";
+import type { ToolsContextValue } from "@/lib/agent/tools/context";
+import type { MentionRow } from "@/ui/agent-composer-context";
+import {
+  attachmentDedupKey,
+  createProjectFileAttachment,
+  type ChatAttachment,
+} from "./chat-attachments";
+
+type ContextRow = ComposerPluginRef | ComposerSkillRef | ComposerPromptTemplateRef;
+type LoadedContextRow = {
+  skill?: ComposerSkillRef;
+  plugin?: ComposerPluginRef;
+  template?: ComposerPromptTemplateRef;
+};
+
+export function useComposerMentionSelection({
+  activeTab,
+  mention,
+  cwd,
+  tools,
+  updateTab,
+  setAttachments,
+  setMention,
+  textareaRef,
+}: {
+  activeTab: SessionTab | null;
+  mention: ComposerMention | null;
+  cwd: string;
+  tools: Pick<ToolsContextValue, "selectionFor" | "setSelection">;
+  updateTab: (tabId: string, patch: (tab: SessionTab) => SessionTab) => void;
+  setAttachments: Dispatch<SetStateAction<ChatAttachment[]>>;
+  setMention: Dispatch<SetStateAction<ComposerMention | null>>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}) {
+  return useCallback(
+    async (entry: MentionRow) => {
+      if (!activeTab || !mention) return;
+
+      if (entry.kind === "file") {
+        const input = consumeComposerMention(activeTab.input, mention);
+        updateTab(activeTab.id, (tab) => ({ ...tab, input }));
+        addUniqueAttachment(setAttachments, await loadProjectFileAttachment(cwd, entry.row));
+      } else {
+        const selectedRow = await loadContextRow(entry.row, mention.kind);
+        const input = consumeComposerMention(activeTab.input, mention);
+        updateTab(activeTab.id, (tab) => ({ ...tab, input }));
+        applySelectedContext(activeTab.id, mention.kind, selectedRow, tools);
+      }
+
+      setMention(null);
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    },
+    [activeTab, cwd, mention, setAttachments, setMention, textareaRef, tools, updateTab],
+  );
+}
+
+async function loadProjectFileAttachment(
+  cwd: string,
+  row: Extract<MentionRow, { kind: "file" }>["row"],
+): Promise<ChatAttachment> {
+  const loaded = await jsonOrNull<{ content: string; truncated: boolean; size: number }>(
+    `/api/agent/fs/file?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(row.rel)}`,
+  );
+  return createProjectFileAttachment({
+    id: row.id,
+    name: row.name,
+    path: row.path,
+    content: loaded?.content ?? "",
+    truncated: loaded?.truncated ?? true,
+    size: loaded?.size ?? 0,
+  });
+}
+
+async function loadContextRow(row: ContextRow, kind: ComposerMention["kind"]): Promise<ContextRow> {
+  if (!row.path) return row;
+  const loaded = await jsonOrNull<LoadedContextRow>(loadEndpoint(kind, row.path));
+  return loaded?.skill
+    ? { ...row, ...loaded.skill, id: row.id }
+    : loaded?.plugin
+      ? { ...row, ...loaded.plugin, id: row.id }
+      : loaded?.template
+        ? { ...row, ...loaded.template, id: row.id }
+        : row;
+}
+
+function loadEndpoint(kind: ComposerMention["kind"], path: string): string {
+  const encoded = encodeURIComponent(path);
+  if (kind === "skill") return `/api/agent/skills/load?path=${encoded}`;
+  if (kind === "promptTemplate") return `/api/agent/prompt-templates/load?path=${encoded}`;
+  return `/api/agent/plugins/load?path=${encoded}`;
+}
+
+function applySelectedContext(
+  sessionId: string,
+  kind: ComposerMention["kind"],
+  selectedRow: ContextRow,
+  tools: Pick<ToolsContextValue, "selectionFor" | "setSelection">,
+) {
+  const current = tools.selectionFor(sessionId);
+  if (kind === "plugin" && !current.plugins.some((plugin) => plugin.id === selectedRow.id)) {
+    return tools.setSelection(sessionId, {
+      ...current,
+      plugins: [...current.plugins, activateComposerPlugin(selectedRow as ComposerPluginRef)],
+    });
+  }
+  if (kind === "skill" && !current.skills.some((skill) => skill.id === selectedRow.id)) {
+    return tools.setSelection(sessionId, {
+      ...current,
+      skills: [...current.skills, selectedRow as ComposerSkillRef],
+    });
+  }
+  if (
+    kind === "promptTemplate" &&
+    !current.promptTemplates.some((template) => template.id === selectedRow.id)
+  ) {
+    return tools.setSelection(sessionId, {
+      ...current,
+      promptTemplates: [...current.promptTemplates, selectedRow as ComposerPromptTemplateRef],
+    });
+  }
+}
+
+function addUniqueAttachment(
+  setAttachments: Dispatch<SetStateAction<ChatAttachment[]>>,
+  attachment: ChatAttachment,
+) {
+  setAttachments((current) => {
+    const nextKey = attachmentDedupKey(attachment);
+    if (current.some((file) => attachmentDedupKey(file) === nextKey)) return current;
+    return [...current, attachment];
+  });
+}
+
+function jsonOrNull<T>(url: string): Promise<T | null> {
+  return fetch(url, { cache: "no-store" })
+    .then((response) => (response.ok ? (response.json() as Promise<T>) : null))
+    .catch(() => null);
+}

--- a/frontend/src/hooks/agent/use-chat-pane-effects.ts
+++ b/frontend/src/hooks/agent/use-chat-pane-effects.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useRef,
   useSyncExternalStore,
   type Dispatch,
   type RefObject,
@@ -7,7 +8,9 @@ import {
 } from "react";
 
 import type { ComposerMention } from "@/lib/agent/composer-context";
-import type { ChatPaneHandle } from "@/lib/agent/session";
+import { newId, type ChatPaneHandle } from "@/lib/agent/session";
+import type { ContextAttachRequest } from "@/lib/agent/tools/types";
+import { attachmentDedupKey, type ChatAttachment } from "@/app/agent/_components/chat-attachments";
 
 const getChatPaneSnapshot = (): number => 0;
 
@@ -87,6 +90,45 @@ export function useChatPaneMentionEffects({
 
   useSyncExternalStore(subscribeMentionIndex, getChatPaneSnapshot, getChatPaneSnapshot);
   useSyncExternalStore(subscribeMentionRows, getChatPaneSnapshot, getChatPaneSnapshot);
+}
+
+export function useChatPaneContextAttachEffect({
+  contextAttachRequest,
+  isFocused,
+  setAttachments,
+}: {
+  contextAttachRequest: ContextAttachRequest | null;
+  isFocused: boolean;
+  setAttachments: Dispatch<SetStateAction<ChatAttachment[]>>;
+}): void {
+  const handledContextAttachRef = useRef(0);
+  const subscribeContextAttach = useCallback(() => {
+    if (
+      contextAttachRequest &&
+      isFocused &&
+      handledContextAttachRef.current !== contextAttachRequest.id
+    ) {
+      handledContextAttachRef.current = contextAttachRequest.id;
+      const attachment: ChatAttachment = {
+        id: newId("ctx"),
+        name: contextAttachRequest.label,
+        type: "text/plain",
+        size: contextAttachRequest.content.length,
+        ...(contextAttachRequest.path ? { path: contextAttachRequest.path } : {}),
+        mode: "text",
+        content: contextAttachRequest.content,
+        previewKind: "file",
+      };
+      setAttachments((current) => {
+        const nextKey = attachmentDedupKey(attachment);
+        if (current.some((file) => attachmentDedupKey(file) === nextKey)) return current;
+        return [...current, attachment];
+      });
+    }
+    return () => undefined;
+  }, [contextAttachRequest, isFocused, setAttachments]);
+
+  useSyncExternalStore(subscribeContextAttach, getChatPaneSnapshot, getChatPaneSnapshot);
 }
 
 export function useChatPaneRegisterHandleEffect({


### PR DESCRIPTION
## Summary
- extract composer mention row selection from ChatPane into a focused hook
- move context attach handling into the shared chat pane effects hook
- keep attachment dedupe and async load ordering behavior intact

## Verification
- npm --prefix frontend run typecheck
- npm --prefix frontend run lint
- npm --prefix frontend run check:static
- npm --prefix frontend run check:cleanup
- git diff --check
- npx --prefix frontend prettier --check frontend/src/app/agent/_components/chat-pane.tsx frontend/src/hooks/agent/use-chat-pane-effects.ts frontend/src/app/agent/_components/use-composer-mention-selection.ts
- npm --prefix frontend run desktop:pack
- reinstalled /Applications/vLLM Studio.app
- verified /api/desktop-health
- packaged /agent Playwright screenshot: frontend/test-results/agent-mention-selection-hook-fixed-desktop.png