### PR TITLE
micro: simplify Hugging Face model card

### DIFF
--- a/frontend/src/ui/huggingface-model-card.tsx
+++ b/frontend/src/ui/huggingface-model-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
+import { useCallback, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Download, ExternalLink, Heart, RefreshCw, Sparkles } from "lucide-react";
 import type { HuggingFaceModel } from "@/lib/types";
 import {
@@ -23,6 +23,12 @@ type HardwareFitSummary = {
   reason: string;
 };
 
+type ModelCardStats = {
+  downloads: number;
+  likes: number;
+  tier: ReturnType<typeof engagementTier>;
+};
+
 export function HuggingFaceModelCardModal({
   model,
   variants = [],
@@ -36,10 +42,82 @@ export function HuggingFaceModelCardModal({
   open: boolean;
   onClose: () => void;
 }) {
+  const modelId = model?.modelId ?? "";
+  const { error, loading, payload } = useModelCardPayload(modelId, open);
+  const stats = modelCardStats(model, payload);
+
+  if (!model) return null;
+
+  const badges = modelCardBadges(model, payload);
+  const readme = readmeContent({ error, loading, summary: readmeSummary(payload?.readme) });
+
+  return (
+    <UiModal isOpen={open} onClose={onClose} maxWidth="max-w-4xl" className="overflow-hidden">
+      <UiModalHeader
+        title={modelDisplayName(model.modelId)}
+        icon={<ModelLogo modelId={model.modelId} author={payload?.author ?? model.author} />}
+        onClose={onClose}
+        actions={
+          <div className="flex items-center gap-1.5">
+            <StatusPill tone={engagementTone(stats.tier)} variant="badge">
+              {engagementLabel(stats.tier)}
+            </StatusPill>
+            <a href={hfModelUrl(model.modelId)} target="_blank" rel="noopener noreferrer">
+              <Button variant="icon" size="sm" title="Open on Hugging Face">
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Button>
+            </a>
+          </div>
+        }
+        closeIcon="x"
+      />
+      <div className="max-h-[78vh] overflow-y-auto p-5">
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <section className="min-w-0 space-y-4">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-[length:var(--fs-sm)] text-(--ui-muted)">
+              <span className="inline-flex items-center gap-1.5">
+                <Download className="h-3.5 w-3.5" />
+                {formatNumber(stats.downloads)} downloads
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Heart className="h-3.5 w-3.5" />
+                {formatNumber(stats.likes)} likes
+              </span>
+              {badges.map((badge) => (
+                <StatusPill key={`${badge.kind}:${badge.label}`} variant="badge">
+                  {badge.label}
+                </StatusPill>
+              ))}
+            </div>
+            <div className="rounded-md border border-(--ui-border) bg-(--ui-surface)">
+              <div className="flex h-9 items-center justify-between border-b border-(--ui-border) px-3">
+                <div className="flex min-w-0 items-center gap-2 text-[length:var(--fs-sm)] font-medium text-(--ui-fg)">
+                  <Sparkles className="h-3.5 w-3.5 text-(--ui-info)" />
+                  Model card
+                </div>
+                {loading ? (
+                  <RefreshCw className="h-3.5 w-3.5 animate-spin text-(--ui-muted)" />
+                ) : null}
+              </div>
+              <div className="p-3">{readme}</div>
+            </div>
+          </section>
+          <aside className="space-y-4">
+            <HardwareFitPanel fit={fit} />
+            <MetadataPanel payload={payload} model={model} />
+            <QuantPanel variants={variants} />
+            <FilesPanel payload={payload} />
+          </aside>
+        </div>
+      </div>
+    </UiModal>
+  );
+}
+
+function useModelCardPayload(modelId: string, open: boolean) {
   const [payload, setPayload] = useState<HuggingFaceModelCardPayload | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const modelId = model?.modelId ?? "";
 
   const load = useCallback(async () => {
     if (!modelId) return;
@@ -71,103 +149,60 @@ export function HuggingFaceModelCardModal({
 
   useSyncExternalStore(subscribe, getModelCardSnapshot, getModelCardSnapshot);
 
-  const title = model ? modelDisplayName(model.modelId) : "Model";
-  const stats = useMemo(() => {
-    const downloads = payload?.downloads ?? model?.downloads ?? 0;
-    const likes = payload?.likes ?? model?.likes ?? 0;
-    return {
-      downloads,
-      likes,
-      tier: engagementTier(likes, downloads),
-    };
-  }, [model, payload]);
+  return { error, loading, payload };
+}
 
-  if (!model) return null;
+function modelCardStats(
+  model: HuggingFaceModel | null,
+  payload: HuggingFaceModelCardPayload | null,
+): ModelCardStats {
+  const downloads = payload?.downloads ?? model?.downloads ?? 0;
+  const likes = payload?.likes ?? model?.likes ?? 0;
+  return { downloads, likes, tier: engagementTier(likes, downloads) };
+}
 
+function modelCardBadges(
+  model: HuggingFaceModel,
+  payload: HuggingFaceModelCardPayload | null,
+): Array<{ kind: string; label: string }> {
+  return [
+    { kind: "pipeline", label: payload?.pipeline_tag ?? model.pipeline_tag },
+    { kind: "library", label: payload?.library_name ?? model.library_name },
+  ].filter((badge): badge is { kind: string; label: string } => Boolean(badge.label));
+}
+
+function engagementTone(tier: ModelCardStats["tier"]) {
+  if (tier === "heavy") return "good";
+  if (tier === "warm") return "info";
+  return "default";
+}
+
+function engagementLabel(tier: ModelCardStats["tier"]) {
+  return tier === "heavy" ? "high signal" : tier;
+}
+
+function readmeContent({
+  error,
+  loading,
+  summary,
+}: {
+  error: string | null;
+  loading: boolean;
+  summary: string;
+}): ReactNode {
+  if (error) return <p className="text-[length:var(--fs-sm)] text-(--ui-danger)">{error}</p>;
+  if (summary) {
+    return (
+      <pre className="max-h-[460px] whitespace-pre-wrap font-sans text-[length:var(--fs-md)] leading-6 text-(--ui-fg)/85">
+        {summary}
+      </pre>
+    );
+  }
+  if (loading) return null;
   return (
-    <UiModal isOpen={open} onClose={onClose} maxWidth="max-w-4xl" className="overflow-hidden">
-      <UiModalHeader
-        title={title}
-        icon={<ModelLogo modelId={model.modelId} author={payload?.author ?? model.author} />}
-        onClose={onClose}
-        actions={
-          <div className="flex items-center gap-1.5">
-            <StatusPill
-              tone={stats.tier === "heavy" ? "good" : stats.tier === "warm" ? "info" : "default"}
-              variant="badge"
-            >
-              {stats.tier === "heavy" ? "high signal" : stats.tier}
-            </StatusPill>
-            <a href={hfModelUrl(model.modelId)} target="_blank" rel="noopener noreferrer">
-              <Button variant="icon" size="sm" title="Open on Hugging Face">
-                <ExternalLink className="h-3.5 w-3.5" />
-              </Button>
-            </a>
-          </div>
-        }
-        closeIcon="x"
-      />
-      <div className="max-h-[78vh] overflow-y-auto p-5">
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
-          <section className="min-w-0 space-y-4">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-[length:var(--fs-sm)] text-(--ui-muted)">
-              <span className="inline-flex items-center gap-1.5">
-                <Download className="h-3.5 w-3.5" />
-                {formatNumber(stats.downloads)} downloads
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <Heart className="h-3.5 w-3.5" />
-                {formatNumber(stats.likes)} likes
-              </span>
-              {payload?.pipeline_tag || model.pipeline_tag ? (
-                <StatusPill variant="badge">
-                  {payload?.pipeline_tag ?? model.pipeline_tag}
-                </StatusPill>
-              ) : null}
-              {payload?.library_name || model.library_name ? (
-                <StatusPill variant="badge">
-                  {payload?.library_name ?? model.library_name}
-                </StatusPill>
-              ) : null}
-            </div>
-
-            <div className="rounded-md border border-(--ui-border) bg-(--ui-surface)">
-              <div className="flex h-9 items-center justify-between border-b border-(--ui-border) px-3">
-                <div className="flex min-w-0 items-center gap-2 text-[length:var(--fs-sm)] font-medium text-(--ui-fg)">
-                  <Sparkles className="h-3.5 w-3.5 text-(--ui-info)" />
-                  Model card
-                </div>
-                {loading ? (
-                  <RefreshCw className="h-3.5 w-3.5 animate-spin text-(--ui-muted)" />
-                ) : null}
-              </div>
-              <div className="p-3">
-                {error ? (
-                  <p className="text-[length:var(--fs-sm)] text-(--ui-danger)">{error}</p>
-                ) : null}
-                {!error && readmeSummary(payload?.readme) ? (
-                  <pre className="max-h-[460px] whitespace-pre-wrap font-sans text-[length:var(--fs-md)] leading-6 text-(--ui-fg)/85">
-                    {readmeSummary(payload?.readme)}
-                  </pre>
-                ) : null}
-                {!error && !loading && !readmeSummary(payload?.readme) ? (
-                  <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
-                    No README content was returned for this model.
-                  </p>
-                ) : null}
-              </div>
-            </div>
-          </section>
-
-          <aside className="space-y-4">
-            <HardwareFitPanel fit={fit} />
-            <MetadataPanel payload={payload} model={model} />
-            <QuantPanel variants={variants} />
-            <FilesPanel payload={payload} />
-          </aside>
-        </div>
-      </div>
-    </UiModal>
+    <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
+      No README content was returned for this model.
+    </p>
   );
 }
 


### PR DESCRIPTION
## Summary
- Extract model-card payload loading and stats/readme helper logic out of the modal render body
- Preserve modal layout and behavior while removing the Hugging Face model-card complexity warning
- Use stable typed badge keys for pipeline/library labels

## Verification
- npm --prefix frontend run lint -- src/ui/huggingface-model-card.tsx
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- Reinstalled /Applications/vLLM Studio.app
- curl http://127.0.0.1:61449/api/desktop-health => ok
- Packaged /discover modal smoke screenshot: frontend/test-results/huggingface-model-card-modal.png
- Sub-agent validator review: no blocking findings; non-blocking duplicate badge-key edge fixed

## Accounting
- ESLint warnings: 6 -> 5
- jscpd: 0 clones, 65,039 analyzed lines
