### PR TITLE
micro: simplify terminal pty boot args

### DIFF
--- a/frontend/src/hooks/agent/use-terminal-panel-effects.ts
+++ b/frontend/src/hooks/agent/use-terminal-panel-effects.ts
@@ -43,6 +43,16 @@ type FallbackSession = {
   previousCwd: string | null;
 };
 
+type PtyBootOptions = {
+  pty: PtyBridge;
+  term: XTerm;
+  fit: FitAddon;
+  refs: TerminalRefs;
+  element: HTMLDivElement;
+  cwd: string | null;
+  ownerKey: string;
+};
+
 const getTerminalPanelSnapshot = (): number => 0;
 
 export function useTerminalPanelEffects({
@@ -144,7 +154,7 @@ export function useTerminalPanelEffects({
       }
 
       if (!useFallback && pty) {
-        cleanupTerminal = await bootPty(pty, term, fit, refs, element, cwd, ownerKey);
+        cleanupTerminal = await bootPty({ pty, term, fit, refs, element, cwd, ownerKey });
       } else {
         cleanupTerminal = bootFallback(term, fit, refs, element, cwd);
       }
@@ -168,15 +178,15 @@ export function useTerminalPanelEffects({
   useSyncExternalStore(subscribeTerminal, getTerminalPanelSnapshot, getTerminalPanelSnapshot);
 }
 
-async function bootPty(
-  pty: PtyBridge,
-  term: XTerm,
-  fit: FitAddon,
-  refs: TerminalRefs,
-  element: HTMLDivElement,
-  cwd: string | null,
-  ownerKey: string,
-): Promise<() => void> {
+async function bootPty({
+  pty,
+  term,
+  fit,
+  refs,
+  element,
+  cwd,
+  ownerKey,
+}: PtyBootOptions): Promise<() => void> {
   const { cols, rows } = term;
   let currentId: string | null = null;
   const queuedData: Array<{ sessionId: string; chunk: string }> = [];


### PR DESCRIPTION
## Summary
- Replace `bootPty` positional arguments with a typed `PtyBootOptions` object.
- Keep PTY setup, event replay, resize, key handling, and cleanup behavior unchanged.
- Remove the terminal hook max-params lint warning.

## Accounting
- frontend/src/hooks/agent/use-terminal-panel-effects.ts: 386 -> 396 lines (+10).
- ESLint warning count: 17 -> 16 after removing `bootPty` max-params.

## Verification
- npm --prefix frontend run lint -- src/hooks/agent/use-terminal-panel-effects.ts
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- pre-push hook: npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- reinstalled /Applications/vLLM Studio.app and verified desktop health, canonical app path, and bundle id
- packaged /agent smoke: http://127.0.0.1:61449/agent rendered without unexpected-error text
- screenshot saved at frontend/test-results/terminal-boot-options-packaged-agent.png
- sub-agent review: no findings