### PR TITLE
micro: add settings fact rows primitive

### DIFF
--- a/frontend/src/ui/configs/agent-settings-sections.tsx
+++ b/frontend/src/ui/configs/agent-settings-sections.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useState, useSyncExternalStore } from "react";
-import { SettingsButton, SettingsGroup, SettingsRow, SettingsValue, StatusPill } from "@/ui";
+import {
+  SettingsButton,
+  SettingsFactRows,
+  SettingsGroup,
+  StatusPill,
+  type SettingsFactRow,
+} from "@/ui";
 import { cleanSessionTitle } from "@/lib/agent/session/helpers";
 import { SESSIONS_CHANGED_EVENT } from "@/lib/agent/workspace/events";
 import { useSidebarStatus } from "@/hooks/use-sidebar-status";
@@ -68,58 +74,57 @@ export function ArchivedChatsSettings() {
       setRestoringId(null);
     }
   };
+  const archiveRows: SettingsFactRow[] = error
+    ? [
+        {
+          key: "archive-error",
+          label: "Archive",
+          description: error,
+          value: "Try refreshing this settings section.",
+          dim: true,
+          status: { label: "error", tone: "warning" },
+        },
+      ]
+    : sessions.length === 0
+      ? [
+          {
+            key: "archive-empty",
+            label: "Archive",
+            description: "Use a session row menu to archive instead of deleting from disk.",
+            value: loading ? "Loading archived chats…" : "No archived chats.",
+            dim: true,
+            status: { label: loading ? "loading" : "empty" },
+          },
+        ]
+      : sessions.map((session) => ({
+          key: session.id,
+          label: cleanSessionTitle(session.firstUserMessage) || session.id,
+          description: session.projectPath || "Session project metadata is not available.",
+          value: session.id,
+          mono: true,
+          status: { label: "archived", tone: "info" },
+          actions: (
+            <SettingsButton
+              onClick={() => void unarchive(session)}
+              disabled={restoringId === session.id}
+            >
+              {restoringId === session.id ? "Restoring" : "Restore"}
+            </SettingsButton>
+          ),
+          children: (
+            <div className="text-[length:var(--fs-md)] text-(--dim)/55">
+              {session.projectName ? `${session.projectName} · ` : ""}
+              {session.archivedAt ? `archived ${session.archivedAt}` : session.updatedAt}
+            </div>
+          ),
+        }));
   return (
     <SettingsGroup
       title="Archived chats"
       description="Archived sessions are excluded from normal chat fetches. Restore one here to return it to the sidebar."
       actions={<StatusPill>{loading ? "loading" : `${sessions.length} archived`}</StatusPill>}
     >
-      {error ? (
-        <SettingsRow
-          label="Archive"
-          description={error}
-          value={<SettingsValue dim>Try refreshing this settings section.</SettingsValue>}
-          status={<StatusPill tone="warning">error</StatusPill>}
-        />
-      ) : null}
-      {!error && sessions.length === 0 ? (
-        <SettingsRow
-          label="Archive"
-          description="Use a session row menu to archive instead of deleting from disk."
-          value={
-            <SettingsValue dim>
-              {loading ? "Loading archived chats…" : "No archived chats."}
-            </SettingsValue>
-          }
-          status={<StatusPill>{loading ? "loading" : "empty"}</StatusPill>}
-        />
-      ) : (
-        sessions.map((session) => {
-          return (
-            <SettingsRow
-              key={session.id}
-              label={cleanSessionTitle(session.firstUserMessage) || session.id}
-              description={session.projectPath || "Session project metadata is not available."}
-              value={<SettingsValue mono>{session.id}</SettingsValue>}
-              status={<StatusPill tone="info">archived</StatusPill>}
-              actions={
-                <SettingsButton
-                  onClick={() => void unarchive(session)}
-                  disabled={restoringId === session.id}
-                >
-                  {restoringId === session.id ? "Restoring" : "Restore"}
-                </SettingsButton>
-              }
-            >
-              <div className="text-[length:var(--fs-md)] text-(--dim)/55">
-                {" "}
-                {session.projectName ? `${session.projectName} · ` : ""}
-                {session.archivedAt ? `archived ${session.archivedAt}` : session.updatedAt}{" "}
-              </div>
-            </SettingsRow>
-          );
-        })
-      )}
+      <SettingsFactRows rows={archiveRows} />
     </SettingsGroup>
   );
 }
@@ -135,6 +140,27 @@ export function SkillsSettings() {
   }, []);
 
   useSyncExternalStore(subscribeSkills, getConfigsViewSnapshot, getConfigsViewSnapshot);
