### PR TITLE
micro: extract session prompt stream

### DIFF
--- a/frontend/src/lib/agent/sessions/engine.ts
+++ b/frontend/src/lib/agent/sessions/engine.ts
@@ -7,7 +7,6 @@ import {
 import { isAgentEndEvent } from "@/lib/agent/pi-events";
 import {
   type ChatMessage,
-  type ChatMessageAttachment,
   mergeCanonicalAndRuntimeEvents,
   newId,
   nowLabel,
@@ -15,7 +14,6 @@ import {
   replayCursorAfterRuntimeHydration,
   replaySessionEvents,
   runtimeStatusAcceptsControl,
-  sessionTitleFromPrompt,
   statusAfterControlPhase,
   type TokenStats,
   usageFromEvent,
@@ -28,51 +26,19 @@ import {
   type ComposerSkillRef,
 } from "@/lib/agent/composer-context";
 import { promptRequestsBrowser } from "@/lib/agent/browser/intent";
-import type { AgentImageInput } from "@/lib/agent/contracts/turn";
-import type { Session, SessionId, SessionStatus } from "@/lib/agent/sessions/types";
+import type { Session, SessionId } from "@/lib/agent/sessions/types";
 import type { ToolSelection } from "@/lib/agent/tools/types";
-import { traceAgentReasoning } from "@/lib/agent/trace-reasoning";
 import * as api from "./api";
-import {
-  resolveRuntimeSessionId,
-  runtimeCanHydrateCanonicalSession,
-  runtimeIsActiveForPiSession,
-} from "./engine-helpers";
+import { resolveRuntimeSessionId, runtimeCanHydrateCanonicalSession } from "./engine-helpers";
 import { applyPiEventToSession } from "./pi-event-applier";
-import { drainQueuedTurnAfterAgentEnd } from "./queue-drain";
-import { claimRuntimePromptStream, releaseRuntimePromptStream } from "./stream-ownership";
+import { submitPromptTurn, type SubmitArgs } from "./prompt-stream";
 import { createTextDeltaCoalescer, type TextDeltaCoalescer } from "./text-delta-coalescer";
 
 const EMPTY_PLUGINS: ComposerPluginRef[] = [];
 const EMPTY_SKILLS: ComposerSkillRef[] = [];
 const EMPTY_PROMPT_TEMPLATES: ComposerPromptTemplateRef[] = [];
 
-function mergeSkills(
-  existing: ComposerSkillRef[] | undefined,
-  next: ComposerSkillRef[],
-): ComposerSkillRef[] | undefined {
-  if (!existing?.length && next.length === 0) return existing;
-  const byId = new Map<string, ComposerSkillRef>();
-  for (const skill of existing ?? []) byId.set(skill.id || skill.path || skill.name, skill);
-  for (const skill of next) byId.set(skill.id || skill.path || skill.name, skill);
-  return [...byId.values()];
-}
-
 type UpdateSession = (sessionId: SessionId, patch: (session: Session) => Session) => void;
-
-type SubmitArgs = {
-  text: string;
-  /** Pre-resolved prompt text (with attachments / context already merged). */
-  prompt: string;
-  displayText: string;
-  userText: string;
-  images?: AgentImageInput[];
-  attachments?: ChatMessageAttachment[];
-  plugins?: ComposerPluginRef[];
-  skills?: ComposerSkillRef[];
-  promptTemplates?: ComposerPromptTemplateRef[];
-  targetSessionId?: SessionId;
-};
 
 export type UseSessionEngineDeps = {
   /** Latest `tabs` snapshot — engine reads via a ref so it doesn't restart on every frame. */
@@ -342,151 +308,27 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
 
   const submitPrompt = useCallback(
     async (args: SubmitArgs) => {
-      const sessionId = args.targetSessionId ?? activeTabId;
-      const selected = tabsRef.current.find((tab) => tab.id === sessionId);
-      if (!selected || !modelId) return;
-
-      const userId = newId("user");
-      const assistantId = newId("assistant");
-      const runtime = selected.runtimeSessionId || runtimeSessionId;
-      const browserEnabledForTurn = browserToolEnabled || promptRequestsBrowser(args.userText);
-      const selection = selectionForRef.current(sessionId);
-      const plugins = args.plugins ?? activeComposerPlugins(selection.plugins ?? EMPTY_PLUGINS);
-      const skills = args.skills ?? selection.skills ?? EMPTY_SKILLS;
-      const promptTemplates =
-        args.promptTemplates ?? selection.promptTemplates ?? EMPTY_PROMPT_TEMPLATES;
-
-      // Optimistic: push a user message + a blank assistant placeholder so the
-      // UI shows "we received it" even before the first SSE chunk lands.
-      updateSession(sessionId, (session) => ({
-        ...session,
-        cwd: session.cwd || cwd,
-        modelId: session.modelId || modelId,
-        startedAt: session.startedAt ?? new Date().toISOString(),
-        input: "",
-        error: "",
-        status: "starting",
-        usedSkills: mergeSkills(session.usedSkills, skills),
-        activeAssistantId: assistantId,
-        title:
-          session.messages.filter((m) => m.role === "user").length === 0
-            ? sessionTitleFromPrompt(args.userText)
-            : session.title,
-        messages: [
-          ...session.messages,
-          {
-            id: userId,
-            role: "user",
-            text: args.displayText,
-            attachments: args.attachments,
-            skills,
-            timestamp: nowLabel(),
-          },
-          { id: assistantId, role: "assistant", text: "", blocks: [], timestamp: nowLabel() },
-        ],
-      }));
-
-      let agentEnded = false;
-      let streamError = "";
-      const controller = new AbortController();
-      const streamOwnerId = `${sessionId}:${assistantId}`;
-      liveAssistantIdsRef.current.set(sessionId, assistantId);
-      promptStreamControllersRef.current.set(runtime, controller);
-      claimRuntimePromptStream(runtime, streamOwnerId, controller);
-      try {
-        await api.submitTurnStream(
-          {
-            sessionId: runtime,
-            modelId,
-            message: args.prompt,
-            images: args.images,
-            cwd: cwd.trim() || undefined,
-            piSessionId:
-              tabsRef.current.find((tab) => tab.id === sessionId)?.piSessionId ??
-              selected.piSessionId,
-            browserToolEnabled: browserEnabledForTurn,
-            browserSessionId: runtime,
-            canvasEnabled,
-            plugins: plugins as ComposerPluginRef[],
-            skills,
-            promptTemplates,
-          },
-          (payload) => {
-            if (controller.signal.aborted) return;
-            if (payload.type === "status") {
-              const phase = payload.phase;
-              updateSession(sessionId, (session) => ({
-                ...session,
-                piSessionId: payload.piSessionId || session.piSessionId,
-                status: (phase === "done" ? "idle" : phase) as SessionStatus,
-                activeAssistantId: phase === "done" ? undefined : session.activeAssistantId,
-              }));
-              if (payload.piSessionId) onPiSessionIdChange?.(payload.piSessionId);
-            } else if (payload.type === "error") {
-              streamError = payload.error;
-              flushPiEventBatch(sessionId);
-              updateSession(sessionId, (session) => ({
-                ...session,
-                error: payload.error,
-                status: "idle",
-              }));
-            } else if (payload.type === "pi") {
-              if (!shouldApplyRuntimeSeq(sessionId, payload.seq)) return;
-              const piEvent = payload.event;
-              traceAgentReasoning("engine.pi", {
-                sessionId,
-                assistantId,
-                seq: payload.seq,
-                event: piEvent,
-              });
-              const eventId = piSessionIdFromEvent(piEvent);
-              if (eventId) {
-                updateSession(sessionId, (session) => ({ ...session, piSessionId: eventId }));
-                onPiSessionIdChange?.(eventId);
-              }
-              if (isAgentEndEvent(piEvent)) {
-                agentEnded = true;
-                const latestPiSessionId =
-                  eventId ??
-                  tabsRef.current.find((tab) => tab.id === sessionId)?.piSessionId ??
-                  selected.piSessionId ??
-                  "";
-                onPiSessionIdChange?.(latestPiSessionId);
-              }
-              enqueuePiEvent(sessionId, assistantId, piEvent, { flushNow: agentEnded });
-            }
-          },
-          { signal: controller.signal },
-        );
-      } catch (err) {
-        if (!controller.signal.aborted) {
-          streamError = err instanceof Error ? err.message : "Agent request failed";
-        }
-      } finally {
-        flushPiEventBatch(sessionId);
-        promptStreamControllersRef.current.delete(runtime);
-        releaseRuntimePromptStream(runtime, streamOwnerId);
-        liveAssistantIdsRef.current.delete(sessionId);
-        const currentPiSessionId =
-          tabsRef.current.find((tab) => tab.id === sessionId)?.piSessionId ??
-          selected.piSessionId ??
-          null;
-        const runtimeStatus = await api.loadRuntimeStatus(runtime, currentPiSessionId);
-        const runtimeStillActive =
-          !agentEnded && runtimeIsActiveForPiSession(runtimeStatus, currentPiSessionId);
-        updateSession(sessionId, (session) => ({
-          ...session,
-          status: runtimeStillActive ? "running" : "idle",
-          activeAssistantId: runtimeStillActive ? assistantId : undefined,
-          error: streamError && !runtimeStillActive ? streamError : session.error,
-          contextUsage: runtimeStatus?.contextUsage ?? session.contextUsage ?? null,
-        }));
-      }
-
-      // Drain the per-session queue once the agent finished its turn.
-      if (agentEnded) {
-        drainQueuedTurnAfterAgentEnd({ submitPromptRef, tabsRef, updateSession }, sessionId);
-      }
+      await submitPromptTurn(
+        {
+          activeTabId,
+          browserToolEnabled,
+          canvasEnabled,
+          cwd,
+          enqueuePiEvent,
+          flushPiEventBatch,
+          liveAssistantIdsRef,
+          modelId,
+          onPiSessionIdChange,
+          promptStreamControllersRef,
+          runtimeSessionId,
+          selectionFor: selectionForRef.current,
+          shouldApplyRuntimeSeq,
+          submitPromptRef,
+          tabsRef,
+          updateSession,
+        },
+        args,
+      );
     },
     [
       activeTabId,

--- a/frontend/src/lib/agent/sessions/prompt-stream.ts
+++ b/frontend/src/lib/agent/sessions/prompt-stream.ts
@@ -1,0 +1,335 @@
+import { isAgentEndEvent } from "@/lib/agent/pi-events";
+import {
+  type ChatMessageAttachment,
+  newId,
+  nowLabel,
+  piSessionIdFromEvent,
+  sessionTitleFromPrompt,
+  type AgentTurnSsePayload,
+} from "@/lib/agent/session";
+import {
+  activeComposerPlugins,
+  type ComposerPluginRef,
+  type ComposerPromptTemplateRef,
+  type ComposerSkillRef,
+} from "@/lib/agent/composer-context";
+import { promptRequestsBrowser } from "@/lib/agent/browser/intent";
+import type { AgentImageInput } from "@/lib/agent/contracts/turn";
+import type { ToolSelection } from "@/lib/agent/tools/types";
+import { traceAgentReasoning } from "@/lib/agent/trace-reasoning";
+import * as api from "./api";
+import { runtimeIsActiveForPiSession } from "./engine-helpers";
+import { drainQueuedTurnAfterAgentEnd } from "./queue-drain";
+import { claimRuntimePromptStream, releaseRuntimePromptStream } from "./stream-ownership";
+import type { Session, SessionId, SessionStatus } from "./types";
+
+const EMPTY_PLUGINS: ComposerPluginRef[] = [];
+const EMPTY_SKILLS: ComposerSkillRef[] = [];
+const EMPTY_PROMPT_TEMPLATES: ComposerPromptTemplateRef[] = [];
+
+type MutableRef<T> = { current: T };
+type UpdateSession = (sessionId: SessionId, patch: (session: Session) => Session) => void;
+
+export type SubmitArgs = {
+  text: string;
+  /** Pre-resolved prompt text (with attachments / context already merged). */
+  prompt: string;
+  displayText: string;
+  userText: string;
+  images?: AgentImageInput[];
+  attachments?: ChatMessageAttachment[];
+  plugins?: ComposerPluginRef[];
+  skills?: ComposerSkillRef[];
+  promptTemplates?: ComposerPromptTemplateRef[];
+  targetSessionId?: SessionId;
+};
+
+export type PromptStreamDeps = {
+  activeTabId: SessionId;
+  browserToolEnabled: boolean;
+  canvasEnabled: boolean;
+  cwd: string;
+  enqueuePiEvent: (
+    sessionId: SessionId,
+    assistantId: string,
+    event: Record<string, unknown>,
+    options?: { flushNow?: boolean },
+  ) => void;
+  flushPiEventBatch: (sessionId: SessionId) => void;
+  liveAssistantIdsRef: MutableRef<Map<SessionId, string>>;
+  modelId: string;
+  onPiSessionIdChange?: (piSessionId: string) => void;
+  promptStreamControllersRef: MutableRef<Map<string, AbortController>>;
+  runtimeSessionId: string;
+  selectionFor: (sessionId: SessionId) => ToolSelection;
+  shouldApplyRuntimeSeq: (sessionId: SessionId, seq?: number) => boolean;
+  submitPromptRef: MutableRef<(args: SubmitArgs) => Promise<void>>;
+  tabsRef: MutableRef<Session[]>;
+  updateSession: UpdateSession;
+};
+
+type PromptTurnContext = {
+  assistantId: string;
+  browserEnabledForTurn: boolean;
+  plugins: ComposerPluginRef[];
+  promptTemplates: ComposerPromptTemplateRef[];
+  runtime: string;
+  selected: Session;
+  sessionId: SessionId;
+  skills: ComposerSkillRef[];
+  userId: string;
+};
+
+type PromptTurnState = {
+  agentEnded: boolean;
+  streamError: string;
+};
+
+export async function submitPromptTurn(deps: PromptStreamDeps, args: SubmitArgs): Promise<void> {
+  const context = createPromptTurnContext(deps, args);
+  if (!context) return;
+
+  appendOptimisticPrompt(deps, context, args);
+  const state = await streamPromptTurn(deps, context, args);
+  if (state.agentEnded) {
+    drainQueuedTurnAfterAgentEnd(deps, context.sessionId);
+  }
+}
+
+function createPromptTurnContext(
+  deps: PromptStreamDeps,
+  args: SubmitArgs,
+): PromptTurnContext | null {
+  const sessionId = args.targetSessionId ?? deps.activeTabId;
+  const selected = deps.tabsRef.current.find((tab) => tab.id === sessionId);
+  if (!selected || !deps.modelId) return null;
+
+  const selection = deps.selectionFor(sessionId);
+  const plugins = args.plugins ?? activeComposerPlugins(selection.plugins ?? EMPTY_PLUGINS);
+  const skills = args.skills ?? selection.skills ?? EMPTY_SKILLS;
+  const promptTemplates =
+    args.promptTemplates ?? selection.promptTemplates ?? EMPTY_PROMPT_TEMPLATES;
+
+  return {
+    assistantId: newId("assistant"),
+    browserEnabledForTurn: deps.browserToolEnabled || promptRequestsBrowser(args.userText),
+    plugins,
+    promptTemplates,
+    runtime: selected.runtimeSessionId || deps.runtimeSessionId,
+    selected,
+    sessionId,
+    skills,
+    userId: newId("user"),
+  };
+}
+
+function appendOptimisticPrompt(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  args: SubmitArgs,
+): void {
+  deps.updateSession(context.sessionId, (session) => ({
+    ...session,
+    cwd: session.cwd || deps.cwd,
+    modelId: session.modelId || deps.modelId,
+    startedAt: session.startedAt ?? new Date().toISOString(),
+    input: "",
+    error: "",
+    status: "starting",
+    usedSkills: mergeSkills(session.usedSkills, context.skills),
+    activeAssistantId: context.assistantId,
+    title:
+      session.messages.filter((message) => message.role === "user").length === 0
+        ? sessionTitleFromPrompt(args.userText)
+        : session.title,
+    messages: [
+      ...session.messages,
+      {
+        id: context.userId,
+        role: "user",
+        text: args.displayText,
+        attachments: args.attachments,
+        skills: context.skills,
+        timestamp: nowLabel(),
+      },
+      { id: context.assistantId, role: "assistant", text: "", blocks: [], timestamp: nowLabel() },
+    ],
+  }));
+}
+
+async function streamPromptTurn(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  args: SubmitArgs,
+): Promise<PromptTurnState> {
+  const state: PromptTurnState = { agentEnded: false, streamError: "" };
+  const controller = new AbortController();
+  const streamOwnerId = `${context.sessionId}:${context.assistantId}`;
+  deps.liveAssistantIdsRef.current.set(context.sessionId, context.assistantId);
+  deps.promptStreamControllersRef.current.set(context.runtime, controller);
+  claimRuntimePromptStream(context.runtime, streamOwnerId, controller);
+
+  try {
+    await api.submitTurnStream(
+      promptTurnRequest(deps, context, args),
+      (payload) => applyPromptPayload(deps, context, state, controller, payload),
+      { signal: controller.signal },
+    );
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      state.streamError = error instanceof Error ? error.message : "Agent request failed";
+    }
+  } finally {
+    await finalizePromptTurn(deps, context, state, streamOwnerId);
+  }
+
+  return state;
+}
+
+function promptTurnRequest(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  args: SubmitArgs,
+): api.SubmitTurnArgs {
+  return {
+    sessionId: context.runtime,
+    modelId: deps.modelId,
+    message: args.prompt,
+    images: args.images,
+    cwd: deps.cwd.trim() || undefined,
+    piSessionId:
+      deps.tabsRef.current.find((tab) => tab.id === context.sessionId)?.piSessionId ??
+      context.selected.piSessionId,
+    browserToolEnabled: context.browserEnabledForTurn,
+    browserSessionId: context.runtime,
+    canvasEnabled: deps.canvasEnabled,
+    plugins: context.plugins,
+    skills: context.skills,
+    promptTemplates: context.promptTemplates,
+  };
+}
+
+function applyPromptPayload(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  state: PromptTurnState,
+  controller: AbortController,
+  payload: AgentTurnSsePayload,
+): void {
+  if (controller.signal.aborted) return;
+  if (payload.type === "status") {
+    applyPromptStatusPayload(deps, context, payload);
+  } else if (payload.type === "error") {
+    applyPromptErrorPayload(deps, context, state, payload.error);
+  } else {
+    applyPromptPiPayload(deps, context, state, payload);
+  }
+}
+
+function applyPromptStatusPayload(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  payload: Extract<AgentTurnSsePayload, { type: "status" }>,
+): void {
+  const phase = payload.phase;
+  deps.updateSession(context.sessionId, (session) => ({
+    ...session,
+    piSessionId: payload.piSessionId || session.piSessionId,
+    status: (phase === "done" ? "idle" : phase) as SessionStatus,
+    activeAssistantId: phase === "done" ? undefined : session.activeAssistantId,
+  }));
+  if (payload.piSessionId) deps.onPiSessionIdChange?.(payload.piSessionId);
+}
+
+function applyPromptErrorPayload(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  state: PromptTurnState,
+  error: string,
+): void {
+  state.streamError = error;
+  deps.flushPiEventBatch(context.sessionId);
+  deps.updateSession(context.sessionId, (session) => ({
+    ...session,
+    error,
+    status: "idle",
+  }));
+}
+
+function applyPromptPiPayload(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  state: PromptTurnState,
+  payload: Extract<AgentTurnSsePayload, { type: "pi" }>,
+): void {
+  if (!deps.shouldApplyRuntimeSeq(context.sessionId, payload.seq)) return;
+  const piEvent = payload.event;
+  traceAgentReasoning("engine.pi", {
+    sessionId: context.sessionId,
+    assistantId: context.assistantId,
+    seq: payload.seq,
+    event: piEvent,
+  });
+  const eventId = piSessionIdFromEvent(piEvent);
+  if (eventId) {
+    deps.updateSession(context.sessionId, (session) => ({ ...session, piSessionId: eventId }));
+    deps.onPiSessionIdChange?.(eventId);
+  }
+  if (isAgentEndEvent(piEvent)) {
+    state.agentEnded = true;
+    deps.onPiSessionIdChange?.(latestPiSessionId(deps, context, eventId));
+  }
+  deps.enqueuePiEvent(context.sessionId, context.assistantId, piEvent, {
+    flushNow: state.agentEnded,
+  });
+}
+
+function latestPiSessionId(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  eventId: string | null,
+): string {
+  return (
+    eventId ??
+    deps.tabsRef.current.find((tab) => tab.id === context.sessionId)?.piSessionId ??
+    context.selected.piSessionId ??
+    ""
+  );
+}
+
+async function finalizePromptTurn(
+  deps: PromptStreamDeps,
+  context: PromptTurnContext,
+  state: PromptTurnState,
+  streamOwnerId: string,
+): Promise<void> {
+  deps.flushPiEventBatch(context.sessionId);
+  deps.promptStreamControllersRef.current.delete(context.runtime);
+  releaseRuntimePromptStream(context.runtime, streamOwnerId);
+  deps.liveAssistantIdsRef.current.delete(context.sessionId);
+  const currentPiSessionId =
+    deps.tabsRef.current.find((tab) => tab.id === context.sessionId)?.piSessionId ??
+    context.selected.piSessionId ??
+    null;
+  const runtimeStatus = await api.loadRuntimeStatus(context.runtime, currentPiSessionId);
+  const runtimeStillActive =
+    !state.agentEnded && runtimeIsActiveForPiSession(runtimeStatus, currentPiSessionId);
+  deps.updateSession(context.sessionId, (session) => ({
+    ...session,
+    status: runtimeStillActive ? "running" : "idle",
+    activeAssistantId: runtimeStillActive ? context.assistantId : undefined,
+    error: state.streamError && !runtimeStillActive ? state.streamError : session.error,
+    contextUsage: runtimeStatus?.contextUsage ?? session.contextUsage ?? null,
+  }));
+}
+
+function mergeSkills(
+  existing: ComposerSkillRef[] | undefined,
+  next: ComposerSkillRef[],
+): ComposerSkillRef[] | undefined {
+  if (!existing?.length && next.length === 0) return existing;
+  const byId = new Map<string, ComposerSkillRef>();
+  for (const skill of existing ?? []) byId.set(skill.id || skill.path || skill.name, skill);
+  for (const skill of next) byId.set(skill.id || skill.path || skill.name, skill);
+  return [...byId.values()];
+}


### PR DESCRIPTION
## Summary
- Move the normal prompt streaming path out of useSessionEngine into a private prompt-stream module
- Keep control/replay/compact logic in the engine while removing both session-engine lint warnings
- Preserve stream ownership, optimistic message insertion, SSE handling, runtime reconciliation, and queue draining behavior

## Verification
- npm --prefix frontend run lint -- src/lib/agent/sessions/engine.ts src/lib/agent/sessions/prompt-stream.ts
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- Reinstalled /Applications/vLLM Studio.app
- curl http://127.0.0.1:61449/api/desktop-health => ok
- Sub-agent validator review: no blocking findings

## Accounting
- ESLint warnings: 4 -> 2
- engine.ts: 634 -> 479 lines
- jscpd: 0 clones, 65,242 analyzed lines
