### PR TITLE
micro: split tool call think rewriter

### DIFF
--- a/controller/src/modules/proxy/think-rewriter.ts
+++ b/controller/src/modules/proxy/think-rewriter.ts
@@ -1,0 +1,154 @@
+const thinkingOpenPrefixes = ["<thinking", "<analysis", "<think"];
+const thinkingClosePrefixes = ["</thinking", "</analysis", "</think"];
+const thinkingAllPrefixes = [...thinkingOpenPrefixes, ...thinkingClosePrefixes];
+
+export type ThinkRewriter = {
+  inThink: () => boolean;
+  drainCarry: () => string;
+  drainPendingContent: () => string;
+  rewrite: (
+    deltaText: string,
+    defaultToReasoning?: boolean
+  ) => { content: string; reasoningAppend: string };
+};
+
+const getThinkingTagLength = (
+  suffix: string
+): { kind: "open" | "close"; length: number } | null => {
+  if (!suffix.startsWith("<")) return null;
+  const closeIndex = suffix.indexOf(">");
+  if (closeIndex < 0) return null;
+  const tag = suffix.slice(0, closeIndex + 1);
+  if (/^<(think|thinking|analysis)(?:\s+[^>]*)?>$/i.test(tag))
+    return { kind: "open", length: closeIndex + 1 };
+  if (/^<\/(think|thinking|analysis)(?:\s+[^>]*)?>$/i.test(tag))
+    return { kind: "close", length: closeIndex + 1 };
+  return null;
+};
+
+export const thinkingTagPrefixIsPartial = (suffix: string): boolean => {
+  const lower = suffix.toLowerCase();
+  if (!lower.startsWith("<")) return false;
+
+  for (const prefix of thinkingAllPrefixes) {
+    if (prefix.startsWith(lower)) {
+      return true;
+    }
+    if (lower.startsWith(prefix)) {
+      const next = lower[prefix.length];
+      if (!next) return true;
+      if (
+        next === ">" ||
+        next === " " ||
+        next === "/" ||
+        next === "\t" ||
+        next === "\n" ||
+        next === "\r"
+      )
+        return true;
+    }
+  }
+
+  return false;
+};
+
+export const createThinkRewriter = (
+  settings: {
+    bufferImplicitReasoningContent?: boolean;
+  } = {}
+): ThinkRewriter => {
+  let inThink = false;
+  let thinkCarry = "";
+  let pendingImplicitContent = "";
+  let seenOpen = false;
+  let resolvedImplicitPrefix = false;
+
+  return {
+    inThink(): boolean {
+      return inThink;
+    },
+    drainCarry(): string {
+      const tail = thinkCarry;
+      thinkCarry = "";
+      return tail;
+    },
+    drainPendingContent(): string {
+      const pending = pendingImplicitContent;
+      pendingImplicitContent = "";
+      return pending;
+    },
+    rewrite(
+      deltaText: string,
+      defaultToReasoning = false
+    ): { content: string; reasoningAppend: string } {
+      const combined = thinkCarry + (deltaText ?? "");
+      const combinedLower = combined.toLowerCase();
+      let carryIndex = combined.length;
+      let index = 0;
+      let contentOut = "";
+      let reasoningOut = "";
+
+      while (index < carryIndex) {
+        const remainingLower = combinedLower.slice(index);
+
+        if (combined[index] === "<") {
+          const thinkTag = getThinkingTagLength(remainingLower);
+          if (thinkTag?.kind === "open") {
+            if (pendingImplicitContent) {
+              contentOut += pendingImplicitContent;
+              pendingImplicitContent = "";
+            }
+            inThink = true;
+            seenOpen = true;
+            index += thinkTag.length;
+            continue;
+          }
+          if (thinkTag?.kind === "close") {
+            if (!inThink) {
+              // Close tag without an opening tag: model uses implicit
+              // thinking (e.g. DeepSeek sends `...` with no `...`).
+              if (settings.bufferImplicitReasoningContent && !seenOpen && !resolvedImplicitPrefix) {
+                reasoningOut += pendingImplicitContent;
+                pendingImplicitContent = "";
+                resolvedImplicitPrefix = true;
+              }
+              const before = contentOut.trim();
+              if (before) {
+                reasoningOut += contentOut;
+                contentOut = "";
+              }
+            }
+            inThink = false;
+            index += thinkTag.length;
+            continue;
+          }
+          if (thinkingTagPrefixIsPartial(remainingLower)) {
+            carryIndex = index;
+            break;
+          }
+        }
+
+        const ch = combined[index] ?? "";
+        if (inThink || defaultToReasoning) {
+          reasoningOut += ch;
+        } else if (
+          settings.bufferImplicitReasoningContent &&
+          !seenOpen &&
+          !resolvedImplicitPrefix
+        ) {
+          pendingImplicitContent += ch;
+        } else {
+          contentOut += ch;
+        }
+        index += 1;
+      }
+
+      thinkCarry = carryIndex < combined.length ? combined.slice(carryIndex) : "";
+
+      return {
+        content: contentOut,
+        reasoningAppend: reasoningOut,
+      };
+    },
+  };
+};