+  const skillRows: SettingsFactRow[] =
+    skills.length === 0
+      ? [
+          {
+            key: "skill-discovery-empty",
+            label: "Skill discovery",
+            description: "No SKILL.md entries were found in the configured roots.",
+            value: "Empty discovery result",
+            dim: true,
+            status: { label: "empty", tone: "warning" },
+          },
+        ]
+      : skills.slice(0, 80).map((skill) => ({
+          key: skill.id,
+          label: skill.name,
+          description: "Available in the composer with $.",
+          value: `${skill.source} · ${skill.path}`,
+          mono: true,
+          truncate: true,
+          status: { label: "discovered", tone: "info" },
+        }));
   return (
     <SettingsGroup
       title="Skills"
@@ -143,26 +169,7 @@ export function SkillsSettings() {
         <StatusPill tone={skills.length ? "good" : "warning"}>{skills.length} skills</StatusPill>
       }
     >
-      {skills.length === 0 ? (
-        <SettingsRow
-          label="Skill discovery"
-          description="No SKILL.md entries were found in the configured roots."
-          value={<SettingsValue dim>Empty discovery result</SettingsValue>}
-          status={<StatusPill tone="warning">empty</StatusPill>}
-        />
-      ) : (
-        skills
-          .slice(0, 80)
-          .map((skill) => (
-            <SettingsRow
-              key={skill.id}
-              label={skill.name}
-              description="Available in the composer with $."
-              value={<SettingsValue mono>{`${skill.source} · ${skill.path}`}</SettingsValue>}
-              status={<StatusPill tone="info">discovered</StatusPill>}
-            />
-          ))
-      )}{" "}
+      <SettingsFactRows rows={skillRows} />
     </SettingsGroup>
   );
 }
@@ -188,6 +195,14 @@ export function SetupChecksSettings() {
   };
   const rows = [...checks, controllerCheck];
   const blockers = rows.filter((check) => !check.ok);
+  const setupRows: SettingsFactRow[] = rows.map((check) => ({
+    key: check.id,
+    label: check.label,
+    description: check.guidance,
+    value: check.value,
+    mono: true,
+    status: { label: check.ok ? "ok" : "missing", tone: check.ok ? "good" : "warning" },
+  }));
   return (
     <SettingsGroup
       title="First-time setup"
@@ -198,19 +213,7 @@ export function SetupChecksSettings() {
         </StatusPill>
       }
     >
-      {rows.map((check) => (
-        <SettingsRow
-          key={check.id}
-          label={check.label}
-          description={check.guidance}
-          value={<SettingsValue mono>{check.value}</SettingsValue>}
-          status={
-            <StatusPill tone={check.ok ? "good" : "warning"}>
-              {check.ok ? "ok" : "missing"}
-            </StatusPill>
-          }
-        />
-      ))}{" "}
+      <SettingsFactRows rows={setupRows} />
     </SettingsGroup>
   );
 }

