### PR TITLE
micro: tighten runtime resource rows

### DIFF
--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -89,21 +89,16 @@ export function ListRow({
 
   if (variant === "resource") {
     return (
-      <div className={cx("px-4 py-3 transition-colors hover:bg-(--ui-hover)/35", className)}>
-        <div
-          className={cx(
-            "grid min-h-8 min-w-0 grid-cols-1 gap-2",
-            primaryValue
-              ? "lg:grid-cols-[minmax(180px,0.8fr)_minmax(0,1.45fr)_auto_auto] lg:items-start"
-              : "sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start",
-          )}
-        >
-          <div className="min-w-0 flex-1 space-y-1">
-            <div
-              className="min-w-0 truncate text-[length:var(--fs-base)] font-medium leading-snug text-(--ui-fg)"
-              title={label}
-            >
-              {label}
+      <div className={cx("px-3.5 py-3 transition-colors hover:bg-(--ui-hover)/35", className)}>
+        <div className="grid min-w-0 grid-cols-1 gap-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <div className="min-w-0 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <div
+                className="min-w-0 break-words text-[length:var(--fs-base)] font-medium leading-snug text-(--ui-fg)"
+                title={label}
+              >
+                {label}
+              </div>
             </div>
             {description ? (
               <div className="line-clamp-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
@@ -111,27 +106,21 @@ export function ListRow({
               </div>
             ) : null}
           </div>
-          {primaryValue ? (
-            <div className="min-w-0 pt-px text-(--ui-muted)">{primaryValue}</div>
-          ) : null}
-          {status ? <div className="shrink-0 sm:pt-0.5 lg:justify-self-end">{status}</div> : null}
-          {actions ? (
-            <div className="flex shrink-0 items-center gap-1.5 sm:pt-px lg:justify-self-end">
-              {actions}
+          {status || actions ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 sm:justify-end sm:pt-0.5">
+              {status ? <div className="shrink-0">{status}</div> : null}
+              {actions ? <div className="flex shrink-0 items-center gap-1.5">{actions}</div> : null}
             </div>
           ) : null}
         </div>
+        {primaryValue ? (
+          <div className="mt-2 min-w-0 rounded-md border border-(--ui-separator)/70 bg-(--ui-bg)/45 px-2.5 py-2 text-(--ui-muted)">
+            {primaryValue}
+          </div>
+        ) : null}
         {children ? (
-          <div
-            className={cx(
-              "mt-2 grid min-w-0 gap-2 border-t border-(--ui-separator)/70 pt-2 text-[length:var(--fs-sm)] leading-relaxed",
-              primaryValue ? "lg:grid-cols-[minmax(180px,0.8fr)_minmax(0,1.45fr)_auto_auto]" : "",
-            )}
-          >
-            {primaryValue ? <div className="hidden lg:block" /> : null}
-            <div className={cx("min-w-0 space-y-1.5", primaryValue ? "lg:col-span-3" : "")}>
-              {children}
-            </div>
+          <div className="mt-2 min-w-0 space-y-1.5 border-t border-(--ui-separator)/70 pt-2 text-[length:var(--fs-sm)] leading-relaxed">
+            {children}
           </div>
         ) : null}
       </div>

--- a/frontend/src/ui/runtime-targets.tsx
+++ b/frontend/src/ui/runtime-targets.tsx
@@ -257,31 +257,31 @@ function RuntimeTargetMeta({ target }: { target: RuntimeTarget }) {
 function RuntimeTargetSummary({ target }: { target: RuntimeTarget }) {
   const location = pathForTarget(target);
   return (
-    <div className="min-w-0 space-y-1 text-left">
-      <div className="flex min-w-0 items-baseline gap-2">
-        <span className="shrink-0 font-mono text-[length:var(--fs-md)] text-(--ui-fg)/85">
-          {target.installed ? (target.version ?? "installed") : "not installed"}
-        </span>
-        {location ? (
-          <>
-            <span className="shrink-0 text-(--ui-muted)/70" aria-hidden>
-              ·
-            </span>
-            <span
-              className="min-w-0 truncate font-mono text-[length:var(--fs-sm)] text-(--ui-muted)"
-              title={location}
-            >
-              {location}
-            </span>
-          </>
-        ) : null}
-      </div>
-      {target.update && target.capabilities.canUpdate ? (
-        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
-          <span className="text-[length:var(--fs-sm)] text-(--ui-muted)">
-            target {target.update.targetVersion}
+    <div className="grid min-w-0 grid-cols-1 gap-x-3 gap-y-1 text-left sm:grid-cols-[5rem_minmax(0,1fr)]">
+      <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">Version</span>
+      <span className="min-w-0 font-mono text-[length:var(--fs-md)] text-(--ui-fg)/85">
+        {target.installed ? (target.version ?? "installed") : "not installed"}
+      </span>
+      {location ? (
+        <>
+          <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">
+            Location
           </span>
-        </div>
+          <span
+            className="min-w-0 truncate font-mono text-[length:var(--fs-sm)] text-(--ui-muted)"
+            title={location}
+          >
+            {location}
+          </span>
+        </>
+      ) : null}
+      {target.update && target.capabilities.canUpdate ? (
+        <>
+          <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">Target</span>
+          <span className="min-w-0 font-mono text-[length:var(--fs-sm)] text-(--ui-muted)">
+            {target.update.targetVersion}
+          </span>
+        </>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify the shared settings resource row into a compact header plus stable detail lane
- make runtime target summaries easier to scan with labeled version/location/target fields
- improve wrapping for long runtime and registry labels while reducing code size

## Verification
- npm --prefix frontend run lint -- src/ui/list.tsx src/ui/runtime-targets.tsx
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- cd frontend && npm run desktop:pack
- reinstalled /Applications/vLLM Studio.app and verified /api/desktop-health
- verified only /Applications/vLLM Studio.app is installed and bundle id is org.vllm.studio.desktop
- packaged screenshots:
  - frontend/test-results/system-runtime-rows-final-desktop-hydrated.png
  - frontend/test-results/system-runtime-rows-final-mobile-hydrated.png
  - frontend/test-results/plugins-resource-rows-custom-desktop.png
  - frontend/test-results/plugins-resource-rows-registry-desktop.png
- sub-agent validator review: no blocking findings

## Accounting
- 2 files changed, 44 insertions, 55 deletions
- jscpd analyzed total lines: 64,859, down 22 from the prior slice baseline
- repo warning count remains 12; this slice is visual/layout and does not target an eslint warning.