### PR TITLE
micro: extract chat pane composer frame

### DIFF
--- a/frontend/src/app/agent/_components/chat-pane.tsx
+++ b/frontend/src/app/agent/_components/chat-pane.tsx
@@ -1,24 +1,14 @@
 "use client";
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
-import { AgentAttachmentTray } from "@/ui/agent-attachment-tray";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 import { AgentChatPaneHeader } from "@/ui/agent-chat-pane-header";
-import { AgentComposerActions } from "@/ui/agent-composer-actions";
-import { AgentComposerStatusBar } from "@/ui/agent-composer-status-bar";
-import { AgentComposerTextArea } from "@/ui/agent-composer-textarea";
-import {
-  AgentLoadedContextTabs,
-  AgentMentionPicker,
-  type FileMentionRow,
-  type MentionRow,
-} from "@/ui/agent-composer-context";
-import { AgentQueuePanel } from "@/ui/agent-queue-panel";
+import { AgentComposerFrame } from "@/ui/agent-composer-frame";
+import { type FileMentionRow } from "@/ui/agent-composer-context";
 import {
   useChatPaneContextAttachEffect,
   useChatPaneMentionEffects,
-  useChatPaneRegisterHandleEffect,
   useChatPaneStickToBottomEffect,
 } from "@/hooks/agent/use-chat-pane-effects";
