### PR TITLE
micro: simplify MCP action handling

### DIFF
--- a/frontend/src/lib/agent/mcp/api.ts
+++ b/frontend/src/lib/agent/mcp/api.ts
@@ -19,99 +19,117 @@ export function mcpBadRequest(error: string) {
   return { status: 400, payload: { error } };
 }
 
+function mcpOk() {
+  return { status: 200, payload: mcpSnapshot(true) };
+}
+
 export function handleMcpAction(body: Record<string, unknown> | null) {
   if (!body || typeof body.action !== "string") {
     return mcpBadRequest("Expected { action }.");
   }
 
   switch (body.action) {
-    case "set_enabled": {
-      const id = typeof body.id === "string" ? body.id : "";
-      if (!id || typeof body.enabled !== "boolean") {
-        return mcpBadRequest("set_enabled requires { id, enabled }.");
-      }
-      setServerEnabled(id, body.enabled);
-      return { status: 200, payload: mcpSnapshot(true) };
-    }
-
-    case "set_tags": {
-      const id = typeof body.id === "string" ? body.id : "";
-      const tags = parseTags(body.tags);
-      if (!id) return mcpBadRequest("set_tags requires { id, tags }.");
-      setServerTags(id, tags);
-      return { status: 200, payload: mcpSnapshot(true) };
-    }
-
-    case "remove": {
-      const id = typeof body.id === "string" ? body.id : "";
-      if (!id) return mcpBadRequest("remove requires { id }.");
-      removeServer(id);
-      return { status: 200, payload: mcpSnapshot(true) };
-    }
-
-    case "add_from_catalogue": {
-      const catalogueId = typeof body.catalogueId === "string" ? body.catalogueId : "";
-      const entry = findCatalogueEntry(catalogueId);
-      if (!entry) return mcpBadRequest("Unknown catalogue entry.");
-      const env = { ...(entry.env ?? {}), ...(parseEnv(body.env) ?? {}) };
-      const missing = (entry.requiredEnv ?? []).filter((key) => !env[key]?.trim());
-      if (missing.length) {
-        return mcpBadRequest(`Missing required values: ${missing.join(", ")}.`);
-      }
-      const extraArgs = parseArgs(body.args);
-      const def: McpServerDef = {
-        id: `mcp:${entry.name}:${Date.now().toString(36)}`,
-        name: entry.name,
-        displayName: entry.displayName,
-        description: entry.description,
-        ...(entry.shortDescription ? { shortDescription: entry.shortDescription } : {}),
-        category: entry.category,
-        ...(entry.tags?.length ? { tags: entry.tags } : {}),
-        transport: "stdio",
-        command: entry.command,
-        args: extraArgs ?? entry.args,
-        ...(Object.keys(env).length ? { env } : {}),
-      };
-      upsertServer(def, "marketplace");
-      return { status: 200, payload: mcpSnapshot(true) };
-    }
-
-    case "add_manual": {
-      const name = typeof body.name === "string" ? body.name.trim() : "";
-      const command = typeof body.command === "string" ? body.command.trim() : "";
-      if (!name || !command) return mcpBadRequest("add_manual requires { name, command }.");
-      const slug = slugify(name) || "server";
-      const args = parseArgs(body.args);
-      const env = parseEnv(body.env);
-      const tags = parseTags(body.tags);
-      const def: McpServerDef = {
-        id:
-          typeof body.id === "string" && body.id.trim()
-            ? body.id.trim()
-            : `mcp:${slug}:${Date.now().toString(36)}`,
-        name: slug,
-        displayName: name,
-        ...(typeof body.description === "string" && body.description.trim()
-          ? { description: body.description.trim() }
-          : {}),
-        category:
-          typeof body.category === "string" && body.category.trim()
-            ? body.category.trim()
-            : "Custom",
-        ...(tags.length ? { tags } : {}),
-        transport: "stdio",
-        command,
-        ...(args ? { args } : {}),
-        ...(env ? { env } : {}),
-        ...(typeof body.cwd === "string" && body.cwd.trim() ? { cwd: body.cwd.trim() } : {}),
-      };
-      upsertServer(def, "manual");
-      return { status: 200, payload: mcpSnapshot(true) };
-    }
-
+    case "set_enabled":
+      return handleSetEnabled(body);
+    case "set_tags":
+      return handleSetTags(body);
+    case "remove":
+      return handleRemove(body);
+    case "add_from_catalogue":
+      return handleAddFromCatalogue(body);
+    case "add_manual":
+      return handleAddManual(body);
     default:
       return mcpBadRequest(`Unknown action: ${String(body.action)}.`);
   }
+}
+
+function handleSetEnabled(body: Record<string, unknown>) {
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id || typeof body.enabled !== "boolean") {
+    return mcpBadRequest("set_enabled requires { id, enabled }.");
+  }
+  setServerEnabled(id, body.enabled);
+  return mcpOk();
+}
+
+function handleSetTags(body: Record<string, unknown>) {
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id) return mcpBadRequest("set_tags requires { id, tags }.");
+  setServerTags(id, parseTags(body.tags));
+  return mcpOk();
+}
+
+function handleRemove(body: Record<string, unknown>) {
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id) return mcpBadRequest("remove requires { id }.");
+  removeServer(id);
+  return mcpOk();
+}
+
+function handleAddFromCatalogue(body: Record<string, unknown>) {
+  const catalogueId = typeof body.catalogueId === "string" ? body.catalogueId : "";
+  const entry = findCatalogueEntry(catalogueId);
+  if (!entry) return mcpBadRequest("Unknown catalogue entry.");
+  const env = { ...(entry.env ?? {}), ...(parseEnv(body.env) ?? {}) };
+  const missing = (entry.requiredEnv ?? []).filter((key) => !env[key]?.trim());
+  if (missing.length) return mcpBadRequest(`Missing required values: ${missing.join(", ")}.`);
+  const extraArgs = parseArgs(body.args);
+  upsertServer(
+    {
+      id: `mcp:${entry.name}:${Date.now().toString(36)}`,
+      name: entry.name,
+      displayName: entry.displayName,
+      description: entry.description,
+      ...(entry.shortDescription ? { shortDescription: entry.shortDescription } : {}),
+      category: entry.category,
+      ...(entry.tags?.length ? { tags: entry.tags } : {}),
+      transport: "stdio",
+      command: entry.command,
+      args: extraArgs ?? entry.args,
+      ...(Object.keys(env).length ? { env } : {}),
+    },
+    "marketplace",
+  );
+  return mcpOk();
+}
+
+function handleAddManual(body: Record<string, unknown>) {
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const command = typeof body.command === "string" ? body.command.trim() : "";
+  if (!name || !command) return mcpBadRequest("add_manual requires { name, command }.");
+  upsertServer(manualServerDef(body, name, command), "manual");
+  return mcpOk();
+}
+
+function manualServerDef(
+  body: Record<string, unknown>,
+  name: string,
+  command: string,
+): McpServerDef {
+  const slug = slugify(name) || "server";
+  const args = parseArgs(body.args);
+  const env = parseEnv(body.env);
+  const tags = parseTags(body.tags);
+  return {
+    id:
+      typeof body.id === "string" && body.id.trim()
+        ? body.id.trim()
+        : `mcp:${slug}:${Date.now().toString(36)}`,
+    name: slug,
+    displayName: name,
+    ...(typeof body.description === "string" && body.description.trim()
+      ? { description: body.description.trim() }
+      : {}),
+    category:
+      typeof body.category === "string" && body.category.trim() ? body.category.trim() : "Custom",
+    ...(tags.length ? { tags } : {}),
+    transport: "stdio",
+    command,
+    ...(args ? { args } : {}),
+    ...(env ? { env } : {}),
+    ...(typeof body.cwd === "string" && body.cwd.trim() ? { cwd: body.cwd.trim() } : {}),
+  };
 }
 
 function slugify(value: string): string {


### PR DESCRIPTION
## Summary
- split MCP server POST actions into focused handlers for toggles, tags, removal, catalogue add, and manual add
- keep success payloads and bad-request messages unchanged
- remove the `handleMcpAction` complexity warning while preserving `/api/mcp/servers` and legacy `/api/agent/plugins` behavior

## Verification
- npm --prefix frontend run lint -- src/lib/agent/mcp/api.ts
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- cd frontend && npm run desktop:pack
- reinstalled /Applications/vLLM Studio.app and verified /api/desktop-health
- verified only /Applications/vLLM Studio.app is installed and bundle id is org.vllm.studio.desktop
- packaged MCP smoke: GET /api/mcp/servers?includeDisabled=1 returned array payloads; POST remove without id returned 400 {"error":"remove requires { id }."}
- sub-agent validator review: no blocking findings

## Accounting
- repo eslint warnings: 11 -> 10
- removes the `handleMcpAction` complexity warning
- jscpd analyzed total lines: 64,900 (+18 from prior slice baseline)
- no clones, no depcheck issue