--- a/controller/src/modules/proxy/tool-call-stream.ts
+++ b/controller/src/modules/proxy/tool-call-stream.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { parseToolCallsFromContent, type ToolCall } from "./tool-call-parser";
 import { REASONING_FIELDS, firstReasoningField } from "./reasoning-fields";
+import { createThinkRewriter, thinkingTagPrefixIsPartial } from "./think-rewriter";
 
 export interface StreamUsage {
   prompt_tokens: number;
@@ -40,50 +41,6 @@ export const createToolCallStream = (
       // upstream already torn down; ignore.
     }
   };
-  const thinkingOpenPrefixes = ["<thinking", "<analysis", "<think"];
-  const thinkingClosePrefixes = ["</thinking", "</analysis", "</think"];
-  const thinkingAllPrefixes = [...thinkingOpenPrefixes, ...thinkingClosePrefixes];
-
-  const getThinkingTagLength = (
-    suffix: string
-  ): { kind: "open" | "close"; length: number } | null => {
-    if (!suffix.startsWith("<")) return null;
-    const closeIndex = suffix.indexOf(">");
-    if (closeIndex < 0) return null;
-    const tag = suffix.slice(0, closeIndex + 1);
-    if (/^<(think|thinking|analysis)(?:\s+[^>]*)?>$/i.test(tag))
-      return { kind: "open", length: closeIndex + 1 };
-    if (/^<\/(think|thinking|analysis)(?:\s+[^>]*)?>$/i.test(tag))
-      return { kind: "close", length: closeIndex + 1 };
-    return null;
-  };
-
-  const thinkingTagPrefixIsPartial = (suffix: string): boolean => {
-    const lower = suffix.toLowerCase();
-    if (!lower.startsWith("<")) return false;
-
-    for (const prefix of thinkingAllPrefixes) {
-      if (prefix.startsWith(lower)) {
-        return true;
-      }
-      if (lower.startsWith(prefix)) {
-        const next = lower[prefix.length];
-        if (!next) return true;
-        if (
-          next === ">" ||
-          next === " " ||
-          next === "/" ||
-          next === "\t" ||
-          next === "\n" ||
-          next === "\r"
-        )
-          return true;
-      }
-    }
-
-    return false;
-  };
-
   const stripToolXmlDelta = (text: string): string => {
     return text
       .replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, "")