-import { byQuery, type ComposerMention } from "@/lib/agent/composer-context";
+import type { ComposerMention } from "@/lib/agent/composer-context";
 import {
   AgentTurnSsePayload,
   AssistantBlock,
@@ -37,9 +27,13 @@ import {
 import { useSessionEngine } from "@/lib/agent/sessions/engine";
 import { useTools } from "@/lib/agent/tools/context";
 import { Timeline } from "./timeline/timeline";
+import { useChatPaneDerivedState } from "./use-chat-pane-derived-state";
+import { useChatPaneRuntimeHandle } from "./use-chat-pane-runtime-handle";
 import { useChatPaneSendFlow } from "./use-chat-pane-send-flow";
 import { useChatPaneSessionTitle } from "./use-chat-pane-session-title";
 import { useComposerAttachments } from "./use-composer-attachments";
+import { useComposerLoadedContext } from "./use-composer-loaded-context";
+import { useComposerMentionRows } from "./use-composer-mention-rows";
 import { useComposerMentionSelection } from "./use-composer-mention-selection";
 import { useComposerTextareaBehavior } from "./use-composer-textarea-behavior";
 export type {
@@ -132,21 +126,15 @@ export function ChatPane({
   const [mention, setMention] = useState<ComposerMention | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
   const [fileMentionRows, setFileMentionRows] = useState<FileMentionRow[]>([]);
-  const [compacting, setCompacting] = useState(false);
   const tools = useTools();
-  const pluginRows = tools.pluginCatalogue;
-  const skillRows = tools.skillCatalogue;
-  const promptTemplateRows = tools.promptTemplateCatalogue;
-  const activeTab = useMemo(
-    () => tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null,
-    [tabs, activeTabId],
-  );
-  const running = activeTab?.status === "running" || activeTab?.status === "starting";
-  const activeSelection = tools.selectionFor(activeTab?.id);
-  const selectedPlugins = activeSelection.plugins;
-  const selectedSkills = activeSelection.skills;
-  const selectedPromptTemplates = activeSelection.promptTemplates;
-  const showEmptyPrompt = activeTab && activeTab.messages.length === 0 && !running;
+  const {
+    activeTab,
+    currentContextTokens,
+    effectiveContextWindow,
+    running,
+    showEmptyPrompt,
+    visibleQueueItems,
+  } = useChatPaneDerivedState({ activeTabId, contextWindow, tabs });
   const updateTab = useCallback(
     (tabId: string, patch: (tab: SessionTab) => SessionTab) => {
       onTabsChange((currentTabs) =>
@@ -181,31 +169,13 @@ export function ChatPane({
     isFocused,
     setAttachments,
   });
-  const mentionRows = useMemo<MentionRow[]>(() => {
-    if (!mention) return [];
-    if (mention.kind === "skill") {
-      return byQuery(skillRows, mention.query, 8).map((row) => ({ kind: "skill", row }));
-    }
-    if (mention.kind === "promptTemplate") {
-      const templates = byQuery(promptTemplateRows, mention.query, 8).map((row) => ({
-        kind: "promptTemplate" as const,
-        row,
-      }));
-      return templates;
-    }
-    const plugins = byQuery(pluginRows, mention.query, 5).map((row) => ({
-      kind: "plugin" as const,
-      row,
-    }));
-    const q = mention.query.trim().toLowerCase();
-    const files = fileMentionRows
-      .filter(
-        (row) => !q || row.rel.toLowerCase().includes(q) || row.name.toLowerCase().includes(q),
-      )
-      .slice(0, 5)
-      .map((row) => ({ kind: "file" as const, row }));
-    return [...plugins, ...files].slice(0, 8);
-  }, [fileMentionRows, mention, pluginRows, promptTemplateRows, skillRows]);
+  const mentionRows = useComposerMentionRows({
+    fileMentionRows,
+    mention,
+    pluginRows: tools.pluginCatalogue,
+    promptTemplateRows: tools.promptTemplateCatalogue,
+    skillRows: tools.skillCatalogue,
+  });
   useChatPaneMentionEffects({
     cwd,
     mention,
@@ -241,25 +211,8 @@ export function ChatPane({
     lastAppliedComposerHeightRef.current = 0;
     lastComposerValueLengthRef.current = 0;
   }, []);
-  const removeLoadedContext = useCallback(
-    (kind: "plugin" | "skill" | "promptTemplate", id: string) => {
-      if (!activeTab) return;
-      const current = tools.selectionFor(activeTab.id);
-      tools.setSelection(activeTab.id, {
-        plugins:
-          kind === "plugin"
-            ? current.plugins.filter((plugin) => plugin.id !== id)
-            : current.plugins,
-        skills:
-          kind === "skill" ? current.skills.filter((skill) => skill.id !== id) : current.skills,
-        promptTemplates:
-          kind === "promptTemplate"
-            ? current.promptTemplates.filter((template) => template.id !== id)
-            : current.promptTemplates,
-      });
-    },
-    [activeTab, tools],
-  );
+  const { selectedPlugins, selectedSkills, selectedPromptTemplates, removeLoadedContext } =
+    useComposerLoadedContext({ activeTab, tools });
 
   const updateSession = useCallback(
     (sessionId: string, patch: (session: SessionTab) => SessionTab) => updateTab(sessionId, patch),
@@ -313,41 +266,18 @@ export function ChatPane({
       abortTurn,
       attachFiles,
     });
-  const loadAndReplay = useCallback(
-    async (piSessionId: string) => {
-      if (!activeTabId) return;
-      await engine.loadAndReplay(piSessionId, activeTabId);
-    },
-    [activeTabId, engine],
-  );
-  const queue = activeTab?.queue ?? [];
-  const visibleQueueItems = visibleQueuedMessages(queue);
   const openComputerStatus = useCallback(() => {
     tools.setComputerTab("status");
     tools.setComputerOpen(true);
   }, [tools]);
-  // Prefer SDK-computed context usage (uses the model's real tokenizer + the
-  // same compaction settings the SDK enforces). Fall back to the locally
-  // estimated tokenStats while we're waiting for the first runtime status
-  // poll to land.
-  const sdkContextUsage = activeTab?.contextUsage ?? null;
-  const currentContextTokens = sdkContextUsage?.tokens ?? activeTab?.tokenStats?.current ?? 0;
-  const effectiveContextWindow =
-    sdkContextUsage?.contextWindow && sdkContextUsage.contextWindow > 0
-      ? sdkContextUsage.contextWindow
-      : contextWindow;
-  const compactSession = useCallback(async () => {
-    if (!activeTab || running || compacting || !modelId) return;
-    setCompacting(true);
-    try {
-      await engine.compact(activeTab.id);
-    } finally {
-      setCompacting(false);
-    }
-  }, [activeTab, compacting, engine, modelId, running]);
-  const handleRef = useRef<ChatPaneHandle>({ loadAndReplay, compact: compactSession });
-  handleRef.current = { loadAndReplay, compact: compactSession };
-  useChatPaneRegisterHandleEffect({ handleRef, onRegisterHandle });
+  useChatPaneRuntimeHandle({
+    activeTab,
+    activeTabId,
+    engine,
+    modelId,
+    onRegisterHandle,
+    running: Boolean(running),
+  });
   return (
     <section
       onMouseDownCapture={onFocus}
@@ -383,75 +313,53 @@ export function ChatPane({
           emptyPrompt={Boolean(showEmptyPrompt)}
         />
       </div>
-      <form onSubmit={sendMessage} className="shrink-0 bg-(--agent-bg) px-6 pb-1.5 pt-2">
-        <AgentQueuePanel
-          items={visibleQueueItems}
-          expanded={queueExpanded}
-          running={Boolean(running)}
-          onExpandedChange={setQueueExpanded}
-          onEdit={editQueued}
-          onRemove={removeQueued}
-          onSteer={(queueId) => void steerQueued(queueId)}
-        />
-        <div
-          onDragOver={handleComposerDragOver}
-          onDragLeave={handleComposerDragLeave}
-          onDrop={handleComposerDrop}
-          className={`mx-auto w-full max-w-[var(--composer-w)] overflow-visible rounded-2xl border border-(--border)/20 bg-(--sidebar-bg) transition-colors ${composerDragActive ? "outline outline-1 outline-(--accent)/50" : ""}`}
-        >
-          {" "}
-          {composerDragActive ? (
-            <div className="px-4 pt-2 text-[length:var(--fs-sm)] text-(--accent)">
-              Drop files to attach to the next message.
-            </div>
-          ) : null}
-          <AgentLoadedContextTabs
-            plugins={selectedPlugins}
-            skills={selectedSkills}
-            promptTemplates={selectedPromptTemplates}
-            onRemove={removeLoadedContext}
-          />
-          <AgentMentionPicker
-            mention={mention}
-            rows={mentionRows}
-            activeIndex={mentionIndex}
-            onSelect={(entry) => void selectMentionRow(entry)}
-          />
-          <AgentAttachmentTray attachments={attachments} onRemove={removeAttachment} />
-          <AgentComposerTextArea
-            inputRef={textareaRef}
-            value={activeTab?.input ?? ""}
-            onPaste={handleComposerPaste}
-            onChange={handleComposerChange}
-            onKeyDown={handleComposerKeyDown}
-          />
-          <AgentComposerActions
-            fileInputRef={fileInputRef}
-            onAttachFiles={(files) => void attachFiles(files)}
-            readingAttachments={readingAttachments}
-            running={Boolean(running)}
-            status={activeTab?.status}
-            input={activeTab?.input ?? ""}
-            attachmentsCount={attachments.length}
-            browserToolEnabled={browserToolEnabled}
-            onToggleBrowserTool={onToggleBrowserTool}
-            canvasEnabled={canvasEnabled}
-            onToggleCanvas={onToggleCanvas}
-            onQueueMessage={() => void queueMessage()}
-            onAbortTurn={() => void abortTurn()}
-          />
-        </div>
-        <AgentComposerStatusBar
-          cwd={cwd}
-          gitBranch={gitBranch}
-          gitSummary={gitSummary}
-          onInitGit={onInitGit}
-          modelSelector={modelSelector}
-          currentContextTokens={currentContextTokens}
-          contextWindow={effectiveContextWindow}
-          onOpenStatus={openComputerStatus}
-        />
-      </form>
+      <AgentComposerFrame
+        attachments={attachments}
+        browserToolEnabled={browserToolEnabled}
+        canvasEnabled={canvasEnabled}
+        composerDragActive={composerDragActive}
+        contextWindow={effectiveContextWindow}
+        currentContextTokens={currentContextTokens}
+        cwd={cwd}
+        fileInputRef={fileInputRef}
+        gitBranch={gitBranch}
+        gitSummary={gitSummary}
+        input={activeTab?.input ?? ""}
+        mention={mention}
+        mentionIndex={mentionIndex}
+        mentionRows={mentionRows}
+        modelSelector={modelSelector}
+        onAbortTurn={() => void abortTurn()}
+        onAttachFiles={(files) => void attachFiles(files)}
+        onComposerChange={handleComposerChange}
+        onComposerDragLeave={handleComposerDragLeave}
+        onComposerDragOver={handleComposerDragOver}
+        onComposerDrop={handleComposerDrop}
+        onComposerKeyDown={handleComposerKeyDown}
+        onComposerPaste={handleComposerPaste}
+        onEditQueued={editQueued}
+        onInitGit={onInitGit}
+        onOpenStatus={openComputerStatus}
+        onQueueExpandedChange={setQueueExpanded}
+        onQueueMessage={() => void queueMessage()}
+        onRemoveAttachment={removeAttachment}
+        onRemoveLoadedContext={removeLoadedContext}
+        onRemoveQueued={removeQueued}
+        onSelectMention={(entry) => void selectMentionRow(entry)}
+        onSteerQueued={(queueId) => void steerQueued(queueId)}
+        onSubmit={sendMessage}
+        onToggleBrowserTool={onToggleBrowserTool}
+        onToggleCanvas={onToggleCanvas}
+        promptTemplates={selectedPromptTemplates}
+        queueExpanded={queueExpanded}
+        queueItems={visibleQueueItems}
+        readingAttachments={readingAttachments}
+        running={Boolean(running)}
+        selectedPlugins={selectedPlugins}
+        selectedSkills={selectedSkills}
+        status={activeTab?.status}
+        textareaRef={textareaRef}
+      />
     </section>
   );
 }

--- a/frontend/src/app/agent/_components/use-chat-pane-derived-state.ts
+++ b/frontend/src/app/agent/_components/use-chat-pane-derived-state.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMemo } from "react";
+import { type SessionTab, visibleQueuedMessages } from "@/lib/agent/session";
+
+export function useChatPaneDerivedState({
+  activeTabId,
+  contextWindow,
+  tabs,
+}: {
+  activeTabId: string;
+  contextWindow: number;
+  tabs: SessionTab[];
+}) {
+  const activeTab = useMemo(
+    () => tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null,
+    [tabs, activeTabId],
+  );
+  const running = activeTab?.status === "running" || activeTab?.status === "starting";
+  const showEmptyPrompt = activeTab && activeTab.messages.length === 0 && !running;
+  const queue = activeTab?.queue ?? [];
+  const sdkContextUsage = activeTab?.contextUsage ?? null;
+  const currentContextTokens = sdkContextUsage?.tokens ?? activeTab?.tokenStats?.current ?? 0;
+  const effectiveContextWindow =
+    sdkContextUsage?.contextWindow && sdkContextUsage.contextWindow > 0
+      ? sdkContextUsage.contextWindow
+      : contextWindow;
+
+  return {
+    activeTab,
+    currentContextTokens,
+    effectiveContextWindow,
+    running,
+    showEmptyPrompt,
+    visibleQueueItems: visibleQueuedMessages(queue),
+  };
+}

--- a/frontend/src/app/agent/_components/use-chat-pane-runtime-handle.ts
+++ b/frontend/src/app/agent/_components/use-chat-pane-runtime-handle.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useChatPaneRegisterHandleEffect } from "@/hooks/agent/use-chat-pane-effects";
+import type { ChatPaneHandle, SessionTab } from "@/lib/agent/session";
+import type { SessionEngine } from "@/lib/agent/sessions/engine";
+
+export function useChatPaneRuntimeHandle({
+  activeTab,
+  activeTabId,
+  engine,
+  modelId,
+  onRegisterHandle,
+  running,
+}: {
+  activeTab: SessionTab | null;
+  activeTabId: string;
+  engine: SessionEngine;
+  modelId: string;
+  onRegisterHandle?: (handle: ChatPaneHandle | null) => void;
+  running: boolean;
+}) {
+  const [compacting, setCompacting] = useState(false);
+  const loadAndReplay = useCallback(
+    async (piSessionId: string) => {
+      if (!activeTabId) return;
+      await engine.loadAndReplay(piSessionId, activeTabId);
+    },
+    [activeTabId, engine],
+  );
+  const compactSession = useCallback(async () => {
+    if (!activeTab || running || compacting || !modelId) return;
+    setCompacting(true);
+    try {
+      await engine.compact(activeTab.id);
+    } finally {
+      setCompacting(false);
+    }
+  }, [activeTab, compacting, engine, modelId, running]);
+  const handleRef = useRef<ChatPaneHandle>({ loadAndReplay, compact: compactSession });
+  handleRef.current = { loadAndReplay, compact: compactSession };
+  useChatPaneRegisterHandleEffect({ handleRef, onRegisterHandle });
+}

--- a/frontend/src/app/agent/_components/use-composer-loaded-context.ts
+++ b/frontend/src/app/agent/_components/use-composer-loaded-context.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback } from "react";
+import type { SessionTab } from "@/lib/agent/session";
+import type { ToolsContextValue } from "@/lib/agent/tools/context";
+
+type LoadedContextKind = "plugin" | "skill" | "promptTemplate";
+
+export function useComposerLoadedContext({
+  activeTab,
+  tools,
+}: {
+  activeTab: SessionTab | null;
+  tools: ToolsContextValue;
+}) {
+  const activeSelection = tools.selectionFor(activeTab?.id);
+  const removeLoadedContext = useCallback(
+    (kind: LoadedContextKind, id: string) => {
+      if (!activeTab) return;
+      const current = tools.selectionFor(activeTab.id);
+      tools.setSelection(activeTab.id, {
+        plugins:
+          kind === "plugin"
+            ? current.plugins.filter((plugin) => plugin.id !== id)
+            : current.plugins,
+        skills:
+          kind === "skill" ? current.skills.filter((skill) => skill.id !== id) : current.skills,
+        promptTemplates:
+          kind === "promptTemplate"
+            ? current.promptTemplates.filter((template) => template.id !== id)
+            : current.promptTemplates,
+      });
+    },
+    [activeTab, tools],
+  );
+
+  return {
+    selectedPlugins: activeSelection.plugins,
+    selectedSkills: activeSelection.skills,
+    selectedPromptTemplates: activeSelection.promptTemplates,
+    removeLoadedContext,
+  };
+}

--- a/frontend/src/app/agent/_components/use-composer-mention-rows.ts
+++ b/frontend/src/app/agent/_components/use-composer-mention-rows.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  byQuery,
+  type ComposerMention,
+  type ComposerPluginRef,
+  type ComposerPromptTemplateRef,
+  type ComposerSkillRef,
+} from "@/lib/agent/composer-context";
+import type { FileMentionRow, MentionRow } from "@/ui/agent-composer-context";
+
+type UseComposerMentionRowsOptions = {
+  fileMentionRows: FileMentionRow[];
+  mention: ComposerMention | null;
+  pluginRows: ComposerPluginRef[];
+  promptTemplateRows: ComposerPromptTemplateRef[];
+  skillRows: ComposerSkillRef[];
+};
+
+export function useComposerMentionRows({
+  fileMentionRows,
+  mention,
+  pluginRows,
+  promptTemplateRows,
+  skillRows,
+}: UseComposerMentionRowsOptions): MentionRow[] {
+  return useMemo<MentionRow[]>(() => {
+    if (!mention) return [];
+    if (mention.kind === "skill") {
+      return byQuery(skillRows, mention.query, 8).map((row) => ({ kind: "skill", row }));
+    }
+    if (mention.kind === "promptTemplate") {
+      return byQuery(promptTemplateRows, mention.query, 8).map((row) => ({
+        kind: "promptTemplate" as const,
+        row,
+      }));
+    }
+    const plugins = byQuery(pluginRows, mention.query, 5).map((row) => ({
+      kind: "plugin" as const,
+      row,
+    }));
+    const q = mention.query.trim().toLowerCase();
+    const files = fileMentionRows
+      .filter(
+        (row) => !q || row.rel.toLowerCase().includes(q) || row.name.toLowerCase().includes(q),
+      )
+      .slice(0, 5)
+      .map((row) => ({ kind: "file" as const, row }));
+    return [...plugins, ...files].slice(0, 8);
+  }, [fileMentionRows, mention, pluginRows, promptTemplateRows, skillRows]);
+}

--- a/frontend/src/ui/agent-composer-frame.tsx
+++ b/frontend/src/ui/agent-composer-frame.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import type {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  DragEventHandler,
+  FormEventHandler,
+  KeyboardEventHandler,
+  ReactNode,
+  RefObject,
+} from "react";
+import type {
+  ComposerMention,
+  ComposerPluginRef,
+  ComposerPromptTemplateRef,
+  ComposerSkillRef,
+} from "@/lib/agent/composer-context";
+import type { QueuedMessage } from "@/lib/agent/session";
+import { AgentAttachmentTray, type AgentComposerAttachment } from "./agent-attachment-tray";
+import { AgentComposerActions } from "./agent-composer-actions";
+import {
+  AgentLoadedContextTabs,
+  AgentMentionPicker,
+  type MentionRow,
+} from "./agent-composer-context";
+import { AgentComposerStatusBar } from "./agent-composer-status-bar";
+import { AgentComposerTextArea } from "./agent-composer-textarea";
+import { AgentQueuePanel } from "./agent-queue-panel";
+import { cx } from "./utils";
+
+type LoadedContextKind = "plugin" | "skill" | "promptTemplate";
+
+type GitSummary = {
+  isRepo: boolean;
+  additions: number;
+  deletions: number;
+  statusCount: number;
+};
+
+export type AgentComposerFrameProps = {
+  attachments: AgentComposerAttachment[];
+  browserToolEnabled: boolean;
+  canvasEnabled: boolean;
+  composerDragActive: boolean;
+  contextWindow: number;
+  currentContextTokens: number;
+  cwd: string;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  gitBranch?: string | null;
+  gitSummary?: GitSummary | null;
+  input: string;
+  mention: ComposerMention | null;
+  mentionIndex: number;
+  mentionRows: MentionRow[];
+  modelSelector?: ReactNode;
+  onAbortTurn: () => void;
+  onAttachFiles: (files: FileList | null) => void;
+  onComposerChange: ChangeEventHandler<HTMLTextAreaElement>;
+  onComposerDragLeave: DragEventHandler<HTMLDivElement>;
+  onComposerDragOver: DragEventHandler<HTMLDivElement>;
+  onComposerDrop: DragEventHandler<HTMLDivElement>;
+  onComposerKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+  onComposerPaste: ClipboardEventHandler<HTMLTextAreaElement>;
+  onEditQueued: (queueId: string, text: string) => void;
+  onInitGit?: () => void;
+  onOpenStatus: () => void;
+  onQueueExpandedChange: (expanded: boolean) => void;
+  onQueueMessage: () => void;
+  onRemoveAttachment: (id: string) => void;
+  onRemoveLoadedContext: (kind: LoadedContextKind, id: string) => void;
+  onRemoveQueued: (queueId: string) => void;
+  onSelectMention: (entry: MentionRow) => void;
+  onSteerQueued: (queueId: string) => void;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  onToggleBrowserTool: () => void;
+  onToggleCanvas: () => void;
+  promptTemplates: ComposerPromptTemplateRef[];
+  queueExpanded: boolean;
+  queueItems: QueuedMessage[];
+  readingAttachments: boolean;
+  running: boolean;
+  selectedPlugins: ComposerPluginRef[];
+  selectedSkills: ComposerSkillRef[];
+  status?: string;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+};
+
+export function AgentComposerFrame({
+  attachments,
+  browserToolEnabled,
+  canvasEnabled,
+  composerDragActive,
+  contextWindow,
+  currentContextTokens,
+  cwd,
+  fileInputRef,
+  gitBranch,
+  gitSummary,
+  input,
+  mention,
+  mentionIndex,
+  mentionRows,
+  modelSelector,
+  onAbortTurn,
+  onAttachFiles,
+  onComposerChange,
+  onComposerDragLeave,
+  onComposerDragOver,
+  onComposerDrop,
+  onComposerKeyDown,
+  onComposerPaste,
+  onEditQueued,
+  onInitGit,
+  onOpenStatus,
+  onQueueExpandedChange,
+  onQueueMessage,
+  onRemoveAttachment,
+  onRemoveLoadedContext,
+  onRemoveQueued,
+  onSelectMention,
+  onSteerQueued,
+  onSubmit,
+  onToggleBrowserTool,
+  onToggleCanvas,
+  promptTemplates,
+  queueExpanded,
+  queueItems,
+  readingAttachments,
+  running,
+  selectedPlugins,
+  selectedSkills,
+  status,
+  textareaRef,
+}: AgentComposerFrameProps) {
+  return (
+    <form onSubmit={onSubmit} className="shrink-0 bg-(--agent-bg) px-6 pb-1.5 pt-2">
+      <AgentQueuePanel
+        items={queueItems}
+        expanded={queueExpanded}
+        running={running}
+        onExpandedChange={onQueueExpandedChange}
+        onEdit={onEditQueued}
+        onRemove={onRemoveQueued}
+        onSteer={onSteerQueued}
+      />
+      <div
+        onDragOver={onComposerDragOver}
+        onDragLeave={onComposerDragLeave}
+        onDrop={onComposerDrop}
+        className={cx(
+          "mx-auto w-full max-w-[var(--composer-w)] overflow-visible rounded-2xl border border-(--border)/20 bg-(--sidebar-bg) transition-colors",
+          composerDragActive && "outline outline-1 outline-(--accent)/50",
+        )}
+      >
+        {composerDragActive ? (
+          <div className="px-4 pt-2 text-[length:var(--fs-sm)] text-(--accent)">
+            Drop files to attach to the next message.
+          </div>
+        ) : null}
+        <AgentLoadedContextTabs
+          plugins={selectedPlugins}
+          skills={selectedSkills}
+          promptTemplates={promptTemplates}
+          onRemove={onRemoveLoadedContext}
+        />
+        <AgentMentionPicker
+          mention={mention}
+          rows={mentionRows}
+          activeIndex={mentionIndex}
+          onSelect={onSelectMention}
+        />
+        <AgentAttachmentTray attachments={attachments} onRemove={onRemoveAttachment} />
+        <AgentComposerTextArea
+          inputRef={textareaRef}
+          value={input}
+          onPaste={onComposerPaste}
+          onChange={onComposerChange}
+          onKeyDown={onComposerKeyDown}
+        />
+        <AgentComposerActions
+          fileInputRef={fileInputRef}
+          onAttachFiles={onAttachFiles}
+          readingAttachments={readingAttachments}
+          running={running}
+          status={status}
+          input={input}
+          attachmentsCount={attachments.length}
+          browserToolEnabled={browserToolEnabled}
+          onToggleBrowserTool={onToggleBrowserTool}
+          canvasEnabled={canvasEnabled}
+          onToggleCanvas={onToggleCanvas}
+          onQueueMessage={onQueueMessage}
+          onAbortTurn={onAbortTurn}
+        />
+      </div>
+      <AgentComposerStatusBar
+        cwd={cwd}
+        gitBranch={gitBranch}
+        gitSummary={gitSummary}
+        onInitGit={onInitGit}
+        modelSelector={modelSelector}
+        currentContextTokens={currentContextTokens}
+        contextWindow={contextWindow}
+        onOpenStatus={onOpenStatus}
+      />
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the composer form/queue/mention/attachment/status UI into `AgentComposerFrame` in the UI kit.
- Move ChatPane derived active-tab state, runtime handle registration, loaded context removal, and mention-row filtering into focused hooks.
- Remove the remaining ChatPane complexity warning while preserving composer behavior.

## Accounting
- `chat-pane.tsx`: 457 -> 365 lines (-92).
- New extracted files total 383 lines: `AgentComposerFrame` plus four focused hooks.
- Net for this slice: +291 lines, with reusable composer UI now in `frontend/src/ui`.
- ESLint warning count: 14 -> 13.

## Verification
- npm --prefix frontend run lint -- src/app/agent/_components/chat-pane.tsx src/app/agent/_components/use-chat-pane-derived-state.ts src/app/agent/_components/use-chat-pane-runtime-handle.ts src/ui/agent-composer-frame.tsx src/app/agent/_components/use-composer-mention-rows.ts src/app/agent/_components/use-composer-loaded-context.ts
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- pre-push hook: npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- reinstalled /Applications/vLLM Studio.app and verified desktop health, canonical app path, and bundle id
- packaged /agent screenshot saved at frontend/test-results/chat-pane-composer-frame-packaged-agent.png
- sub-agent review: no findings