### PR TITLE
refactor: simplify cli output helpers

### DIFF
--- a/cli/src/headless.ts
+++ b/cli/src/headless.ts
@@ -2,16 +2,30 @@ import * as api from "./api";
 
 type CommandHandler = () => Promise<void>;
 
+const printJson = (value: unknown, pretty = false): void => {
+  console.log(JSON.stringify(value, null, pretty ? 2 : undefined));
+};
+
+const showJson =
+  (load: () => Promise<unknown>): CommandHandler =>
+  async () => {
+    printJson(await load(), true);
+  };
+
+const exitJson = (value: unknown, ok: boolean): never => {
+  printJson(value);
+  process.exit(ok ? 0 : 1);
+};
+
 const COMMANDS: Record<string, CommandHandler> = {
-  status: async () => console.log(JSON.stringify(await api.fetchStatus(), null, 2)),
-  gpus: async () => console.log(JSON.stringify(await api.fetchGPUs(), null, 2)),
-  recipes: async () => console.log(JSON.stringify(await api.fetchRecipes(), null, 2)),
-  config: async () => console.log(JSON.stringify(await api.fetchConfig(), null, 2)),
-  metrics: async () => console.log(JSON.stringify(await api.fetchLifetimeMetrics(), null, 2)),
+  status: showJson(api.fetchStatus),
+  gpus: showJson(api.fetchGPUs),
+  recipes: showJson(api.fetchRecipes),
+  config: showJson(api.fetchConfig),
+  metrics: showJson(api.fetchLifetimeMetrics),
   evict: async () => {
     const ok = await api.evictModel();
-    console.log(JSON.stringify({ success: ok }));
-    process.exit(ok ? 0 : 1);
+    exitJson({ success: ok }, ok);
   },
   launch: async () => {
     const id = process.argv[3];
@@ -20,8 +34,7 @@ const COMMANDS: Record<string, CommandHandler> = {
       process.exit(1);
     }
     const ok = await api.launchRecipe(id);
-    console.log(JSON.stringify({ success: ok, recipe_id: id }));
-    process.exit(ok ? 0 : 1);
+    exitJson({ success: ok, recipe_id: id }, ok);
   },
   help: async () => {
     console.log(`vllm-studio - Model lifecycle management CLI

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -23,6 +23,10 @@ const state: AppState = {
   error: null,
 };
 
+function rejectionMessage(result: PromiseRejectedResult, fallback: string): string {
+  return result.reason instanceof Error ? result.reason.message : fallback;
+}
+
 async function refresh(): Promise<void> {
   const results = await Promise.allSettled([
     api.fetchGPUs(),
@@ -34,36 +38,19 @@ async function refresh(): Promise<void> {
 
   const errors: string[] = [];
   if (results[0].status === "fulfilled") state.gpus = results[0].value;
-  else
-    errors.push(
-      results[0].reason instanceof Error ? results[0].reason.message : "Failed to fetch GPUs"
-    );
+  else errors.push(rejectionMessage(results[0], "Failed to fetch GPUs"));
 
   if (results[1].status === "fulfilled") state.recipes = results[1].value;
-  else
-    errors.push(
-      results[1].reason instanceof Error ? results[1].reason.message : "Failed to fetch recipes"
-    );
+  else errors.push(rejectionMessage(results[1], "Failed to fetch recipes"));
 
   if (results[2].status === "fulfilled") state.status = results[2].value;
-  else
-    errors.push(
-      results[2].reason instanceof Error ? results[2].reason.message : "Failed to fetch status"
-    );
+  else errors.push(rejectionMessage(results[2], "Failed to fetch status"));
 
   if (results[3].status === "fulfilled") state.config = results[3].value;
-  else
-    errors.push(
-      results[3].reason instanceof Error ? results[3].reason.message : "Failed to fetch config"
-    );
+  else errors.push(rejectionMessage(results[3], "Failed to fetch config"));
 
   if (results[4].status === "fulfilled") state.lifetime = results[4].value;
-  else
-    errors.push(
-      results[4].reason instanceof Error
-        ? results[4].reason.message
-        : "Failed to fetch lifetime metrics"
-    );
+  else errors.push(rejectionMessage(results[4], "Failed to fetch lifetime metrics"));
 
   const hasRecipes = state.recipes.length > 0;
   if (!hasRecipes) state.selectedIndex = 0;


### PR DESCRIPTION
## Summary
- extract shared headless JSON printing helpers for read/mutation commands
- extract TUI refresh rejection-message formatting to remove repeated error boilerplate

## Verification
- cd cli && bun run check
- cd cli && bun run typecheck
- cd cli && bun run lint
- cd cli && bun src/main.ts help
- cd cli && bun src/main.ts launch (verified exit=1 and usage on stderr)
- npm run check
- sub-agent validator review: no concrete findings
- git push pre-push frontend quality gate
