### PR TITLE
micro: tighten settings resource rows

### DIFF
--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -89,42 +89,47 @@ export function ListRow({
 
   if (variant === "resource") {
     return (
-      <div className={cx("px-4 py-3.5 transition-colors hover:bg-(--ui-hover)/35", className)}>
+      <div className={cx("px-4 py-3 transition-colors hover:bg-(--ui-hover)/35", className)}>
         <div
           className={cx(
-            "grid min-h-8 min-w-0 grid-cols-1 gap-2.5",
+            "grid min-h-8 min-w-0 grid-cols-1 gap-2",
             primaryValue
-              ? "lg:grid-cols-[minmax(150px,0.85fr)_minmax(220px,1.25fr)_auto] lg:items-start"
+              ? "lg:grid-cols-[minmax(180px,0.8fr)_minmax(0,1.45fr)_auto_auto] lg:items-start"
               : "sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start",
           )}
         >
           <div className="min-w-0 flex-1 space-y-1">
-            <div className="min-w-0 text-[length:var(--fs-base)] font-medium leading-snug text-(--ui-fg)">
+            <div
+              className="min-w-0 truncate text-[length:var(--fs-base)] font-medium leading-snug text-(--ui-fg)"
+              title={label}
+            >
               {label}
             </div>
             {description ? (
-              <div className="text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+              <div className="line-clamp-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
                 {description}
               </div>
             ) : null}
           </div>
           {primaryValue ? (
-            <div className="min-w-0 pt-0.5 text-(--ui-muted)">{primaryValue}</div>
+            <div className="min-w-0 pt-px text-(--ui-muted)">{primaryValue}</div>
           ) : null}
-          <div className="flex shrink-0 items-center gap-1.5 sm:pt-0.5 lg:justify-end">
-            {status ? <div className="shrink-0">{status}</div> : null}
-            {actions ? <div className="flex shrink-0 items-center gap-1.5">{actions}</div> : null}
-          </div>
+          {status ? <div className="shrink-0 sm:pt-0.5 lg:justify-self-end">{status}</div> : null}
+          {actions ? (
+            <div className="flex shrink-0 items-center gap-1.5 sm:pt-px lg:justify-self-end">
+              {actions}
+            </div>
+          ) : null}
         </div>
         {children ? (
           <div
             className={cx(
               "mt-2 grid min-w-0 gap-2 border-t border-(--ui-separator)/70 pt-2 text-[length:var(--fs-sm)] leading-relaxed",
-              primaryValue ? "lg:grid-cols-[minmax(150px,0.85fr)_minmax(220px,1.25fr)_auto]" : "",
+              primaryValue ? "lg:grid-cols-[minmax(180px,0.8fr)_minmax(0,1.45fr)_auto_auto]" : "",
             )}
           >
             {primaryValue ? <div className="hidden lg:block" /> : null}
-            <div className={cx("min-w-0 space-y-1.5", primaryValue ? "lg:col-span-2" : "")}>
+            <div className={cx("min-w-0 space-y-1.5", primaryValue ? "lg:col-span-3" : "")}>
               {children}
             </div>
           </div>

--- a/frontend/src/ui/runtime-targets.tsx
+++ b/frontend/src/ui/runtime-targets.tsx
@@ -257,23 +257,30 @@ function RuntimeTargetMeta({ target }: { target: RuntimeTarget }) {
 function RuntimeTargetSummary({ target }: { target: RuntimeTarget }) {
   const location = pathForTarget(target);
   return (
-    <div className="min-w-0 text-left">
-      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
-        <span className="font-mono text-[length:var(--fs-md)] text-(--ui-fg)/85">
+    <div className="min-w-0 space-y-1 text-left">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span className="shrink-0 font-mono text-[length:var(--fs-md)] text-(--ui-fg)/85">
           {target.installed ? (target.version ?? "installed") : "not installed"}
         </span>
-        {target.update && target.capabilities.canUpdate ? (
+        {location ? (
+          <>
+            <span className="shrink-0 text-(--ui-muted)/70" aria-hidden>
+              ·
+            </span>
+            <span
+              className="min-w-0 truncate font-mono text-[length:var(--fs-sm)] text-(--ui-muted)"
+              title={location}
+            >
+              {location}
+            </span>
+          </>
+        ) : null}
+      </div>
+      {target.update && target.capabilities.canUpdate ? (
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
           <span className="text-[length:var(--fs-sm)] text-(--ui-muted)">
             target {target.update.targetVersion}
           </span>
-        ) : null}
-      </div>
-      {location ? (
-        <div
-          className="mt-1 line-clamp-2 min-w-0 break-all font-mono text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)"
-          title={location}
-        >
-          {location}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- Tighten the shared `SettingsRow` resource variant so resource rows use cleaner desktop columns, shorter vertical padding, truncated labels, and clamped descriptions.
- Compact runtime target summaries into a single version/path line with the full path preserved in `title`.
- Keep expanded row details aligned under the resource value/status/action area.

## Accounting
- `frontend/src/ui/list.tsx`: 222 -> 227 lines.
- `frontend/src/ui/runtime-targets.tsx`: 357 -> 364 lines.
- Net +12 lines for a shared UI-kit layout improvement.

## Verification
- npx --prefix frontend prettier --check frontend/src/ui/list.tsx frontend/src/ui/runtime-targets.tsx
- npm --prefix frontend run typecheck
- npm --prefix frontend run lint -- src/ui/list.tsx src/ui/runtime-targets.tsx
- npm --prefix frontend run check:static
- npm --prefix frontend run check:cleanup
- git diff --check
- npm --prefix frontend run desktop:pack
- Reinstalled /Applications/vLLM Studio.app and verified org.vllm.studio.desktop
- curl -fsS http://127.0.0.1:61449/api/desktop-health
- Packaged app Playwright screenshot: /settings#system rendered without unexpected error and with overflowX 0
- Screenshot: frontend/test-results/settings-system-resource-row-layout.png

## Review
- Validator Mill: no findings in `list.tsx` or `runtime-targets.tsx`; confirmed full runtime target path remains available via `title` on the truncated location span.
- Residual risk: visual coverage focused on Settings/System; other `variant="resource"` consumers inherit the same primitive change but were not individually screenshotted.
