### PR TITLE
refactor: remove stale litellm config contract

### DIFF
--- a/shared/contracts/system.ts
+++ b/shared/contracts/system.ts
@@ -25,8 +25,6 @@ export interface EnvironmentInfo {
   controller_url: string;
   inference_url: string;
   frontend_url: string;
-  /** @deprecated No longer served. */
-  litellm_url?: string;
 }
 
 export interface RuntimeBackendInfo {

--- a/tests/controller/integration/controller-route-contracts.test.ts
+++ b/tests/controller/integration/controller-route-contracts.test.ts
@@ -980,6 +980,7 @@ world"}</arguments></tool_call>`,
         frontend_url: expect.any(String),
       }),
     );
+    expect(configBody.environment).not.toHaveProperty("litellm_url");
     expect(configBody.runtime).toEqual(expect.any(Object));
 
     const specResponse = await app.request("/api/spec");


### PR DESCRIPTION
## Summary
- remove the stale optional `litellm_url` field from the shared `/config` environment contract
- add a controller route-contract assertion that `/config` no longer serves `litellm_url`

## Verification
- npm run check:contracts
- npm run check:controller
- npm run check:cli
- npm --prefix frontend run typecheck
- npm run test:controller:integration
- npm run check
- git push pre-push frontend quality gate

## Review note
A validator flagged that removing the field is a source-level break for hypothetical external TypeScript consumers. The shared contract layer has no package manifest/publish target and is internal to this private repo; runtime `/config` has already stopped serving the field, and the integration contract now asserts that absence.
