### PR TITLE
fix: use canonical desktop user data

### DIFF
--- a/frontend/desktop/app-identity.ts
+++ b/frontend/desktop/app-identity.ts
@@ -1,14 +1,44 @@
 import { app } from "electron";
 import path from "node:path";
+import { migrateLegacyUserData } from "./logic/user-data-migration";
 
+const CANONICAL_APP_NAME = "vLLM Studio";
+const LEGACY_USER_DATA_NAME = "frontend";
 const devAppName = process.env.VLLM_STUDIO_DESKTOP_APP_NAME?.trim();
 const devUserDataDir = process.env.VLLM_STUDIO_DESKTOP_USER_DATA_DIR?.trim();
+const releaseChannel = process.env.VLLM_STUDIO_DESKTOP_CHANNEL?.trim().toLowerCase();
+const nonStablePackagedChannel =
+  app.isPackaged && (releaseChannel === "beta" || releaseChannel === "alpha");
 
-if (devAppName) {
-  app.setName(devAppName);
-  process.title = devAppName;
+if (nonStablePackagedChannel) {
+  throw new Error(
+    `Packaged ${releaseChannel} desktop builds are disabled in the stable builder config. Use a separate Electron Builder config with its own app id, product name, and user-data path.`,
+  );
 }
 
-if (devUserDataDir) {
-  app.setPath("userData", path.resolve(devUserDataDir));
+const appName = devAppName || (app.isPackaged ? CANONICAL_APP_NAME : app.getName());
+if (devAppName || app.isPackaged) {
+  app.setName(appName);
+  process.title = appName;
+}
+
+const appDataDir = app.getPath("appData");
+const userDataDir = devUserDataDir
+  ? path.resolve(devUserDataDir)
+  : app.isPackaged
+    ? path.join(appDataDir, appName)
+    : app.getPath("userData");
+
+app.setPath("userData", userDataDir);
+
+if (app.isPackaged && appName === CANONICAL_APP_NAME && !devAppName && !devUserDataDir) {
+  const migrated = migrateLegacyUserData({
+    legacyDir: path.join(appDataDir, LEGACY_USER_DATA_NAME),
+    targetDir: userDataDir,
+  });
+  if (migrated.length > 0) {
+    console.info(
+      `[desktop] Migrated ${migrated.length} legacy user-data paths from ${LEGACY_USER_DATA_NAME}`,
+    );
+  }
 }

--- a/frontend/desktop/logic/user-data-migration.ts
+++ b/frontend/desktop/logic/user-data-migration.ts
@@ -1,0 +1,128 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const MIGRATION_MARKER = "legacy-user-data-migration-v1.json";
+const MIGRATED_USER_DATA_PATHS = [
+  "Local Storage",
+  "Cookies",
+  "Cookies-journal",
+  "DIPS",
+  "DIPS-shm",
+  "DIPS-wal",
+  "IndexedDB",
+  "Network Persistent State",
+  "Preferences",
+  "Session Storage",
+  "SharedStorage",
+  "SharedStorage-shm",
+  "SharedStorage-wal",
+  "TransportSecurity",
+  "Trust Tokens",
+  "Trust Tokens-journal",
+  "WebStorage",
+  "agent-canvas",
+  "agent-canvas.json",
+  "agent-session-metadata.json",
+  "api-settings.json",
+  "chats.db",
+  "computer-use",
+  "controllers.json",
+  "embedded-frontend.port",
+  "list-1-to-5000.txt",
+  "logs",
+  "mcp",
+  "pi-agent",
+  "projects.json",
+  "session-prefs.json",
+  "ui-preferences.json",
+  "vekor",
+] as const;
+
+export function migrateLegacyUserData({
+  legacyDir,
+  targetDir,
+}: {
+  legacyDir: string;
+  targetDir: string;
+}): string[] {
+  const sourceRoot = path.resolve(legacyDir);
+  const targetRoot = path.resolve(targetDir);
+  if (sourceRoot === targetRoot || !existsSync(sourceRoot)) return [];
+  const markerPath = path.join(targetRoot, MIGRATION_MARKER);
+  if (existsSync(markerPath)) return [];
+
+  try {
+    mkdirSync(targetRoot, { recursive: true });
+  } catch (error) {
+    console.warn(`[desktop] Failed to prepare user-data migration target: ${String(error)}`);
+    return [];
+  }
+
+  const migrated: string[] = [];
+  const skipped: string[] = [];
+  const failed: string[] = [];
+  for (const relativePath of MIGRATED_USER_DATA_PATHS) {
+    const sourcePath = path.join(sourceRoot, relativePath);
+    if (!existsSync(sourcePath)) continue;
+    try {
+      const targetPath = path.join(targetRoot, relativePath);
+      const copied = copyMissingPath(sourcePath, targetPath);
+      (copied ? migrated : skipped).push(relativePath);
+    } catch (error) {
+      failed.push(relativePath);
+      console.warn(`[desktop] Failed to migrate ${relativePath}: ${String(error)}`);
+    }
+  }
+  if (failed.length === 0) {
+    writeMigrationMarker(markerPath, { legacyDir: sourceRoot, migrated, skipped });
+  } else {
+    console.warn(
+      `[desktop] Legacy user-data migration left ${failed.length} paths pending; will retry next launch`,
+    );
+  }
+  return migrated;
+}
+
+function copyMissingPath(sourcePath: string, targetPath: string): boolean {
+  if (existsSync(targetPath)) {
+    const sourceStat = statSync(sourcePath);
+    const targetStat = statSync(targetPath);
+    if (!sourceStat.isDirectory() || !targetStat.isDirectory()) return false;
+
+    let copied = false;
+    for (const entry of readdirSync(sourcePath)) {
+      copied =
+        copyMissingPath(path.join(sourcePath, entry), path.join(targetPath, entry)) || copied;
+    }
+    return copied;
+  }
+
+  const stat = statSync(sourcePath);
+  if (!stat.isDirectory()) {
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    cpSync(sourcePath, targetPath, { force: false });
+    return true;
+  }
+
+  mkdirSync(targetPath, { recursive: true });
+  let copied = true;
+  for (const entry of readdirSync(sourcePath)) {
+    copied = copyMissingPath(path.join(sourcePath, entry), path.join(targetPath, entry)) || copied;
+  }
+  return copied;
+}
+
+function writeMigrationMarker(
+  markerPath: string,
+  details: { legacyDir: string; migrated: string[]; skipped: string[] },
+): void {
+  try {
+    writeFileSync(
+      markerPath,
+      `${JSON.stringify({ ...details, migratedAt: new Date().toISOString() }, null, 2)}\n`,
+      "utf8",
+    );
+  } catch (error) {
+    console.warn(`[desktop] Failed to write user-data migration marker: ${String(error)}`);
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build --webpack",
     "start": "node scripts/start-standalone.mjs",
     "start:next": "next start",
-    "test": "tsx --test scripts/test-build-agent-session-options.ts",
+    "test": "tsx --test scripts/test-build-agent-session-options.ts scripts/test-desktop-user-data-migration.ts",
     "test:e2e": "tsx --test ../tests/frontend/e2e/*.test.ts",
     "test:e2e:ui": "playwright test",
     "lint": "eslint",

--- a/frontend/scripts/test-desktop-user-data-migration.ts
+++ b/frontend/scripts/test-desktop-user-data-migration.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { migrateLegacyUserData } from "../desktop/logic/user-data-migration";
+
+test("desktop legacy user-data migration copies missing state without overwriting canonical state", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "vllm-userdata-migrate-"));
+  const legacyDir = path.join(root, "frontend");
+  const targetDir = path.join(root, "vLLM Studio");
+
+  mkdirSync(path.join(legacyDir, "Local Storage"), { recursive: true });
+  mkdirSync(path.join(legacyDir, "mcp"), { recursive: true });
+  mkdirSync(targetDir, { recursive: true });
+
+  writeFileSync(path.join(legacyDir, "projects.json"), '{"projects":[{"id":"old"}]}\n');
+  writeFileSync(path.join(targetDir, "projects.json"), '{"projects":[{"id":"new"}]}\n');
+  writeFileSync(path.join(legacyDir, "embedded-frontend.port"), "61449");
+  writeFileSync(path.join(legacyDir, "Local Storage", "leveldb"), "renderer-state");
+  writeFileSync(path.join(legacyDir, "mcp", "registries.json"), '{"sources":[]}\n');
+
+  const first = migrateLegacyUserData({ legacyDir, targetDir });
+  assert.deepEqual(first, ["Local Storage", "embedded-frontend.port", "mcp"]);
+  assert.equal(
+    readFileSync(path.join(targetDir, "projects.json"), "utf8"),
+    '{"projects":[{"id":"new"}]}\n',
+  );
+  assert.equal(readFileSync(path.join(targetDir, "embedded-frontend.port"), "utf8"), "61449");
+  assert.equal(
+    readFileSync(path.join(targetDir, "Local Storage", "leveldb"), "utf8"),
+    "renderer-state",
+  );
+  assert.equal(
+    readFileSync(path.join(targetDir, "mcp", "registries.json"), "utf8"),
+    '{"sources":[]}\n',
+  );
+
+  assert.deepEqual(migrateLegacyUserData({ legacyDir, targetDir }), []);
+  assert.equal(existsSync(path.join(targetDir, "legacy-user-data-migration-v1.json")), true);
+});


### PR DESCRIPTION
## Summary
- set packaged stable Electron launches to the canonical `vLLM Studio` user-data path instead of the accidental `frontend` profile
- migrate selected legacy `frontend` state into the canonical profile without overwriting existing canonical files
- preserve embedded frontend port and renderer storage so the app keeps its origin/state
- block packaged beta/alpha launches under the stable builder config instead of silently sharing stable app metadata/profile
- add a committed migration test for no-overwrite + sentinel behavior

## Verification
- `npm --prefix frontend run test`
- `npm --prefix frontend run typecheck:desktop`
- `npm --prefix frontend run check:quality`
- `npm --prefix frontend run desktop:pack`
- clean reinstall to `/Applications/vLLM Studio.app`
- installed app single path: `/Applications/vLLM Studio.app`
- installed bundle id: `org.vllm.studio.desktop`
- running process user-data dir: `/Users/sero/Library/Application Support/vLLM Studio`
- canonical port file: `/Users/sero/Library/Application Support/vLLM Studio/embedded-frontend.port`
- installed health: `{"ok":true}`
- pre-push `npm --prefix frontend run check:quality`

## Review
- McClintock found blockers in the initial migration: repeat overwrites, missing port/storage migration, beta/alpha profile ambiguity, and sentinel-on-failure behavior.
- All blockers were patched. Final re-review found no blocking issues.

## Residual gaps
- Migration test covers no-overwrite + sentinel happy path. Retry-after-copy-failure and packaged non-stable fail-fast branch are not directly covered yet.