### PR TITLE
micro: simplify session archive route

### DIFF
--- a/frontend/src/app/api/agent/sessions/[id]/route.ts
+++ b/frontend/src/app/api/agent/sessions/[id]/route.ts
@@ -36,13 +36,32 @@ function optionalBodyString(body: Record<string, unknown>, key: string): string 
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
-  const { id } = await context.params;
+type ArchivePatchBody = Record<string, unknown> & { archived: boolean };
+
+type ArchiveSummary = {
+  cwd: string;
+  firstUserMessage: string | null;
+  updatedAt: string;
+};
+
+type ArchiveLookup = {
+  cwd: string;
+  summary: ArchiveSummary | null;
+};
+
+function jsonError(error: string, status: number): Response {
+  return Response.json({ error }, { status });
+}
+
+function validatePatchSessionId(id: string): Response | null {
   if (!id) return Response.json({ error: "session id is required" }, { status: 400 });
   if (!isValidSessionId(id)) {
     return Response.json({ error: "session id is invalid" }, { status: 400 });
   }
+  return null;
+}
 
+async function readArchivePatchBody(request: NextRequest): Promise<ArchivePatchBody | Response> {
   let body: unknown;
   try {
     body = await request.json();
@@ -52,38 +71,64 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
   if (!isRecord(body) || typeof body.archived !== "boolean") {
     return Response.json({ error: "archived boolean is required" }, { status: 400 });
   }
+  return body as ArchivePatchBody;
+}
 
+async function resolveArchiveLookup(
+  id: string,
+  body: ArchivePatchBody,
+): Promise<ArchiveLookup | Response> {
   const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
   if (body.archived && !cwd) {
     return Response.json({ error: "cwd is required to archive a session" }, { status: 400 });
   }
-  let summary: {
-    cwd: string;
-    firstUserMessage: string | null;
-    updatedAt: string;
-  } | null = null;
-  if (cwd) {
-    if (!path.isAbsolute(cwd)) {
-      return Response.json({ error: "cwd must be absolute" }, { status: 400 });
-    }
-    if (!existsSync(cwd) || !statSync(cwd).isDirectory()) {
-      return Response.json({ error: "cwd does not exist" }, { status: 404 });
-    }
-    const matches = await listSessions(cwd, { ids: [id], includeArchived: true });
-    summary = matches.find((session) => session.id === id) ?? null;
-    if (body.archived && !summary) {
-      return Response.json({ error: "session not found" }, { status: 404 });
-    }
+  if (!cwd) return { cwd, summary: null };
+  const cwdError = validateExistingCwd(cwd);
+  if (cwdError) return cwdError;
+  const matches = await listSessions(cwd, { ids: [id], includeArchived: true });
+  const summary = matches.find((session) => session.id === id) ?? null;
+  if (body.archived && !summary) {
+    return Response.json({ error: "session not found" }, { status: 404 });
   }
+  return { cwd, summary };
+}
+
+function validateExistingCwd(cwd: string): Response | null {
+  if (!path.isAbsolute(cwd)) return jsonError("cwd must be absolute", 400);
+  if (!existsSync(cwd) || !statSync(cwd).isDirectory()) {
+    return jsonError("cwd does not exist", 404);
+  }
+  return null;
+}
+
+function archiveMetadata(body: ArchivePatchBody, lookup: ArchiveLookup) {
+  return {
+    cwd: lookup.summary?.cwd ?? lookup.cwd,
+    title: lookup.summary?.firstUserMessage ?? optionalBodyString(body, "title"),
+    projectId: optionalBodyString(body, "projectId"),
+    projectName: optionalBodyString(body, "projectName"),
+    sessionUpdatedAt: lookup.summary?.updatedAt ?? null,
+  };
+}
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const idError = validatePatchSessionId(id);
+  if (idError) return idError;
+
+  const body = await readArchivePatchBody(request);
+  if (body instanceof Response) return body;
+
+  const lookup = await resolveArchiveLookup(id, body);
+  if (lookup instanceof Response) return lookup;
 
   try {
-    const archiveState = setSessionArchived(id, body.archived, new Date(), {
-      cwd: summary?.cwd ?? cwd,
-      title: summary?.firstUserMessage ?? optionalBodyString(body, "title"),
-      projectId: optionalBodyString(body, "projectId"),
-      projectName: optionalBodyString(body, "projectName"),
-      sessionUpdatedAt: summary?.updatedAt ?? null,
-    });
+    const archiveState = setSessionArchived(
+      id,
+      body.archived,
+      new Date(),
+      archiveMetadata(body, lookup),
+    );
     return Response.json({ session: { id, ...archiveState } });
   } catch (error) {
     return Response.json(


### PR DESCRIPTION
## Summary
- split the session archive PATCH handler into route-local helpers for id validation, body parsing, cwd/session lookup, and archive metadata
- preserve existing error responses and archive/unarchive behavior
- remove the PATCH route complexity lint warning

## Accounting
- frontend lint warnings drop from 19 to 18
- `frontend/src/app/api/agent/sessions/[id]/route.ts` is now 139 lines; PATCH itself is a short flow with helpers

## Verification
- npx --prefix frontend prettier --check touched file
- npm --prefix frontend run typecheck
- npm --prefix frontend run lint -- 'src/app/api/agent/sessions/[id]/route.ts'
- npm --prefix frontend run check:static
- npm --prefix frontend run check:cleanup
- git diff --check
- npm --prefix frontend run desktop:pack
- reinstalled /Applications/vLLM Studio.app
- verified /api/desktop-health
- packaged PATCH probes: invalid id, missing cwd, invalid archived body all return expected 400s
- packaged /agent Playwright screenshot: frontend/test-results/session-route-cleanup-agent-desktop.png
- validator Sartre: no findings
