### PR TITLE
micro: simplify MCP registry mapping

### DIFF
--- a/frontend/src/lib/agent/mcp/official-registry.ts
+++ b/frontend/src/lib/agent/mcp/official-registry.ts
@@ -86,28 +86,8 @@ function toCatalogueEntry(row: RegistryServerRow, source: McpRegistrySource): Mc
   const server = row.server;
   const selectedPackage = selectInstallablePackage(server.packages ?? []);
   const launch = selectedPackage ? launchFromPackage(selectedPackage) : null;
-  const env = selectedPackage ? envDefaults(selectedPackage.environmentVariables ?? []) : undefined;
-  const requiredEnv = selectedPackage
-    ? (selectedPackage.environmentVariables ?? [])
-        .filter((entry) => entry.isRequired && entry.name)
-        .map((entry) => String(entry.name))
-    : [];
   const remoteOnly = !selectedPackage && Boolean(server.remotes?.length);
   const registry = source.builtIn ? "official" : "custom";
-  const packageTags = selectedPackage
-    ? [selectedPackage.registryType, selectedPackage.transport.type]
-    : remoteOnly
-      ? ["remote"]
-      : ["metadata"];
-  const attributes = [
-    `registry:${source.name}`,
-    `version:${server.version}`,
-    ...(row._meta?.["io.modelcontextprotocol.registry/official"]?.status
-      ? [`status:${row._meta["io.modelcontextprotocol.registry/official"].status}`]
-      : []),
-    ...(selectedPackage ? [`package:${selectedPackage.registryType}`] : []),
-    ...(remoteOnly ? ["remote-only"] : []),
-  ];
 
   return {
     id: `${registry}:${source.id}:${server.name}:${server.version}`,
@@ -120,25 +100,68 @@ function toCatalogueEntry(row: RegistryServerRow, source: McpRegistrySource): Mc
     args: launch?.args ?? [],
     tags: [
       registry,
-      ...packageTags,
-      ...(server.repository?.source ? [server.repository.source] : []),
+      ...packageTagsFor(selectedPackage, remoteOnly),
+      ...repositorySourceTags(server.repository),
     ],
     registry,
     registryName: source.name,
     registrySourceId: source.id,
     registryUrl: versionUrl(source.url, server.name, server.version),
     repositoryUrl: server.repository?.url,
-    attributes,
-    env,
-    requiredEnv,
-    homepage: server.websiteUrl ?? server.repository?.url ?? source.url,
+    attributes: registryAttributes(row, source, selectedPackage, remoteOnly),
+    env: selectedPackage ? envDefaults(selectedPackage.environmentVariables ?? []) : undefined,
+    requiredEnv: selectedPackage
+      ? requiredEnvironmentNames(selectedPackage.environmentVariables ?? [])
+      : [],
+    homepage: homepageForServer(server, source),
     installable: Boolean(launch),
-    unsupportedReason: launch
-      ? undefined
-      : remoteOnly
-        ? "Remote MCP transports are listed, but this app currently installs stdio servers."
-        : "No supported stdio package is listed for this server.",
+    unsupportedReason: unsupportedReasonFor(launch, remoteOnly),
   };
+}
+
+function registryAttributes(
+  row: RegistryServerRow,
+  source: McpRegistrySource,
+  selectedPackage: RegistryPackage | null,
+  remoteOnly: boolean,
+): string[] {
+  const officialStatus = row._meta?.["io.modelcontextprotocol.registry/official"]?.status;
+  return [
+    `registry:${source.name}`,
+    `version:${row.server.version}`,
+    ...(officialStatus ? [`status:${officialStatus}`] : []),
+    ...(selectedPackage ? [`package:${selectedPackage.registryType}`] : []),
+    ...(remoteOnly ? ["remote-only"] : []),
+  ];
+}
+
+function packageTagsFor(selectedPackage: RegistryPackage | null, remoteOnly: boolean): string[] {
+  if (selectedPackage) return [selectedPackage.registryType, selectedPackage.transport.type];
+  return remoteOnly ? ["remote"] : ["metadata"];
+}
+
+function repositorySourceTags(repository: RegistryServer["repository"]): string[] {
+  return repository?.source ? [repository.source] : [];
+}
+
+function requiredEnvironmentNames(inputs: RegistryInput[]): string[] {
+  return inputs
+    .filter((entry) => entry.isRequired && entry.name)
+    .map((entry) => String(entry.name));
+}
+
+function homepageForServer(server: RegistryServer, source: McpRegistrySource): string {
+  return server.websiteUrl ?? server.repository?.url ?? source.url;
+}
+
+function unsupportedReasonFor(
+  launch: { command: string; args: string[] } | null,
+  remoteOnly: boolean,
+): string | undefined {
+  if (launch) return undefined;
+  return remoteOnly
+    ? "Remote MCP transports are listed, but this app currently installs stdio servers."
+    : "No supported stdio package is listed for this server.";
 }
 
 function selectInstallablePackage(packages: RegistryPackage[]): RegistryPackage | null {


### PR DESCRIPTION
## Summary
- extract registry attributes, package tags, required env names, homepage, and unsupported reason helpers from the official-compatible MCP registry mapper
- preserve the catalogue entry output shape while reducing `toCatalogueEntry` complexity
- keep official/custom registry metadata and stdio launch mapping intact

## Verification
- npm --prefix frontend run lint -- src/lib/agent/mcp/official-registry.ts
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- cd frontend && npm run desktop:pack
- reinstalled /Applications/vLLM Studio.app and verified /api/desktop-health
- verified only /Applications/vLLM Studio.app is installed and bundle id is org.vllm.studio.desktop
- packaged registry smoke: /api/mcp/registry?q=filesystem&limit=3 returned 3 entries; first entry official/installable with tags official,npm,stdio,github
- sub-agent validator review: no blocking findings

## Accounting
- repo eslint warnings: 12 -> 11
- removes the `toCatalogueEntry` complexity warning
- jscpd analyzed total lines: 64,882 (+23 from prior slice baseline)
- no clones, no depcheck issue