### PR TITLE
micro: reuse settings fact rows in plugins

### DIFF
--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -162,12 +162,14 @@ export function RowValue({
   mono = false,
   dim = false,
   truncate = false,
+  wrap = false,
   className,
 }: {
   children: ReactNode;
   mono?: boolean;
   dim?: boolean;
   truncate?: boolean;
+  wrap?: boolean;
   className?: string;
 }) {
   const value =
@@ -179,6 +181,7 @@ export function RowValue({
         mono ? "font-mono text-[length:var(--fs-md)]" : "",
         dim ? "text-(--ui-muted)" : "text-(--ui-fg)/80",
         truncate ? "min-w-0 truncate" : "",
+        wrap && !truncate ? "min-w-0 whitespace-normal break-words [overflow-wrap:anywhere]" : "",
         className,
       )}
       title={typeof children === "string" ? children : undefined}

--- a/frontend/src/ui/plugins/plugins-installed-servers.tsx
+++ b/frontend/src/ui/plugins/plugins-installed-servers.tsx
@@ -4,13 +4,12 @@ import { Tags, Trash2 } from "lucide-react";
 import { EmptySafeNotice } from "../list";
 import {
   SettingsButton,
+  SettingsFactRows,
   SettingsGroup,
   SettingsInput,
-  SettingsRow,
-  SettingsValue,
+  type SettingsFactRow,
 } from "../settings";
 import { StatusPill } from "../status";
-import { ServerPill } from "./plugins-page-parts";
 import type { McpServer } from "./plugins-types";
 import { serverDescription, serverLocation } from "./plugins-utils";
 
@@ -33,6 +32,49 @@ export function InstalledMcpServersPanel({
   onTagDraftChange: (server: McpServer, value: string) => void;
   onSaveTags: (server: McpServer) => void;
 }) {
+  const rows: SettingsFactRow[] = servers.map((server) => ({
+    key: server.id,
+    variant: "resource",
+    label: server.displayName ?? server.name,
+    description: serverDescription(server),
+    value: serverLocation(server),
+    mono: true,
+    wrap: true,
+    status: serverStatus(server),
+    actions: (
+      <>
+        <SettingsButton onClick={() => onToggleServer(server)} disabled={busyId === server.id}>
+          {server.enabled ? "Disable" : "Enable"}
+        </SettingsButton>
+        <SettingsButton
+          tone="danger"
+          onClick={() => onRemoveServer(server)}
+          disabled={busyId === server.id}
+          title="Remove MCP server"
+        >
+          <Trash2 className="h-3 w-3" />
+        </SettingsButton>
+      </>
+    ),
+    children: (
+      <div className="flex items-center gap-2">
+        <Tags className="h-3.5 w-3.5 shrink-0 text-(--ui-muted)" />
+        <SettingsInput
+          value={tagDrafts[server.id] ?? (server.tags ?? []).join(", ")}
+          onChange={(value) => onTagDraftChange(server, value)}
+          onBlur={() => onSaveTags(server)}
+          placeholder="tag, another-tag"
+        />
+        <SettingsButton
+          onClick={() => onSaveTags(server)}
+          disabled={busyId === `${server.id}:tags`}
+        >
+          Save tags
+        </SettingsButton>
+      </div>
+    ),
+  }));
+
   return (
     <SettingsGroup
       title="Installed MCP servers"
@@ -44,53 +86,16 @@ export function InstalledMcpServersPanel({
       }
     >
       {servers.length ? (
-        servers.map((server) => (
-          <SettingsRow
-            key={server.id}
-            variant="resource"
-            label={server.displayName ?? server.name}
-            description={serverDescription(server)}
-            value={<SettingsValue mono>{serverLocation(server)}</SettingsValue>}
-            status={<ServerPill server={server} />}
-            actions={
-              <>
-                <SettingsButton
-                  onClick={() => onToggleServer(server)}
-                  disabled={busyId === server.id}
-                >
-                  {server.enabled ? "Disable" : "Enable"}
-                </SettingsButton>
-                <SettingsButton
-                  tone="danger"
-                  onClick={() => onRemoveServer(server)}
-                  disabled={busyId === server.id}
-                  title="Remove MCP server"
-                >
-                  <Trash2 className="h-3 w-3" />
-                </SettingsButton>
-              </>
-            }
-          >
-            <div className="flex items-center gap-2">
-              <Tags className="h-3.5 w-3.5 shrink-0 text-(--ui-muted)" />
-              <SettingsInput
-                value={tagDrafts[server.id] ?? (server.tags ?? []).join(", ")}
-                onChange={(value) => onTagDraftChange(server, value)}
-                onBlur={() => onSaveTags(server)}
-                placeholder="tag, another-tag"
-              />
-              <SettingsButton
-                onClick={() => onSaveTags(server)}
-                disabled={busyId === `${server.id}:tags`}
-              >
-                Save tags
-              </SettingsButton>
-            </div>
-          </SettingsRow>
-        ))
+        <SettingsFactRows rows={rows} />
       ) : (
         <EmptySafeNotice>No MCP servers configured yet.</EmptySafeNotice>
       )}
     </SettingsGroup>
   );
+}
+
+function serverStatus(server: McpServer): NonNullable<SettingsFactRow["status"]> {
+  if (!server.enabled) return { label: "disabled" };
+  if (server.source === "marketplace") return { label: "marketplace", tone: "info" };
+  return { label: "manual", tone: "info" };
 }

--- a/frontend/src/ui/plugins/plugins-page-parts.tsx
+++ b/frontend/src/ui/plugins/plugins-page-parts.tsx
@@ -6,7 +6,7 @@ import { EmptySafeNotice } from "../list";
 import { ModelButton } from "../model-page";
 import { SettingsButton, SettingsGroup, SettingsInput, SettingsRow } from "../settings";
 import { StatusPill } from "../status";
-import { type CatalogueEntry, type McpServer } from "./plugins-types";
+import { type CatalogueEntry } from "./plugins-types";
 import { missingRequiredEnv } from "./plugins-utils";
 
 export function RegistryRow({
@@ -182,12 +182,6 @@ export function ConfigureEntryPanel({
       </div>
     </div>
   );
-}
-
-export function ServerPill({ server }: { server: McpServer }) {
-  if (!server.enabled) return <StatusPill>disabled</StatusPill>;
-  if (server.source === "marketplace") return <StatusPill tone="info">marketplace</StatusPill>;
-  return <StatusPill tone="info">manual</StatusPill>;
 }
 
 function registryLabel(entry: CatalogueEntry): string {

--- a/frontend/src/ui/plugins/plugins-registry-sources.tsx
+++ b/frontend/src/ui/plugins/plugins-registry-sources.tsx
@@ -3,10 +3,11 @@
 import { EmptySafeNotice } from "../list";
 import {
   SettingsButton,
+  SettingsFactRows,
   SettingsGroup,
   SettingsInput,
   SettingsRow,
-  SettingsValue,
+  type SettingsFactRow,
 } from "../settings";
 import { StatusPill } from "../status";
 import type { RegistrySource } from "./plugins-types";
@@ -40,6 +41,35 @@ export function RegistrySourcesPanel({
   onRemoveSource: (source: RegistrySource) => void;
   loading?: boolean;
 }) {
+  const rows: SettingsFactRow[] = sources.map((source) => ({
+    key: source.id,
+    variant: "resource",
+    label: source.name,
+    description: source.url,
+    value: source.builtIn ? "official" : "custom",
+    status: {
+      label: source.enabled ? "enabled" : "disabled",
+      tone: source.enabled ? "good" : "default",
+    },
+    actions: source.builtIn ? undefined : (
+      <>
+        <SettingsButton
+          onClick={() => onToggleSource(source)}
+          disabled={busyId === `${source.id}:enabled`}
+        >
+          {source.enabled ? "Disable" : "Enable"}
+        </SettingsButton>
+        <SettingsButton
+          tone="danger"
+          onClick={() => onRemoveSource(source)}
+          disabled={busyId === `${source.id}:remove`}
+        >
+          Remove
+        </SettingsButton>
+      </>
+    ),
+  }));
+
   return (
     <SettingsGroup
       title="Registry sources"
@@ -47,39 +77,7 @@ export function RegistrySourcesPanel({
       actions={<SettingsButton onClick={onToggleOpen}>{open ? "Close" : "Add"}</SettingsButton>}
     >
       {sources.length ? (
-        sources.map((source) => (
-          <SettingsRow
-            key={source.id}
-            variant="resource"
-            label={source.name}
-            description={source.url}
-            value={<SettingsValue>{source.builtIn ? "official" : "custom"}</SettingsValue>}
-            status={
-              <StatusPill tone={source.enabled ? "good" : "default"}>
-                {source.enabled ? "enabled" : "disabled"}
-              </StatusPill>
-            }
-            actions={
-              source.builtIn ? null : (
-                <>
-                  <SettingsButton
-                    onClick={() => onToggleSource(source)}
-                    disabled={busyId === `${source.id}:enabled`}
-                  >
-                    {source.enabled ? "Disable" : "Enable"}
-                  </SettingsButton>
-                  <SettingsButton
-                    tone="danger"
-                    onClick={() => onRemoveSource(source)}
-                    disabled={busyId === `${source.id}:remove`}
-                  >
-                    Remove
-                  </SettingsButton>
-                </>
-              )
-            }
-          />
-        ))
+        <SettingsFactRows rows={rows} />
       ) : (
         <EmptySafeNotice>
           {loading

--- a/frontend/src/ui/settings.tsx
+++ b/frontend/src/ui/settings.tsx
@@ -102,14 +102,16 @@ export function SettingsValue({
   mono = false,
   dim = false,
   truncate = false,
+  wrap = false,
 }: {
   children: ReactNode;
   mono?: boolean;
   dim?: boolean;
   truncate?: boolean;
+  wrap?: boolean;
 }) {
   return (
-    <RowValue mono={mono} dim={dim} truncate={truncate}>
+    <RowValue mono={mono} dim={dim} truncate={truncate} wrap={wrap}>
       {children}
     </RowValue>
   );
@@ -120,9 +122,11 @@ export type SettingsFactRow = {
   value: ReactNode;
   key?: string | number;
   description?: ReactNode;
+  variant?: "settings" | "resource";
   mono?: boolean;
   dim?: boolean;
   truncate?: boolean;
+  wrap?: boolean;
   status?: { label: ReactNode; tone?: StatusTone };
   actions?: ReactNode;
   children?: ReactNode;
@@ -134,10 +138,11 @@ export function SettingsFactRows({ rows }: { rows: SettingsFactRow[] }) {
       {rows.map((row) => (
         <SettingsRow
           key={row.key ?? row.label}
+          variant={row.variant}
           label={row.label}
           description={row.description}
           value={
-            <SettingsValue mono={row.mono} dim={row.dim} truncate={row.truncate}>
+            <SettingsValue mono={row.mono} dim={row.dim} truncate={row.truncate} wrap={row.wrap}>
               {row.value}
             </SettingsValue>
           }


### PR DESCRIPTION
## Summary
- extend SettingsFactRows to support resource rows and wrapped values
- convert Installed MCP servers and Registry sources to the shared settings fact-row renderer
- remove the now-unused ServerPill helper
- wrap installed server location text instead of truncating it, preserving readability while avoiding mobile overflow

## Accounting
- 5 files changed: +95 / -90, net +5 lines in the committed diff
- This keeps the Plugins row surface visually equivalent while moving two more repeated row maps onto the shared UI-kit primitive.

## Verification
- npm --prefix frontend run typecheck
- npm --prefix frontend run check:ui-structure
- npm --prefix frontend run check:quality
- npm --prefix frontend run desktop:pack
- clean reinstall to /Applications/vLLM Studio.app from the committed tree
- installed app health: /plugins 200, /settings#plugins 200, /api/desktop-health 200
- installed screenshots/overflow:
  - frontend/test-results/plugins-settings-fact-rows-plugins-page-desktop-installed-final.png
  - frontend/test-results/plugins-settings-fact-rows-plugins-page-mobile-installed-final.png
  - frontend/test-results/plugins-settings-fact-rows-settings-plugins-desktop-installed-final.png
  - frontend/test-results/plugins-settings-fact-rows-settings-plugins-mobile-installed-final.png
  - all overflowCount 0 / scrollDelta 0

## Review
- Validator Nash found no blocking findings.
- Follow-up review confirmed the wrap path addresses visible truncation concerns for installed MCP server locations without type/render blockers.