### PR TITLE
micro: share session query parsing

### DIFF
--- a/frontend/src/app/api/agent/sessions/all/route.ts
+++ b/frontend/src/app/api/agent/sessions/all/route.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { listProjectsFromStore } from "@/lib/agent/projects-store";
 import { listSessions, type SessionSummary } from "@/lib/agent/sessions-store";
 import { listArchivedSessionMetadata } from "@/lib/agent/session-metadata-store";
+import { archiveQueryOptions, parseRelativeSince } from "../session-query";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -16,35 +17,10 @@ export type AggregatedSession = SessionSummary & {
   projectPath: string;
 };
 
-function parseSince(value: string | null): Date | null {
-  if (!value) return null;
-  const match = value.match(/^(\d+)([dhm])$/);
-  if (!match) return null;
-  const amount = Number(match[1]);
-  if (!Number.isFinite(amount) || amount <= 0) return null;
-  const unit = match[2];
-  const multiplier = unit === "d" ? 86_400_000 : unit === "h" ? 3_600_000 : 60_000;
-  return new Date(Date.now() - amount * multiplier);
-}
-
-function archiveOptions(searchParams: URLSearchParams): {
-  includeArchived?: boolean;
-  archivedOnly?: boolean;
-} {
-  const archived = searchParams.get("archived")?.toLowerCase();
-  const includeArchived = searchParams.get("includeArchived")?.toLowerCase();
-  return {
-    ...(includeArchived === "1" || includeArchived === "true" ? { includeArchived: true } : {}),
-    ...(archived === "1" || archived === "true" || archived === "only"
-      ? { archivedOnly: true, includeArchived: true }
-      : {}),
-  };
-}
-
 export async function GET(request: NextRequest) {
   const sinceParam = request.nextUrl.searchParams.get("since");
-  const since = parseSince(sinceParam) ?? undefined;
-  const archive = archiveOptions(request.nextUrl.searchParams);
+  const since = parseRelativeSince(sinceParam) ?? undefined;
+  const archive = archiveQueryOptions(request.nextUrl.searchParams);
   const projects = listProjectsFromStore();
   const aggregated: AggregatedSession[] = [];
   const seenIds = new Set<string>();

--- a/frontend/src/app/api/agent/sessions/route.ts
+++ b/frontend/src/app/api/agent/sessions/route.ts
@@ -2,40 +2,16 @@ import { NextRequest } from "next/server";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import { listSessions } from "@/lib/agent/sessions-store";
+import { archiveQueryOptions, parseRelativeSince } from "./session-query";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-function parseSince(value: string | null): Date | null {
-  if (!value) return null;
-  const match = value.match(/^(\d+)([dhm])$/);
-  if (!match) return null;
-  const amount = Number(match[1]);
-  if (!Number.isFinite(amount) || amount <= 0) return null;
-  const unit = match[2];
-  const multiplier = unit === "d" ? 86_400_000 : unit === "h" ? 3_600_000 : 60_000;
-  return new Date(Date.now() - amount * multiplier);
-}
-
-function archiveOptions(searchParams: URLSearchParams): {
-  includeArchived?: boolean;
-  archivedOnly?: boolean;
-} {
-  const archived = searchParams.get("archived")?.toLowerCase();
-  const includeArchived = searchParams.get("includeArchived")?.toLowerCase();
-  return {
-    ...(includeArchived === "1" || includeArchived === "true" ? { includeArchived: true } : {}),
-    ...(archived === "1" || archived === "true" || archived === "only"
-      ? { archivedOnly: true, includeArchived: true }
-      : {}),
-  };
-}
 
 export async function GET(request: NextRequest) {
   const cwdParam = request.nextUrl.searchParams.get("cwd")?.trim() ?? "";
   const sinceParam = request.nextUrl.searchParams.get("since");
   const idsParam = request.nextUrl.searchParams.get("ids");
-  const since = parseSince(sinceParam);
+  const since = parseRelativeSince(sinceParam);
   const ids = idsParam
     ? idsParam
         .split(",")
@@ -55,7 +31,7 @@ export async function GET(request: NextRequest) {
   const sessions = await listSessions(cwdParam, {
     ...(since ? { since } : {}),
     ids,
-    ...archiveOptions(request.nextUrl.searchParams),
+    ...archiveQueryOptions(request.nextUrl.searchParams),
   });
   return Response.json({ sessions });
 }

--- a/frontend/src/app/api/agent/sessions/session-query.ts
+++ b/frontend/src/app/api/agent/sessions/session-query.ts
@@ -1,0 +1,24 @@
+export function parseRelativeSince(value: string | null): Date | null {
+  if (!value) return null;
+  const match = value.match(/^(\d+)([dhm])$/);
+  if (!match) return null;
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const unit = match[2];
+  const multiplier = unit === "d" ? 86_400_000 : unit === "h" ? 3_600_000 : 60_000;
+  return new Date(Date.now() - amount * multiplier);
+}
+
+export function archiveQueryOptions(searchParams: URLSearchParams): {
+  includeArchived?: boolean;
+  archivedOnly?: boolean;
+} {
+  const archived = searchParams.get("archived")?.toLowerCase();
+  const includeArchived = searchParams.get("includeArchived")?.toLowerCase();
+  return {
+    ...(includeArchived === "1" || includeArchived === "true" ? { includeArchived: true } : {}),
+    ...(archived === "1" || archived === "true" || archived === "only"
+      ? { archivedOnly: true, includeArchived: true }
+      : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- extract duplicated `since` and archive query parsing from session list routes
- preserve project-route invalid-since validation and all-route lenient behavior
- keep archive/includeArchived option behavior unchanged

## Accounting
- `sessions/route.ts` and `sessions/all/route.ts` drop 54 repeated lines
- new shared helper is 24 lines; net -24 lines
- frontend gates still report 0 clones

## Verification
- npx --prefix frontend prettier --check touched files
- npm --prefix frontend run typecheck
- npm --prefix frontend run lint -- touched files
- npm --prefix frontend run check:static
- npm --prefix frontend run check:cleanup
- git diff --check
- npm --prefix frontend run desktop:pack
- reinstalled /Applications/vLLM Studio.app
- verified /api/desktop-health
- packaged endpoint probes: invalid since 400; valid session list 200 array; all-sessions archive query 200 array
- packaged /agent screenshot: frontend/test-results/session-query-helper-agent-desktop.png
- validator Confucius: no findings