@@ -127,121 +84,6 @@ export const createToolCallStream = (
 
     history.set(key, { text: previous.text + text, snapshot: false });
     return text;
-  };
-
-  type ThinkRewriter = {
-    inThink: () => boolean;
-    drainCarry: () => string;
-    drainPendingContent: () => string;
-    rewrite: (
-      deltaText: string,
-      defaultToReasoning?: boolean
-    ) => { content: string; reasoningAppend: string };
-  };
-
-  const createThinkRewriter = (
-    settings: {
-      bufferImplicitReasoningContent?: boolean;
-    } = {}
-  ): ThinkRewriter => {
-    let inThink = false;
-    let thinkCarry = "";
-    let pendingImplicitContent = "";
-    let seenOpen = false;
-    let resolvedImplicitPrefix = false;
-
-    return {
-      inThink(): boolean {
-        return inThink;
-      },
-      drainCarry(): string {
-        const tail = thinkCarry;
-        thinkCarry = "";
-        return tail;
-      },
-      drainPendingContent(): string {
-        const pending = pendingImplicitContent;
-        pendingImplicitContent = "";
-        return pending;
-      },
-      rewrite(
-        deltaText: string,
-        defaultToReasoning = false
-      ): { content: string; reasoningAppend: string } {
-        const combined = thinkCarry + (deltaText ?? "");
-        const combinedLower = combined.toLowerCase();
-        let carryIndex = combined.length;
-        let index = 0;
-        let contentOut = "";
-        let reasoningOut = "";
-
-        while (index < carryIndex) {
-          const remainingLower = combinedLower.slice(index);
-
-          if (combined[index] === "<") {
-            const thinkTag = getThinkingTagLength(remainingLower);
-            if (thinkTag?.kind === "open") {
-              if (pendingImplicitContent) {
-                contentOut += pendingImplicitContent;
-                pendingImplicitContent = "";
-              }
-              inThink = true;
-              seenOpen = true;
-              index += thinkTag.length;
-              continue;
-            }
-            if (thinkTag?.kind === "close") {
-              if (!inThink) {
-                // Close tag without an opening tag: model uses implicit
-                // thinking (e.g. DeepSeek sends `...` with no `...`).
-                if (
-                  settings.bufferImplicitReasoningContent &&
-                  !seenOpen &&
-                  !resolvedImplicitPrefix
-                ) {
-                  reasoningOut += pendingImplicitContent;
-                  pendingImplicitContent = "";
-                  resolvedImplicitPrefix = true;
-                }
-                const before = contentOut.trim();
-                if (before) {
-                  reasoningOut += contentOut;
-                  contentOut = "";
-                }
-              }
-              inThink = false;
-              index += thinkTag.length;
-              continue;
-            }
-            if (thinkingTagPrefixIsPartial(remainingLower)) {
-              carryIndex = index;
-              break;
-            }
-          }
-
-          const ch = combined[index] ?? "";
-          if (inThink || defaultToReasoning) {
-            reasoningOut += ch;
-          } else if (
-            settings.bufferImplicitReasoningContent &&
-            !seenOpen &&
-            !resolvedImplicitPrefix
-          ) {
-            pendingImplicitContent += ch;
-          } else {
-            contentOut += ch;
-          }
-          index += 1;
-        }
-
-        thinkCarry = carryIndex < combined.length ? combined.slice(carryIndex) : "";
-
-        return {
-          content: contentOut,
-          reasoningAppend: reasoningOut,
-        };
-      },
-    };
   };
 
   const contentThink = createThinkRewriter({

--- a/tests/controller/integration/tool-call-stream.test.ts
+++ b/tests/controller/integration/tool-call-stream.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { createToolCallStream } from "../../../controller/src/modules/proxy/tool-call-stream";
+import {
+  createThinkRewriter,
+  thinkingTagPrefixIsPartial,
+} from "../../../controller/src/modules/proxy/think-rewriter";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -76,7 +80,9 @@ describe("createToolCallStream SSE framing", () => {
       // Must NOT be a merged event (would contain an embedded newline).
       expect(value).not.toContain("\n");
       const parsed = JSON.parse(value) as {
-        choices?: Array<{ delta?: { tool_calls?: Array<{ function?: { name?: string } }> } }>;
+        choices?: Array<{
+          delta?: { tool_calls?: Array<{ function?: { name?: string } }> };
+        }>;
       };
       const toolCalls = parsed.choices?.[0]?.delta?.tool_calls;
       if (Array.isArray(toolCalls) && toolCalls.length > 0) {
@@ -107,5 +113,35 @@ describe("createToolCallStream SSE framing", () => {
       expect(() => JSON.parse(value)).not.toThrow();
     }
     expect(events).toContain("[DONE]");
+  });
+});
+
+describe("think rewriter", () => {
+  test("carries partial analysis tags across chunk boundaries", () => {
+    const rewriter = createThinkRewriter();
+
+    expect(thinkingTagPrefixIsPartial("<anal")).toBe(true);
+    expect(rewriter.rewrite("<anal")).toEqual({
+      content: "",
+      reasoningAppend: "",
+    });
+    expect(rewriter.rewrite("ysis>plan</analysis>answer")).toEqual({
+      content: "answer",
+      reasoningAppend: "plan",
+    });
+    expect(rewriter.drainCarry()).toBe("");
+  });
+
+  test("recognizes thinking aliases with attributes", () => {
+    const rewriter = createThinkRewriter();
+
+    expect(thinkingTagPrefixIsPartial("<thinking ")).toBe(true);
+    expect(thinkingTagPrefixIsPartial("</thinking")).toBe(true);
+    expect(
+      rewriter.rewrite('<thinking mode="deep">reason</thinking>answer'),
+    ).toEqual({
+      content: "answer",
+      reasoningAppend: "reason",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extract the thinking-tag rewriter from the tool call stream module
- keep stream behavior in place while shrinking the oversized proxy file
- add direct coverage for partial `<analysis>` tags and `<thinking>` aliases with attributes

## Verification
- `npm --prefix controller run typecheck`
- `npm --prefix controller run test:integration -- ../tests/controller/integration/tool-call-stream.test.ts` (40 pass)
- `npm --prefix controller run lint`
- `npm --prefix controller run check`
- pre-push `npm --prefix frontend run check:quality`

## Accounting
- `controller/src/modules/proxy/tool-call-stream.ts`: 563 -> 405 lines
- controller duplicate scan: 0 clones
- sub-agent review: no blocking issues; requested alias/partial-tag coverage was added

No frontend files changed in this slice, so the desktop rebuild/reinstall rule does not apply.