### PR TITLE
micro: flatten settings resource rows

### DIFF
--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -66,7 +66,8 @@ export type { TableProps, THeadProps, TBodyProps, TRowProps, THProps, TCellProps
 export { AppPage, PageHeader, SectionNav, RefreshIconButton } from "./page";
 export type { SectionNavItem } from "./page";
 
-export { ListGroup, ListRow, RowValue, EmptySafeNotice, KeyValueRow } from "./list";
+export { ListGroup, ListRow, RowFacts, RowValue, EmptySafeNotice, KeyValueRow } from "./list";
+export type { RowFact } from "./list";
 
 export { Toggle } from "./toggle";
 export { Slider } from "./slider";

--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -113,11 +113,7 @@ export function ListRow({
             </div>
           ) : null}
         </div>
-        {primaryValue ? (
-          <div className="mt-2 min-w-0 rounded-md border border-(--ui-separator)/70 bg-(--ui-bg)/45 px-2.5 py-2 text-(--ui-muted)">
-            {primaryValue}
-          </div>
-        ) : null}
+        {primaryValue ? <div className="mt-2 min-w-0 text-(--ui-muted)">{primaryValue}</div> : null}
         {children ? (
           <div className="mt-2 min-w-0 space-y-1.5 border-t border-(--ui-separator)/70 pt-2 text-[length:var(--fs-sm)] leading-relaxed">
             {children}
@@ -187,6 +183,43 @@ export function RowValue({
     >
       {children || "Not set"}
     </div>
+  );
+}
+
+export type RowFact = {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+  title?: string;
+  truncate?: boolean;
+};
+
+export function RowFacts({ items, className }: { items: RowFact[]; className?: string }) {
+  return (
+    <dl
+      className={cx(
+        "grid min-w-0 grid-cols-1 gap-x-3 gap-y-1.5 sm:grid-cols-[6rem_minmax(0,1fr)]",
+        className,
+      )}
+    >
+      {items.map((item) => (
+        <div key={item.label} className="contents">
+          <dt className="text-[length:var(--fs-xs)] font-medium uppercase text-(--ui-muted)/70">
+            {item.label}
+          </dt>
+          <dd
+            className={cx(
+              "min-w-0 text-[length:var(--fs-sm)] text-(--ui-fg)/80",
+              item.mono ? "font-mono" : "",
+              item.truncate ? "truncate" : "break-words",
+            )}
+            title={item.title ?? (typeof item.value === "string" ? item.value : undefined)}
+          >
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 

--- a/frontend/src/ui/runtime-targets.tsx
+++ b/frontend/src/ui/runtime-targets.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowUpCircle, DownloadCloud, Loader2 } from "lucide-react";
 import type { EngineBackend, EngineJob, RuntimeTarget } from "@/lib/types";
+import { RowFacts, type RowFact } from "./list";
 import { SettingsButton, SettingsRow, SettingsValue } from "./settings";
 import { StatusPill, type UiTone } from "./status";
 
@@ -256,35 +257,21 @@ function RuntimeTargetMeta({ target }: { target: RuntimeTarget }) {
 
 function RuntimeTargetSummary({ target }: { target: RuntimeTarget }) {
   const location = pathForTarget(target);
-  return (
-    <div className="grid min-w-0 grid-cols-1 gap-x-3 gap-y-1 text-left sm:grid-cols-[5rem_minmax(0,1fr)]">
-      <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">Version</span>
-      <span className="min-w-0 font-mono text-[length:var(--fs-md)] text-(--ui-fg)/85">
-        {target.installed ? (target.version ?? "installed") : "not installed"}
-      </span>
-      {location ? (
-        <>
-          <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">
-            Location
-          </span>
-          <span
-            className="min-w-0 truncate font-mono text-[length:var(--fs-sm)] text-(--ui-muted)"
-            title={location}
-          >
-            {location}
-          </span>
-        </>
-      ) : null}
-      {target.update && target.capabilities.canUpdate ? (
-        <>
-          <span className="text-[length:var(--fs-xs)] uppercase text-(--ui-muted)/70">Target</span>
-          <span className="min-w-0 font-mono text-[length:var(--fs-sm)] text-(--ui-muted)">
-            {target.update.targetVersion}
-          </span>
-        </>
-      ) : null}
-    </div>
-  );
+  const facts: RowFact[] = [
+    {
+      label: "Version",
+      value: target.installed ? (target.version ?? "installed") : "not installed",
+      mono: true,
+    },
+  ];
+  if (location) {
+    facts.push({ label: "Location", value: location, mono: true, title: location, truncate: true });
+  }
+  if (target.update && target.capabilities.canUpdate) {
+    facts.push({ label: "Latest", value: target.update.targetVersion, mono: true });
+  }
+
+  return <RowFacts items={facts} />;
 }
 
 export function RuntimeTargetStatus({
@@ -334,27 +321,29 @@ export function RuntimeJobMessage({ job }: { job: EngineJob }) {
 export function RuntimeUpdateDetails({ update }: { update: NonNullable<RuntimeTarget["update"]> }) {
   const pinHint = update.changes.find((change) => change.startsWith("Set "));
   return (
-    <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[length:var(--fs-sm)] text-(--ui-muted)">
-      <span>
-        Update available:{" "}
-        <span className="font-mono text-(--ui-fg)/70">
-          {update.currentVersion ?? "unknown"} -&gt; {update.targetVersion}
+    <div className="space-y-1 text-[length:var(--fs-sm)] text-(--ui-muted)">
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+        <span>
+          Update available:{" "}
+          <span className="font-mono text-(--ui-fg)/70">
+            {update.currentVersion ?? "unknown"} -&gt; {update.targetVersion}
+          </span>
         </span>
-      </span>
-      {update.restartRequired ? (
-        <StatusPill tone="warning" variant="badge">
-          restarts model
-        </StatusPill>
-      ) : null}
-      <a
-        href={update.releaseNotesUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-(--ui-accent)/80 hover:underline"
-      >
-        release notes
-      </a>
-      {pinHint ? <span className="basis-full text-(--ui-muted)/70">{pinHint}</span> : null}
+        {update.restartRequired ? (
+          <StatusPill tone="warning" variant="badge">
+            restarts model
+          </StatusPill>
+        ) : null}
+        <a
+          href={update.releaseNotesUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-(--ui-accent)/80 hover:underline"
+        >
+          release notes
+        </a>
+      </div>
+      {pinHint ? <p className="text-(--ui-muted)/70">{pinHint}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable `RowFacts` UI-kit primitive for compact row metadata
- flatten shared resource rows by removing the nested mini-panel wrapper
- use `RowFacts` for runtime target version/location/latest details and tidy update detail text

## Verification
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run check:ui-structure`
- `npm --prefix frontend run check:quality`
- `npm --prefix frontend run desktop:pack`
- clean reinstall to `/Applications/vLLM Studio.app`
- installed app single path: `/Applications/vLLM Studio.app`
- installed bundle id: `org.vllm.studio.desktop`
- installed health: `http://127.0.0.1:61449/api/desktop-health` -> `{"ok":true}`
- Playwright screenshot: `frontend/test-results/settings-system-rowfacts-installed.png`; overflow scan found 0 offenders
- pre-push `npm --prefix frontend run check:quality`

## Accounting
- `frontend/src/ui/runtime-targets.tsx`: 364 -> 353 lines
- `frontend/src/ui/list.tsx`: 216 -> 249 lines, adds shared RowFacts primitive
- frontend duplicate scan: 0 clones
- sub-agent review: no blockers; non-blocking RowFacts/wrapper notes addressed before commit