--- a/frontend/src/ui/configs/configs-view.tsx
+++ b/frontend/src/ui/configs/configs-view.tsx
@@ -127,7 +127,6 @@ export function ConfigsView({
       onReload={onReload}
       onSelectSection={selectSection}
     >
-      {" "}
       {activeSection === "connection" ? (
         <ApiConnectionSection
           apiSettingsLoading={apiSettingsLoading}
@@ -153,11 +152,11 @@ export function ConfigsView({
           />
         </div>
       ) : null}
-      {activeSection === "appearance" ? <AppearanceSettings /> : null}{" "}
+      {activeSection === "appearance" ? <AppearanceSettings /> : null}
       {activeSection === "archive" ? <ArchivedChatsSettings /> : null}
-      {activeSection === "plugins" ? <PluginsSettingsSection /> : null}{" "}
+      {activeSection === "plugins" ? <PluginsSettingsSection /> : null}
       {activeSection === "skills" ? <SkillsSettings /> : null}
-      {activeSection === "setup" ? <SetupChecksSettings /> : null}{" "}
+      {activeSection === "setup" ? <SetupChecksSettings /> : null}
     </SettingsLayout>
   );
 }

--- a/frontend/src/ui/configs/system-settings-section.tsx
+++ b/frontend/src/ui/configs/system-settings-section.tsx
@@ -1,16 +1,14 @@
-import { SettingsGroup, SettingsRow, SettingsValue, StatusPill, type StatusTone } from "@/ui";
+import {
+  SettingsFactRows,
+  SettingsGroup,
+  SettingsRow,
+  SettingsValue,
+  StatusPill,
+  type SettingsFactRow,
+  type StatusTone,
+} from "@/ui";
 import type { ApiConnectionSettings } from "@/lib/configs/types";
 import type { CompatibilityCheck, CompatibilityReport, ConfigData, ServiceInfo } from "@/lib/types";
-
-type SettingsFactRow = {
-  label: string;
-  value: string | number;
-  key?: string;
-  description?: string;
-  mono?: boolean;
-  dim?: boolean;
-  status?: { label: string; tone?: StatusTone };
-};
 
 export function ServicesSettings({
   data,
@@ -310,23 +308,6 @@ function CompatibilitySettings({
       )}
     </SettingsGroup>
   );
-}
-function SettingsFactRows({ rows }: { rows: SettingsFactRow[] }) {
-  return rows.map((row) => (
-    <SettingsRow
-      key={row.key ?? row.label}
-      label={row.label}
-      description={row.description}
-      value={
-        <SettingsValue mono={row.mono} dim={row.dim}>
-          {row.value}
-        </SettingsValue>
-      }
-      status={
-        row.status ? <StatusPill tone={row.status.tone}>{row.status.label}</StatusPill> : undefined
-      }
-    />
-  ));
 }
 function serviceFactRow(service: ServiceInfo): SettingsFactRow {
   return {

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -126,6 +126,7 @@ export { SessionsCommand } from "./sessions-command";
 // Page-specialized adapters kept in /ui so library swaps happen in one place.
 export {
   SettingsLayout,
+  SettingsFactRows,
   SettingsGroup,
   SettingsRow,
   SettingsValue,
@@ -135,7 +136,12 @@ export {
   SettingsNotice,
   SettingsActions,
 } from "./settings";
-export type { SettingsSectionDef, SettingsSectionId, StatusTone } from "./settings";
+export type {
+  SettingsFactRow,
+  SettingsSectionDef,
+  SettingsSectionId,
+  StatusTone,
+} from "./settings";
 
 export {
   ModelSection,

--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -170,6 +170,8 @@ export function RowValue({
   truncate?: boolean;
   className?: string;
 }) {
+  const value =
+    children === null || children === undefined || children === "" ? "Not set" : children;
   return (
     <div
       className={cx(
@@ -181,7 +183,7 @@ export function RowValue({
       )}
       title={typeof children === "string" ? children : undefined}
     >
-      {children || "Not set"}
+      {value}
     </div>
   );
 }

--- a/frontend/src/ui/settings.tsx
+++ b/frontend/src/ui/settings.tsx
@@ -115,6 +115,46 @@ export function SettingsValue({
   );
 }
 
+export type SettingsFactRow = {
+  label: string;
+  value: ReactNode;
+  key?: string | number;
+  description?: ReactNode;
+  mono?: boolean;
+  dim?: boolean;
+  truncate?: boolean;
+  status?: { label: ReactNode; tone?: StatusTone };
+  actions?: ReactNode;
+  children?: ReactNode;
+};
+
+export function SettingsFactRows({ rows }: { rows: SettingsFactRow[] }) {
+  return (
+    <>
+      {rows.map((row) => (
+        <SettingsRow
+          key={row.key ?? row.label}
+          label={row.label}
+          description={row.description}
+          value={
+            <SettingsValue mono={row.mono} dim={row.dim} truncate={row.truncate}>
+              {row.value}
+            </SettingsValue>
+          }
+          status={
+            row.status ? (
+              <StatusPill tone={row.status.tone}>{row.status.label}</StatusPill>
+            ) : undefined
+          }
+          actions={row.actions}
+        >
+          {row.children}
+        </SettingsRow>
+      ))}
+    </>
+  );
+}
+
 export function SettingsButton({
   children,
   onClick,


### PR DESCRIPTION
## Summary
- add shared SettingsFactRows / SettingsFactRow to the settings UI-kit adapter
- replace the private System settings fact-row renderer with the shared primitive
- convert Archived chats, Skills, and First-time setup rows to data-driven SettingsFactRows
- keep numeric 0 visible in RowValue instead of falling back to Not set
- remove stray JSX whitespace nodes in the Settings shell

## Accounting
- 6 files changed: +145 / -114, net +31 lines in the committed diff
- System settings section: 398 -> 379 lines after moving the private row renderer into the UI kit
- This slice adds a shared primitive to enable further Settings/Plugins row extraction; it intentionally trades a small net increase for removing a private duplicated renderer and fixing mobile long-path overflow.

## Verification
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:ui-structure
- npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- clean reinstall to /Applications/vLLM Studio.app from the committed tree
- installed app health: /settings 200, /api/settings 200, /api/desktop-health 200
- installed screenshots/overflow matrix for /settings#system, #archive, #skills, #setup:
  - frontend/test-results/settings-fact-rows-system-desktop-installed-fixed.png
  - frontend/test-results/settings-fact-rows-system-mobile-installed-fixed.png
  - frontend/test-results/settings-fact-rows-archive-desktop-installed-fixed.png
  - frontend/test-results/settings-fact-rows-archive-mobile-installed-fixed.png
  - frontend/test-results/settings-fact-rows-skills-desktop-installed-fixed.png
  - frontend/test-results/settings-fact-rows-skills-mobile-installed-fixed.png
  - frontend/test-results/settings-fact-rows-setup-desktop-installed-fixed.png
  - frontend/test-results/settings-fact-rows-setup-mobile-installed-fixed.png
  - all overflowCount 0 / scrollDelta 0
- final committed-build Skills mobile screenshot:
  - frontend/test-results/settings-fact-rows-skills-mobile-installed-final.png
  - overflowCount 0 / scrollDelta 0

## Review
- Validator Epicurus found no blocking findings.
- Follow-up review confirmed the Skills truncation fix addresses the long-path mobile overflow risk and preserves the full string in title.