### PR TITLE
micro: standardize settings row details

### DIFF
--- a/frontend/src/ui/configs/engines-section.tsx
+++ b/frontend/src/ui/configs/engines-section.tsx
@@ -9,6 +9,7 @@ import {
   ENGINE_META,
   MANAGED_RUNTIME_BACKENDS,
   ManagedRuntimeInstallRows,
+  RowDetailLine,
   RuntimeTargetRows,
   RuntimeTargetStatus,
   SettingsButton,
@@ -253,12 +254,14 @@ function BackendRow({
       }
     >
       {info.python_path || info.binary_path ? (
-        <SettingsValue mono dim truncate>
+        <RowDetailLine mono truncate size="md">
           {info.python_path ?? info.binary_path}
-        </SettingsValue>
+        </RowDetailLine>
       ) : null}
       {state.status === "error" && state.message ? (
-        <p className="truncate text-[length:var(--fs-sm)] text-(--err)">{state.message}</p>
+        <RowDetailLine tone="danger" truncate>
+          {state.message}
+        </RowDetailLine>
       ) : null}
     </SettingsRow>
   );

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -66,7 +66,15 @@ export type { TableProps, THeadProps, TBodyProps, TRowProps, THProps, TCellProps
 export { AppPage, PageHeader, SectionNav, RefreshIconButton } from "./page";
 export type { SectionNavItem } from "./page";
 
-export { ListGroup, ListRow, RowFacts, RowValue, EmptySafeNotice, KeyValueRow } from "./list";
+export {
+  ListGroup,
+  ListRow,
+  RowDetailLine,
+  RowFacts,
+  RowValue,
+  EmptySafeNotice,
+  KeyValueRow,
+} from "./list";
 export type { RowFact } from "./list";
 
 export { Toggle } from "./toggle";
@@ -83,11 +91,8 @@ export {
   MANAGED_RUNTIME_BACKENDS,
   SETUP_RUNTIME_BACKENDS,
   ManagedRuntimeInstallRows,
-  RuntimeJobMessage,
-  RuntimeTargetRow,
   RuntimeTargetRows,
   RuntimeTargetStatus,
-  RuntimeUpdateDetails,
   isManagedRuntimeTarget,
   isRunningEngineJob,
   jobForRuntimeTarget,

--- a/frontend/src/ui/left-sidebar.tsx
+++ b/frontend/src/ui/left-sidebar.tsx
@@ -204,7 +204,7 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
             aria-label="Resize sidebar"
             title="Resize sidebar"
             onMouseDown={startSidebarResize}
-            className={`absolute right-0 top-0 z-[60] h-full w-2 translate-x-1 cursor-col-resize transition-colors ${
+            className={`absolute right-0 top-0 z-[60] h-full w-2 cursor-col-resize transition-colors ${
               sidebarResizing ? "bg-(--accent)/25" : "hover:bg-(--accent)/20"
             }`}
           />

--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -223,6 +223,57 @@ export function RowFacts({ items, className }: { items: RowFact[]; className?: s
   );
 }
 
+type RowDetailTone = "muted" | "warning" | "danger";
+type RowDetailSize = "inherit" | "sm" | "md";
+
+const rowDetailToneClass: Record<RowDetailTone, string> = {
+  muted: "text-(--ui-muted)",
+  warning: "text-(--ui-warning)",
+  danger: "text-(--ui-danger)/80",
+};
+
+const rowDetailSizeClass: Record<RowDetailSize, string> = {
+  inherit: "",
+  sm: "text-[length:var(--fs-sm)]",
+  md: "text-[length:var(--fs-md)]",
+};
+
+export function RowDetailLine({
+  children,
+  tone = "muted",
+  size = "inherit",
+  mono = false,
+  truncate = false,
+  clamp = false,
+  title,
+  className,
+}: {
+  children: ReactNode;
+  tone?: RowDetailTone;
+  size?: RowDetailSize;
+  mono?: boolean;
+  truncate?: boolean;
+  clamp?: boolean;
+  title?: string;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cx(
+        rowDetailToneClass[tone],
+        rowDetailSizeClass[size],
+        mono ? "font-mono" : "",
+        truncate ? "truncate" : "",
+        clamp ? "line-clamp-3 whitespace-pre-wrap" : "",
+        className,
+      )}
+      title={title ?? (typeof children === "string" ? children : undefined)}
+    >
+      {children}
+    </p>
+  );
+}
+
 export function EmptySafeNotice({ children }: { children: ReactNode }) {
   return (
     <div className="px-3.5 py-2.5 text-[length:var(--fs-md)] leading-relaxed text-(--ui-muted)">

--- a/frontend/src/ui/page.tsx
+++ b/frontend/src/ui/page.tsx
@@ -69,7 +69,7 @@ export function SectionNav<Id extends string = string>({
   onSelectItem: (item: Id) => void;
 }) {
   return (
-    <nav aria-label={label} className="-mx-1 pb-1 lg:mx-0">
+    <nav aria-label={label} className="pb-1">
       <div className="flex flex-wrap gap-1 lg:flex-col lg:flex-nowrap">
         {items.map((item) => {
           const active = activeItem === item.id;

--- a/frontend/src/ui/runtime-targets.tsx
+++ b/frontend/src/ui/runtime-targets.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowUpCircle, DownloadCloud, Loader2 } from "lucide-react";
 import type { EngineBackend, EngineJob, RuntimeTarget } from "@/lib/types";
-import { RowFacts, type RowFact } from "./list";
+import { RowDetailLine, RowFacts, type RowFact } from "./list";
 import { SettingsButton, SettingsRow, SettingsValue } from "./settings";
 import { StatusPill, type UiTone } from "./status";
 
@@ -151,7 +151,7 @@ export function RuntimeTargetRows({
   ));
 }
 
-export function RuntimeTargetRow({
+function RuntimeTargetRow({
   target,
   job,
   onAction,
@@ -190,12 +190,8 @@ export function RuntimeTargetRow({
       {target.capabilities.canUpdate && target.update ? (
         <RuntimeUpdateDetails update={target.update} />
       ) : null}
-      {!target.capabilities.canUpdate ? (
-        <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">{unsupportedReason}</p>
-      ) : null}
-      {healthMessage ? (
-        <p className="text-[length:var(--fs-sm)] text-(--ui-warning)">{healthMessage}</p>
-      ) : null}
+      {!target.capabilities.canUpdate ? <RowDetailLine>{unsupportedReason}</RowDetailLine> : null}
+      {healthMessage ? <RowDetailLine tone="warning">{healthMessage}</RowDetailLine> : null}
     </SettingsRow>
   );
 }
@@ -304,25 +300,32 @@ export function RuntimeTargetStatus({
   );
 }
 
-export function RuntimeJobMessage({ job }: { job: EngineJob }) {
+function RuntimeJobMessage({ job }: { job: EngineJob }) {
+  const tone = job.status === "error" ? "danger" : "muted";
   return (
-    <div
-      className={`space-y-1 text-[length:var(--fs-md)] ${job.status === "error" ? "text-(--ui-danger)/80" : "text-(--ui-muted)"}`}
-    >
-      <p>{job.message}</p>
-      {job.command ? <p className="truncate font-mono">{job.command}</p> : null}
-      {job.error || job.outputTail ? (
-        <p className="line-clamp-3 whitespace-pre-wrap font-mono">{job.error ?? job.outputTail}</p>
+    <>
+      <RowDetailLine tone={tone} size="md">
+        {job.message}
+      </RowDetailLine>
+      {job.command ? (
+        <RowDetailLine mono truncate tone={tone} size="md">
+          {job.command}
+        </RowDetailLine>
       ) : null}
-    </div>
+      {job.error || job.outputTail ? (
+        <RowDetailLine mono clamp tone={tone} size="md">
+          {job.error ?? job.outputTail}
+        </RowDetailLine>
+      ) : null}
+    </>
   );
 }
 
-export function RuntimeUpdateDetails({ update }: { update: NonNullable<RuntimeTarget["update"]> }) {
+function RuntimeUpdateDetails({ update }: { update: NonNullable<RuntimeTarget["update"]> }) {
   const pinHint = update.changes.find((change) => change.startsWith("Set "));
   return (
-    <div className="space-y-1 text-[length:var(--fs-sm)] text-(--ui-muted)">
-      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+    <>
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-(--ui-muted)">
         <span>
           Update available:{" "}
           <span className="font-mono text-(--ui-fg)/70">
@@ -343,8 +346,8 @@ export function RuntimeUpdateDetails({ update }: { update: NonNullable<RuntimeTa
           release notes
         </a>
       </div>
-      {pinHint ? <p className="text-(--ui-muted)/70">{pinHint}</p> : null}
-    </div>
+      {pinHint ? <RowDetailLine className="text-(--ui-muted)/70">{pinHint}</RowDetailLine> : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a shared RowDetailLine primitive for settings/list row detail text
- use it in runtime target rows and legacy backend rows while preserving error tone, text size, and truncated path titles
- trim unused runtime row/detail exports from the UI barrel
- remove two small horizontal-overflow sources in the settings section nav and desktop sidebar resize handle

## Accounting
- touched files: 6
- diff: +92 / -30
- line deltas: list +51, runtime-targets +5, engines-section +1, index +5, page 0, left-sidebar 0

## Verification
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:ui-structure
- npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- clean reinstalled /Applications/vLLM Studio.app
- verified only /Applications/vLLM Studio.app is installed
- verified bundle id org.vllm.studio.desktop
- verified /settings, /api/settings, and /api/desktop-health return 200 from installed embedded server
- Playwright /settings#system screenshots and overflow scans at 1440x1400 and 390x844 both reported overflowCount 0
- validator re-review reported no blocking findings

Screenshots:
- /Users/sero/projects/vllm-studio/frontend/test-results/settings-system-detail-primitives-installed.png
- /Users/sero/projects/vllm-studio/frontend/test-results/settings-system-detail-primitives-mobile-installed.png